### PR TITLE
Fix links to the quickstart demo and make it clearer that the links point to a demo.

### DIFF
--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -1,6 +1,7 @@
 # pgEdge MCP Server and AI Toolkit Quickstart Demo
 
-In this Quickstart demo, we'll walk you through getting started with the MCP server. This guide creates a:
+In this Quickstart demo, we'll walk you through getting started with the MCP 
+server. This guide creates a:
 
 - **PostgreSQL 17** - pgEdge PostgreSQL distribution
 - **Northwind Dataset** - Classic demo database with orders, customers, products
@@ -14,7 +15,8 @@ The Northwind database is a classic SQL Server sample database containing:
 - **~1000 Rows**: Realistic business data for testing and demos
 - **1 Schema**: `northwind` (keeps your `public` schema clean)
 
-The dataset is perfect for testing natural language queries, joins, aggregations, and analytics, and is installed with the Quickstart.
+The dataset is perfect for testing natural language queries, joins, 
+aggregations, and analytics, and is installed with the Quickstart.
 
 
 ## Prerequisites
@@ -24,7 +26,8 @@ Before running the deployment steps:
 - Install Docker Desktop
 - Obtain an LLM API key (Anthropic or OpenAI)
 
-After meeting the prerequisites, you're ready to install the AI Toolkit.  There are two installation options:
+After meeting the prerequisites, you're ready to install the AI Toolkit.  
+There are two installation options:
 
 * a [One-Step Quickstart](#one-step-quickstart) that uses default settings to launch the demo.
 * a [Three-Step Quickstart](#three-step-quickstart) that allows you to configure settings before launching the demo.
@@ -32,7 +35,8 @@ After meeting the prerequisites, you're ready to install the AI Toolkit.  There 
 
 ## One-Step QuickStart
 
-The single command option is the fastest way to get started.  Execute the following command:
+The single command option is the fastest way to get started.  Execute the 
+following command:
 
 `/bin/sh -c "$(curl -fsSL https://downloads.pgedge.com/quickstart/mcp/pgedge-ait-demo.sh)"`
 
@@ -107,7 +111,8 @@ To stop: cd /tmp/pgedge-download.28085 && docker compose down -v
 For more information: https://github.com/pgEdge/pgedge-postgres-mcp
 ```
 
-Then, navigate to the address of the MCP Server (`http://localhost:8081`) and use these queries to test the server:
+Then, navigate to the address of the MCP Server (`http://localhost:8081`) and 
+use these queries to test the server:
 
 - `What tables are in the database?`
 - `Show me the top 10 products by sales`
@@ -139,7 +144,8 @@ Configure your API key
 cp .env.example .env
 ```
 
-Then, edit `.env` and add `PGEDGE_ANTHROPIC_API_KEY` and/or `PGEDGE_OPENAI_API_KEY`.
+Then, edit `.env` and add `PGEDGE_ANTHROPIC_API_KEY` and/or 
+`PGEDGE_OPENAI_API_KEY`.
 
 Use the following command to start the Docker container.
 
@@ -171,7 +177,8 @@ MCP Server API:
   Bearer Token: demo-token-12345
 ```
 
-Then, you can navigate to the address of the MCP Server (`http://localhost:8080`) and use these queries to test the server:
+Then, you can navigate to the address of the MCP Server 
+(`http://localhost:8080`) and use these queries to test the server:
 
 - `What tables are in the database?`
 - `Show me the top 10 products by sales`

--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -180,7 +180,6 @@ MCP Server API:
 ```
 
 Then, you can navigate to the address of the Web Client 
-
 (`http://localhost:8081`) and query the server:
 
 - `What tables are in the database?`

--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -1,4 +1,5 @@
-# pgEdge MCP Server and AI Toolkit Quickstart Demo
+
+# pgEdge Postgres MCP Server and AI Toolkit Quickstart Demo
 
 In this Quickstart demo, we'll walk you through getting started with the MCP 
 server. This guide creates a:

--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -111,7 +111,7 @@ To stop: cd /tmp/pgedge-download.28085 && docker compose down -v
 For more information: https://github.com/pgEdge/pgedge-postgres-mcp
 ```
 
-Then, navigate to the address of the MCP Server (`http://localhost:8081`) and 
+Then, navigate to the address of the Web Client (`http://localhost:8081`) and 
 use these queries to test the server:
 
 - `What tables are in the database?`
@@ -177,8 +177,8 @@ MCP Server API:
   Bearer Token: demo-token-12345
 ```
 
-Then, you can navigate to the address of the MCP Server 
-(`http://localhost:8080`) and use these queries to test the server:
+Then, you can navigate to the address of the Web Client 
+(`http://localhost:8081`) and use these queries to test the server:
 
 - `What tables are in the database?`
 - `Show me the top 10 products by sales`

--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -114,7 +114,8 @@ To stop: cd /tmp/pgedge-download.28085 && docker compose down -v
 For more information: https://github.com/pgEdge/pgedge-postgres-mcp
 ```
 
-Then, navigate to the address of the Web Client (`http://localhost:8081`) and use these queries to test the server:
+Then, navigate to the address of the Web Client 
+(`http://localhost:8081`) and query the server:
 
 - `What tables are in the database?`
 - `Show me the top 10 products by sales`

--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -5,14 +5,16 @@ In this Quickstart demo, we'll walk you through getting started with the MCP
 server. This guide creates a:
 
 - **PostgreSQL 17** - pgEdge PostgreSQL distribution
-- **Northwind Dataset** - Classic demo database with orders, customers, products
+- **Northwind Dataset** - Classic demo database with orders, customers, 
+  products
 - **pgEdge MCP Server** - Natural language interface to your database
 - **pgEdge Web UI** - Modern chat interface for querying with natural language
 - **Pre-configured** - Demo credentials work out of the box
 
 The Northwind database is a classic SQL Server sample database containing:
 
-- **13 Tables**: `Categories`, `Customers`, `Employees`, `Orders`, `Products`, `Shippers`, `Suppliers`, etc.
+- **13 Tables**: `Categories`, `Customers`, `Employees`, `Orders`, `Products`,
+  `Shippers`, `Suppliers`, etc.
 - **~1000 Rows**: Realistic business data for testing and demos
 - **1 Schema**: `northwind` (keeps your `public` schema clean)
 
@@ -112,8 +114,7 @@ To stop: cd /tmp/pgedge-download.28085 && docker compose down -v
 For more information: https://github.com/pgEdge/pgedge-postgres-mcp
 ```
 
-Then, navigate to the address of the Web Client (`http://localhost:8081`) and 
-use these queries to test the server:
+Then, navigate to the address of the Web Client (`http://localhost:8081`) and use these queries to test the server:
 
 - `What tables are in the database?`
 - `Show me the top 10 products by sales`

--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -1,6 +1,6 @@
-# pgEdge MCP Server and AI Toolkit Quickstart
+# pgEdge MCP Server and AI Toolkit Quickstart Demo
 
-In this Quickstart, we'll walk you through getting started with the MCP server. This guide creates a:
+In this Quickstart demo, we'll walk you through getting started with the MCP server. This guide creates a:
 
 - **PostgreSQL 17** - pgEdge PostgreSQL distribution
 - **Northwind Dataset** - Classic demo database with orders, customers, products

--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -179,7 +179,8 @@ MCP Server API:
 ```
 
 Then, you can navigate to the address of the Web Client 
-(`http://localhost:8081`) and use these queries to test the server:
+
+(`http://localhost:8081`) and query the server:
 
 - `What tables are in the database?`
 - `Show me the top 10 products by sales`

--- a/examples/quickstart-demo/README.md
+++ b/examples/quickstart-demo/README.md
@@ -7,4 +7,4 @@ The purpose of this demo is to provide end-users a working interactive example o
 fewest configuration steps.  Therefore, rather than building containers from the repo, it pulls the latest public 
 container images from our repository.
 
-For more detail, please refer to: [Quick Start Guide](../../docs/guide/quickstart.md)
+For more detail, please refer to: [Quick Start Demo Guide](../../docs/guide/quickstart_demo.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,7 @@ nav:
   - Installing the MCP Server:
       - Deploying on Docker: guide/deploy_docker.md
       - Deploying from Source: guide/deploy_source.md
-      - pgEdge Postgres MCP Server - Quickstart: guide/quickstart.md
+      - Quickstart Demo: guide/quickstart_demo.md
       - Accessing Online Help: guide/help.md
   - Configuring the MCP Server:
       - Specifying Configuration Preferences: guide/configuration.md


### PR DESCRIPTION
There was some ambiguity between quickstart content for the *repo* and the *demo*. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed and refreshed the Quickstart to a "Quickstart Demo" with improved readability, line-wrapping, and minor punctuation/formatting tweaks.
  * Updated instructions to reference the Web Client address (http://localhost:8081) where applicable.
  * Updated README and site navigation to point to the revised demo guide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->