### PR TITLE
Add example config files and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,15 @@ A production-ready, full-featured command-line chat interface is available for
 interacting with your PostgreSQL database using natural language:
 
 ```bash
-# Quick start - Stdio mode (MCP server as subprocess)
+# Stdio mode setup (MCP server as subprocess)
+cp examples/pgedge-postgres-mcp-stdio.yaml.example bin/pgedge-postgres-mcp-stdio.yaml
+cp examples/pgedge-nla-cli-stdio.yaml.example bin/pgedge-nla-cli-stdio.yaml
+# Edit config files with your database settings, then:
 ./start_cli_stdio.sh
 
-# Quick start - HTTP mode (MCP server via HTTP with auth)
+# HTTP mode setup (MCP server via HTTP with auth)
+# First set up web client config (see Web Client section), then:
+cp examples/pgedge-nla-cli-http.yaml.example bin/pgedge-nla-cli-http.yaml
 ./start_cli_http.sh
 ```
 
@@ -306,18 +311,31 @@ A web-based management interface is available for monitoring and interacting
 with the MCP server:
 
 ```bash
-# Quick start (starts both MCP server and web interface)
+# 1. Copy example config files
+cp examples/pgedge-postgres-mcp-http.yaml.example bin/pgedge-postgres-mcp-http.yaml
+cp examples/pgedge-postgres-mcp-users.yaml.example bin/pgedge-postgres-mcp-users.yaml
+cp examples/pgedge-postgres-mcp-tokens.yaml.example bin/pgedge-postgres-mcp-tokens.yaml
+
+# 2. Edit config with your database and LLM settings
+nano bin/pgedge-postgres-mcp-http.yaml
+
+# 3. Create a user for web login
+./bin/pgedge-postgres-mcp user add --username myuser --annotation "My User"
+
+# 4. Start the web client (starts both MCP server and web interface)
 ./start_web_client.sh
 ```
 
 **Features:**
+
 - 🔐 Secure authentication using MCP server credentials
 - 📊 Real-time PostgreSQL system information
 - 🌓 Light/dark theme support
 - 📱 Responsive design for desktop and mobile
 
 **Access:**
-- Web Interface: http://localhost:3000
+
+- Web Interface: http://localhost:5173
 - MCP Server API: http://localhost:8080
 
 See [web/README.md](web/README.md) for detailed documentation.

--- a/examples/pgedge-nla-cli-http.yaml.example
+++ b/examples/pgedge-nla-cli-http.yaml.example
@@ -1,0 +1,53 @@
+# pgEdge PostgreSQL MCP Chat Client Configuration - HTTP Mode
+#
+# This configuration connects the CLI chat client to a remote MCP server.
+# Copy this file to bin/pgedge-nla-cli-http.yaml and edit as needed.
+#
+# Usage:
+#   cp examples/pgedge-nla-cli-http.yaml.example bin/pgedge-nla-cli-http.yaml
+#   # Edit bin/pgedge-nla-cli-http.yaml with your settings
+#   ./start_cli_http.sh
+
+# MCP server connection configuration
+mcp:
+    mode: "http"
+    url: "http://127.0.0.1:8080"
+
+    # Authentication mode: "user" or "token"
+    auth_mode: "user"
+
+    # User authentication (will prompt if not set)
+    # username: "myuser"
+    # password: ""  # Will prompt if empty
+
+    # Token authentication (alternative to user auth)
+    # auth_mode: "token"
+    # token: ""  # Or use PGEDGE_MCP_TOKEN environment variable
+
+    tls: false  # Set to true for HTTPS connections
+
+# LLM provider configuration
+llm:
+    provider: "anthropic"  # Options: "anthropic", "openai", "ollama"
+    model: "claude-sonnet-4-5"
+
+    # API key files (recommended for production)
+    anthropic_api_key_file: "~/.anthropic-api-key"
+    openai_api_key_file: "~/.openai-api-key"
+
+    # Or use environment variables: ANTHROPIC_API_KEY, OPENAI_API_KEY
+
+    # Ollama configuration (for local LLM)
+    ollama_url: "http://127.0.0.1:11434"
+
+    max_tokens: 4096
+    temperature: 0.7
+
+# UI configuration
+ui:
+    no_color: false  # Disable colored output (also set via NO_COLOR env var)
+    display_status_messages: true  # Show status messages during tool execution
+    render_markdown: true  # Render markdown with formatting and syntax highlighting
+
+# Chat history file (optional)
+# history_file: "~/.pgedge-nla-cli-history"

--- a/examples/pgedge-nla-cli-stdio.yaml.example
+++ b/examples/pgedge-nla-cli-stdio.yaml.example
@@ -1,0 +1,41 @@
+# pgEdge PostgreSQL MCP Chat Client Configuration - Stdio Mode
+#
+# This configuration runs the MCP server as a subprocess of the CLI client.
+# Copy this file to bin/pgedge-nla-cli-stdio.yaml and edit as needed.
+#
+# Usage:
+#   cp examples/pgedge-nla-cli-stdio.yaml.example bin/pgedge-nla-cli-stdio.yaml
+#   # Edit bin/pgedge-nla-cli-stdio.yaml with your settings
+#   ./start_cli_stdio.sh
+
+# MCP server connection configuration
+mcp:
+    mode: "stdio"
+    server_path: "./pgedge-postgres-mcp"  # Path to server binary
+    server_config_path: "./pgedge-postgres-mcp-stdio.yaml"  # Server config file
+
+# LLM provider configuration
+llm:
+    provider: "anthropic"  # Options: "anthropic", "openai", "ollama"
+    model: "claude-sonnet-4-5"
+
+    # API key files (recommended for production)
+    anthropic_api_key_file: "~/.anthropic-api-key"
+    openai_api_key_file: "~/.openai-api-key"
+
+    # Or use environment variables: ANTHROPIC_API_KEY, OPENAI_API_KEY
+
+    # Ollama configuration (for local LLM)
+    ollama_url: "http://127.0.0.1:11434"
+
+    max_tokens: 4096
+    temperature: 0.7
+
+# UI configuration
+ui:
+    no_color: false  # Disable colored output (also set via NO_COLOR env var)
+    display_status_messages: true  # Show status messages during tool execution
+    render_markdown: true  # Render markdown with formatting and syntax highlighting
+
+# Chat history file (optional)
+# history_file: "~/.pgedge-nla-cli-history"

--- a/examples/pgedge-postgres-mcp-http.yaml.example
+++ b/examples/pgedge-postgres-mcp-http.yaml.example
@@ -1,0 +1,104 @@
+# pgEdge PostgreSQL MCP Server Configuration - HTTP Mode
+#
+# This configuration runs the MCP server in HTTP mode for the web client.
+# Copy this file to bin/pgedge-postgres-mcp-http.yaml and edit as needed.
+#
+# Usage:
+#   cp examples/pgedge-postgres-mcp-http.yaml.example bin/pgedge-postgres-mcp-http.yaml
+#   # Edit bin/pgedge-postgres-mcp-http.yaml with your settings
+#   ./start_web_client.sh
+
+# HTTP mode configuration
+http:
+    enabled: true
+    address: ":8080"
+    tls:
+        enabled: false
+        cert_file: "./server.crt"
+        key_file: "./server.key"
+        chain_file: ""
+    auth:
+        enabled: true
+        token_file: "./pgedge-postgres-mcp-tokens.yaml"
+        max_failed_attempts_before_lockout: 5
+        rate_limit_window_minutes: 15
+        rate_limit_max_attempts: 10
+
+# User authentication file (for web client login)
+user_file: "./pgedge-postgres-mcp-users.yaml"
+
+# Database connection configuration
+# Multiple databases can be configured; each must have a unique name.
+# Use available_to_users to restrict access to specific users (empty = all users)
+databases:
+    - name: "mydb"
+      host: "localhost"
+      port: 5432
+      database: "mydb"
+      user: "postgres"
+      password: ""  # Leave empty to use .pgpass file
+      sslmode: "prefer"
+      pool_max_conns: 10
+      pool_min_conns: 2
+      pool_max_conn_idle_time: "5m"
+      available_to_users: []  # Empty = available to all users
+
+    # Add more databases as needed:
+    # - name: "production"
+    #   host: "prod-db.example.com"
+    #   port: 5432
+    #   database: "production"
+    #   user: "app_user"
+    #   password: ""
+    #   sslmode: "require"
+    #   available_to_users: ["admin", "developer"]
+
+# Embedding generation configuration
+# Enable to allow generating embeddings for semantic search
+embedding:
+    enabled: false
+    provider: "openai"  # Options: "voyage", "openai", "ollama"
+    model: "text-embedding-3-small"
+
+    # API key files (recommended for production)
+    # voyage_api_key_file: "~/.voyage-api-key"
+    # openai_api_key_file: "~/.openai-api-key"
+
+    # Or use environment variables: VOYAGE_API_KEY, OPENAI_API_KEY
+
+# LLM configuration for web client chat
+# REQUIRED for the web client to function
+llm:
+    enabled: true
+    provider: "anthropic"  # Options: "anthropic", "openai", "ollama"
+    model: "claude-sonnet-4-5"
+
+    # API key files (recommended for production)
+    anthropic_api_key_file: "~/.anthropic-api-key"
+    openai_api_key_file: "~/.openai-api-key"
+
+    # Or use environment variables: ANTHROPIC_API_KEY, OPENAI_API_KEY
+
+    # Ollama configuration (for local LLM)
+    ollama_url: "http://127.0.0.1:11434"
+
+    max_tokens: 4096
+    temperature: 0.7
+
+# Knowledgebase configuration (optional)
+# Enable to allow searching pre-built documentation databases
+knowledgebase:
+    enabled: false
+    database_path: "./pgedge-nla-kb.db"
+    embedding_provider: "voyage"
+    embedding_model: "voyage-3"
+
+    # API key files for knowledgebase embeddings
+    # embedding_voyage_api_key_file: "~/.voyage-api-key"
+    # embedding_openai_api_key_file: "~/.openai-api-key"
+
+# Secret file path (for encryption key - auto-generated if not exists)
+secret_file: "./pgedge-postgres-mcp.secret"
+
+# Custom definitions file path (optional)
+# custom_definitions_path: "../examples/pgedge-postgres-mcp-custom.yaml"

--- a/examples/pgedge-postgres-mcp-stdio.yaml.example
+++ b/examples/pgedge-postgres-mcp-stdio.yaml.example
@@ -1,0 +1,80 @@
+# pgEdge PostgreSQL MCP Server Configuration - Stdio Mode
+#
+# This configuration runs the MCP server in stdio mode for Claude Desktop
+# or CLI client integration.
+# Copy this file to bin/pgedge-postgres-mcp-stdio.yaml and edit as needed.
+#
+# Usage:
+#   cp examples/pgedge-postgres-mcp-stdio.yaml.example bin/pgedge-postgres-mcp-stdio.yaml
+#   # Edit bin/pgedge-postgres-mcp-stdio.yaml with your settings
+#   ./start_cli_stdio.sh
+
+# Database connection configuration
+# Multiple databases can be configured; each must have a unique name.
+# In stdio mode, all configured databases are available.
+databases:
+    - name: "mydb"
+      host: "localhost"
+      port: 5432
+      database: "mydb"
+      user: "postgres"
+      password: ""  # Leave empty to use .pgpass file
+      sslmode: "prefer"
+      pool_max_conns: 10
+      pool_min_conns: 2
+      pool_max_conn_idle_time: "5m"
+
+    # Add more databases as needed:
+    # - name: "analytics"
+    #   host: "localhost"
+    #   port: 5432
+    #   database: "analytics"
+    #   user: "postgres"
+    #   password: ""
+    #   sslmode: "prefer"
+
+# Embedding generation configuration
+# Enable to allow generating embeddings for semantic search
+embedding:
+    enabled: false
+    provider: "openai"  # Options: "voyage", "openai", "ollama"
+    model: "text-embedding-3-small"
+
+    # API key files (recommended for production)
+    # voyage_api_key_file: "~/.voyage-api-key"
+    # openai_api_key_file: "~/.openai-api-key"
+
+    # Or use environment variables: VOYAGE_API_KEY, OPENAI_API_KEY
+
+    # Model Dimensions by Provider:
+    # Voyage AI:
+    #   - voyage-3: 1024 dimensions
+    #   - voyage-3-lite: 512 dimensions
+    # OpenAI:
+    #   - text-embedding-3-large: 3072 dimensions
+    #   - text-embedding-3-small: 1536 dimensions
+    # Ollama:
+    #   - nomic-embed-text: 768 dimensions
+    #   - mxbai-embed-large: 1024 dimensions
+
+# LLM configuration (not used in stdio mode - CLI handles LLM directly)
+llm:
+    enabled: false
+
+# Knowledgebase configuration (optional)
+# Enable to allow searching pre-built documentation databases
+knowledgebase:
+    enabled: false
+    database_path: "./pgedge-nla-kb.db"
+    embedding_provider: "voyage"
+    embedding_model: "voyage-3"
+
+    # API key files for knowledgebase embeddings
+    # embedding_voyage_api_key_file: "~/.voyage-api-key"
+    # embedding_openai_api_key_file: "~/.openai-api-key"
+
+# Secret file path (for encryption key - auto-generated if not exists)
+secret_file: "./pgedge-postgres-mcp.secret"
+
+# Custom definitions file path (optional)
+# custom_definitions_path: "../examples/pgedge-postgres-mcp-custom.yaml"

--- a/examples/pgedge-postgres-mcp-tokens.yaml.example
+++ b/examples/pgedge-postgres-mcp-tokens.yaml.example
@@ -1,0 +1,40 @@
+# pgEdge PostgreSQL MCP Server - Token Authentication File
+#
+# This file defines API tokens for programmatic access to the MCP server.
+# Tokens are used for service-to-service authentication or CLI access in
+# HTTP mode with token authentication.
+#
+# Copy this file to bin/pgedge-postgres-mcp-tokens.yaml and edit as needed.
+#
+# Usage:
+#   cp examples/pgedge-postgres-mcp-tokens.yaml.example bin/pgedge-postgres-mcp-tokens.yaml
+#
+# IMPORTANT: Do NOT manually create token hashes. Use the server's token
+# management tools instead:
+#
+#   # Create a new token (will display the token - save it securely!)
+#   ./bin/pgedge-postgres-mcp token add --annotation "My API Token"
+#
+#   # Create token with expiration
+#   ./bin/pgedge-postgres-mcp token add --annotation "Temp Token" --expires 24h
+#
+#   # Create token restricted to specific database
+#   ./bin/pgedge-postgres-mcp token add --annotation "DB Token" --database mydb
+#
+#   # List tokens
+#   ./bin/pgedge-postgres-mcp token list
+#
+#   # Delete token
+#   ./bin/pgedge-postgres-mcp token delete --id token-123456789
+
+# Tokens are stored with SHA256 hashes for security.
+# The structure below shows the format but you should use the CLI to manage
+# tokens.
+tokens:
+    # Example token entry (created by CLI):
+    # token-1234567890:
+    #     hash: abc123...  # SHA256 hash of actual token - DO NOT create manually
+    #     expires_at: null  # or ISO8601 timestamp for expiring tokens
+    #     annotation: API Access Token
+    #     created_at: 2025-01-01T00:00:00Z
+    #     database: null  # or specific database name to restrict access

--- a/examples/pgedge-postgres-mcp-users.yaml.example
+++ b/examples/pgedge-postgres-mcp-users.yaml.example
@@ -1,0 +1,42 @@
+# pgEdge PostgreSQL MCP Server - User Authentication File
+#
+# This file defines users who can authenticate to the MCP server via the web
+# client or CLI in HTTP mode with user authentication.
+#
+# Copy this file to bin/pgedge-postgres-mcp-users.yaml and edit as needed.
+#
+# Usage:
+#   cp examples/pgedge-postgres-mcp-users.yaml.example bin/pgedge-postgres-mcp-users.yaml
+#
+# IMPORTANT: Do NOT manually create password hashes. Use the server's user
+# management tools instead:
+#
+#   # Create a new user (will prompt for password)
+#   ./bin/pgedge-postgres-mcp user add --username myuser --annotation "My User"
+#
+#   # List users
+#   ./bin/pgedge-postgres-mcp user list
+#
+#   # Change password
+#   ./bin/pgedge-postgres-mcp user passwd --username myuser
+#
+#   # Enable/disable user
+#   ./bin/pgedge-postgres-mcp user enable --username myuser
+#   ./bin/pgedge-postgres-mcp user disable --username myuser
+#
+#   # Delete user
+#   ./bin/pgedge-postgres-mcp user delete --username myuser
+
+# Users are stored with bcrypt-hashed passwords for security.
+# The structure below shows the format but you should use the CLI to manage
+# users.
+users:
+    # Example user entry (created by CLI):
+    # admin:
+    #     username: admin
+    #     password_hash: $2a$12$...  # bcrypt hash - DO NOT create manually
+    #     created_at: 2025-01-01T00:00:00Z
+    #     last_login: null
+    #     enabled: true
+    #     annotation: Administrator
+    #     failed_attempts: 0

--- a/web/README.md
+++ b/web/README.md
@@ -59,17 +59,31 @@ The web client uses a **two-tier architecture** communicating directly with the 
 
 ## Quick Start
 
-The easiest way to start the web client is using the provided startup script from the project root:
+Before starting the web client, you need to create configuration files:
 
 ```bash
+# 1. Copy example config files from the project root
+cp examples/pgedge-postgres-mcp-http.yaml.example bin/pgedge-postgres-mcp-http.yaml
+cp examples/pgedge-postgres-mcp-users.yaml.example bin/pgedge-postgres-mcp-users.yaml
+cp examples/pgedge-postgres-mcp-tokens.yaml.example bin/pgedge-postgres-mcp-tokens.yaml
+
+# 2. Edit the config file with your database connection and LLM settings
+nano bin/pgedge-postgres-mcp-http.yaml
+
+# 3. Create a user for web login (will prompt for password)
+./bin/pgedge-postgres-mcp user add --username myuser --annotation "My User"
+
+# 4. Start the web client
 ./start_web_client.sh
 ```
 
 This script will:
-- Start the MCP server in HTTP mode (port 8080) with authentication and LLM proxy enabled
+
+- Start the MCP server in HTTP mode (port 8080) with authentication and LLM proxy
+  enabled
 - Start the Vite development server (port 5173) for the frontend
-- Use pre-configured settings from `bin/pgedge-pg-mcp-web.yaml`
-- Use existing user files from the `bin/` directory
+- Use settings from `bin/pgedge-postgres-mcp-http.yaml`
+- Use user/token files from the `bin/` directory
 
 The MCP server supports both authentication methods simultaneously:
 - **Service Tokens**: Long-lived API tokens from `pgedge-postgres-mcp-tokens.yaml` (for programmatic access)
@@ -81,11 +95,13 @@ Then open [http://localhost:5173](http://localhost:5173) in your browser.
 
 ## Configuration
 
-The web client is configured entirely through the MCP server's configuration file (`bin/pgedge-pg-mcp-web.yaml`). No separate web client configuration is needed.
+The web client is configured entirely through the MCP server's configuration
+file (`bin/pgedge-postgres-mcp-http.yaml`). No separate web client configuration
+is needed.
 
 ### MCP Server Configuration
 
-Edit `bin/pgedge-pg-mcp-web.yaml` to configure:
+Edit `bin/pgedge-postgres-mcp-http.yaml` to configure:
 
 **Database Connection:**
 ```yaml


### PR DESCRIPTION
## Summary

Closes #18 - README instructions for web client are not complete.

- Added 6 example configuration files in `examples/` directory that users can copy to `bin/`
- Updated README.md and web/README.md with setup instructions
- Fixed incorrect config filename reference and port number

## Changes

**New example config files:**

- `pgedge-postgres-mcp-http.yaml.example` - MCP server HTTP mode config
- `pgedge-postgres-mcp-stdio.yaml.example` - MCP server stdio mode config  
- `pgedge-nla-cli-http.yaml.example` - CLI client HTTP mode config
- `pgedge-nla-cli-stdio.yaml.example` - CLI client stdio mode config
- `pgedge-postgres-mcp-users.yaml.example` - User authentication template
- `pgedge-postgres-mcp-tokens.yaml.example` - Token authentication template

**Documentation updates:**

- Added step-by-step config setup instructions to Web Client and CLI Client sections
- Fixed Web Interface port from 3000 to 5173 (Vite default)
- Fixed incorrect config filename in web/README.md

## Test plan

- [ ] Verify example files can be copied and used
- [ ] Check documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated setup and Quick Start instructions with clearer configuration steps
  * Added example configuration files for HTTP and stdio deployment modes
  * Updated web client access port information
  * Enhanced authentication and MCP server configuration documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->