### PR TITLE
Increase kb-builder retry limit to 50 in release workflow to survive …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     push:
         tags:
             - 'v*'
+    workflow_dispatch:
 
 permissions:
     contents: write

--- a/.goreleaser-amd64.yaml
+++ b/.goreleaser-amd64.yaml
@@ -13,7 +13,7 @@ before:
         # Create bin directory for kb.db output
         - mkdir -p bin
         # Generate kb.db using Ollama Cloud (requires OLLAMA_API_KEY env var)
-        - ./pgedge-nla-kb-builder --config examples/pgedge-nla-kb-builder-build.yaml
+        - ./pgedge-nla-kb-builder --config examples/pgedge-nla-kb-builder-build.yaml --max-retries 50
 
 builds:
     # MCP Server - amd64 (all platforms)

--- a/.goreleaser-arm64.yaml
+++ b/.goreleaser-arm64.yaml
@@ -13,7 +13,7 @@ before:
         # Create bin directory for kb.db output
         - mkdir -p bin
         # Generate kb.db using Ollama Cloud (requires OLLAMA_API_KEY env var)
-        - ./pgedge-nla-kb-builder --config examples/pgedge-nla-kb-builder-build.yaml
+        - ./pgedge-nla-kb-builder --config examples/pgedge-nla-kb-builder-build.yaml --max-retries 50
 
 builds:
     # MCP Server - arm64 (all platforms)


### PR DESCRIPTION
- Increase kb-builder retry limit to 50 in release workflow to survive                                                                                                 
    sustained API rate limiting during embedding generation (previous
    default of 5 retries ).
  - Add `workflow_dispatch` trigger to the release workflow so failed
    releases can be re-run manually from the Actions UI without creating
    a new tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled manual triggering of release workflows in addition to automatic tag-based deployments.
  * Improved knowledge base artifact generation reliability by increasing retry attempts during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->