### PR TITLE
Update kb builder sources with latest releases

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -9,31 +9,31 @@ doc_source_path: "bin/doc-source"
 # Documentation sources
 sources:
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_18_1"
+      tag: "REL_18_2"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "18"
 
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_17_7"
+      tag: "REL_17_8"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "17"
 
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_16_11"
+      tag: "REL_16_12"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "16"
 
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_15_15"
+      tag: "REL_15_16"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "15"
 
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_14_20"
+      tag: "REL_14_21"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "14"
@@ -175,10 +175,10 @@ sources:
       project_version: "1.0.0-beta1"
 
     - git_url: "https://github.com/pgEdge/spock.git"
-      tag: "v5.0.4"
+      tag: "v5.0.5"
       doc_path: "docs"
       project_name: "Spock"
-      project_version: "5.0.4"
+      project_version: "5.0.5"
 
     - git_url: "https://github.com/pgEdge/control-plane.git"
       tag: "v0.6.2"
@@ -211,10 +211,34 @@ sources:
       project_version: "0.1.0"
 
     - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.5.4"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.5.4"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.5.3"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.5.3"
+    
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.5.2"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.5.2"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
       tag: "v1.5.1"
       doc_path: "docs"
       project_name: "pgEdge ACE"
       project_version: "1.5.1"
+    
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.5.0"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.5.0"
 
     - git_url: "https://github.com/pgEdge/ace.git"
       tag: "v1.4.2"
@@ -233,6 +257,18 @@ sources:
       doc_path: "docs"
       project_name: "pgEdge ACE"
       project_version: "1.4.0"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.3.5"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.3.5"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.3.4"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.3.4"
 
     - git_url: "https://github.com/pgEdge/pgedge-vectorizer.git"
       tag: "v1.0-beta2"

--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -179,6 +179,12 @@ sources:
       doc_path: "docs"
       project_name: "Spock"
       project_version: "5.0.5"
+      
+    - git_url: "https://github.com/pgEdge/spock.git"
+      tag: "v5.0.4"
+      doc_path: "docs"
+      project_name: "Spock"
+      project_version: "5.0.4"
 
     - git_url: "https://github.com/pgEdge/control-plane.git"
       tag: "v0.6.2"
@@ -263,12 +269,6 @@ sources:
       doc_path: "docs"
       project_name: "pgEdge ACE"
       project_version: "1.3.5"
-
-    - git_url: "https://github.com/pgEdge/ace.git"
-      tag: "v1.3.4"
-      doc_path: "docs"
-      project_name: "pgEdge ACE"
-      project_version: "1.3.4"
 
     - git_url: "https://github.com/pgEdge/pgedge-vectorizer.git"
       tag: "v1.0-beta2"


### PR DESCRIPTION
- Update PostgreSQL doc tags: 18.2, 17.8, 16.12, 15.16, 14.21
- Update Spock to v5.0.5
- Add pgEdge ACE versions 1.5.0-1.5.4 and 1.3.4-1.3.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL documentation source tags across multiple supported versions to their latest releases.
  * Bumped Spock integration to project version 5.0.5.
  * Expanded pgEdge ACE coverage by adding multiple new version entries (including the 1.5.x and 1.3.x series) to broaden compatibility and version tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->