### PR TITLE
Update MCP Server documentation structure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,10 +67,10 @@ nav:
       - Choosing the Right Solution: guide/mcp-vs-rag.md
       - Best Practices - Querying the Server: guide/querying.md
   - Installing the MCP Server:
-      - Deploying from Source: guide/deploy_source.md
+      - pgEdge Postgres MCP Server Quickstart: guide/quickstart_demo.md
       - Deploying on Docker: guide/deploy_docker.md
+      - Deploying from Source: guide/deploy_source.md
       - Testing the MCP Server Deployment: guide/test_server.md
-      - Quickstart Demo: guide/quickstart_demo.md
   - Configuring the MCP Server:
       - Specifying Configuration Preferences: guide/configuration.md
       - Using Environment Variables to Specify Options: guide/env_variable_config.md


### PR DESCRIPTION
If you go to our live docs, the latest version is unable to open the Installation section:  https://docs.pgedge.com/pgedge-postgres-mcp-server/v1-0-0-beta2/guide/quickstart.md

The problem is that link should actually be:

https://docs.pgedge.com/pgedge-postgres-mcp-server/v1-0-0-beta2/guide/quickstart_demo.md

This PR has a change that changes the file name to quickstart_demo.md in the mkdocs.yaml file; once this PR is pushed, I'll make supporting changes to publish the v1.0.0-beta2-docs branch with the v1.0.0-beta2 (latest) drop-down link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized navigation structure for the installation guides section to improve clarity and ease of navigation.
  * Enhanced getting started experience with restructured setup guides and a more prominent Quickstart entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->