### PR TITLE
Fix Windows Docker deployment: no such file or directory error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Force LF line endings for shell scripts to prevent Windows CRLF issues
+# This ensures scripts work correctly in Linux containers regardless of
+# the platform used to clone the repository.
+*.sh text eol=lf
+
+# Dockerfile and docker-compose files should also use LF
+Dockerfile* text eol=lf
+docker-compose*.yml text eol=lf
+docker-compose*.yaml text eol=lf
+
+# Keep batch files with CRLF for Windows compatibility
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -50,8 +50,14 @@ WORKDIR /app
 # Copy the binary from builder
 COPY --from=builder --chown=1001:1001 /workspace/pgedge-postgres-mcp /app/pgedge-postgres-mcp
 
-# Copy initialization script (must be executable and owned by root to create directories)
-COPY --chmod=755 docker/init-server.sh /app/init-server.sh
+# Copy initialization script and normalize line endings
+# The sed command removes Windows CRLF line endings that may be introduced
+# when cloning on Windows with core.autocrlf=true, which would otherwise cause
+# "exec format error" or "no such file or directory" errors in the container.
+COPY docker/init-server.sh /tmp/init-server.sh
+RUN sed 's/\r$//' /tmp/init-server.sh > /app/init-server.sh && \
+    chmod 755 /app/init-server.sh && \
+    rm /tmp/init-server.sh
 
 # Create knowledgebase directory
 RUN mkdir -p /usr/share/pgedge/nla-kb && chown 1001:1001 /usr/share/pgedge/nla-kb

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,15 @@ and this project adheres to
 
 ### Fixed
 
+- Fixed Docker container failing to start on Windows with the error "exec
+  /app/init-server.sh: no such file or directory". This was caused by Git
+  on Windows converting LF line endings to CRLF, which breaks shell script
+  execution in Linux containers. The fix adds a `.gitattributes` file that
+  forces LF line endings for shell scripts and Dockerfiles, and the
+  Dockerfile now normalizes line endings during the build as a defensive
+  measure. Users who cloned the repository before this fix should run
+  `git add --renormalize . && git checkout -- .` to fix existing files.
+
 - Fixed Web GUI losing connection when switching between databases. The
   server now returns proper JSON error responses when the database is
   temporarily unavailable during switching, and the client handles these

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -113,6 +113,45 @@ system-specific.
 * On Linux, you should use `172.17.0.1` or configure a Docker network
   bridge.
 
+### Windows Docker: "exec init-server.sh: no such file or directory"
+
+If the container fails to start on Windows with the error `exec
+/app/init-server.sh: no such file or directory`, this is caused by
+Windows-style CRLF line endings in the shell script. Git on Windows
+converts LF to CRLF by default, which causes the Linux container to fail
+when executing the script.
+
+The repository includes a `.gitattributes` file that prevents this issue
+by forcing LF line endings for shell scripts. If you cloned the
+repository before this fix was added, you can resolve the issue with the
+following steps:
+
+```bash
+# Re-normalize line endings after pulling the latest changes
+git add --renormalize .
+git checkout -- .
+
+# Rebuild the Docker images
+docker-compose build --no-cache
+```
+
+If you prefer a manual fix without pulling updates, you can convert the
+line endings directly:
+
+```powershell
+# PowerShell: Convert CRLF to LF
+(Get-Content docker/init-server.sh -Raw) -replace "`r`n", "`n" |
+    Set-Content docker/init-server.sh -NoNewline
+```
+
+```bash
+# Git Bash or WSL: Convert CRLF to LF
+sed -i 's/\r$//' docker/init-server.sh
+```
+
+After converting the line endings, rebuild the Docker images with
+`docker-compose build --no-cache`.
+
 ## Troubleshooting Configuration Issues
 
 This section provides solutions for common configuration file issues.


### PR DESCRIPTION
## Summary

Fixes #54: Docker container fails to start on Windows with the error `exec /app/init-server.sh: no such file or directory`.

**Root Cause:** Git on Windows converts LF line endings to CRLF by default (`core.autocrlf=true`). When shell scripts have CRLF line endings, the shebang line (`#!/bin/bash`) becomes `#!/bin/bash\r`, causing the Linux container to look for `/bin/bash\r` which doesn't exist.

**Changes:**

- Add `.gitattributes` to force LF line endings for shell scripts and Dockerfiles regardless of platform
- Update `Dockerfile.server` to normalize line endings during build as a defensive measure (uses `sed` to strip CR characters)
- Add troubleshooting documentation for Windows users

## Test plan

- [ ] Clone repository on Windows with default Git settings
- [ ] Run `docker-compose build` and verify no errors
- [ ] Run `docker-compose up` and verify container starts successfully
- [ ] Verify health check passes

**For users with existing clones:**
```bash
git pull
git add --renormalize .
git checkout -- .
docker-compose build --no-cache
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Docker startup failures on Windows systems caused by line ending handling.

* **Documentation**
  * Added troubleshooting section for Windows users experiencing Docker initialization errors.
  * Updated changelog documenting the Windows Docker issue resolution and remediation steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->