### PR TITLE
Publish Docker latest images only on version tag pushes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,6 @@ name: Docker - Build and Publish
 
 on:
     push:
-        branches: [main]
         tags: ['v*']
     # Allow manual trigger with KB_SOURCE input
     workflow_dispatch:
@@ -64,7 +63,7 @@ jobs:
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=sha
-                      type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
             - name: Build and push server image
               id: build
@@ -83,9 +82,9 @@ jobs:
         name: Build MCP Server Image (with Knowledgebase)
         runs-on: ubuntu-latest
         needs: build-server
-        # Only build with-kb image on main branch, tags, or manual trigger with kb_source
+        # Only build with-kb image on tags or manual trigger with kb_source
         if: |
-            (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) ||
+            startsWith(github.ref, 'refs/tags/') ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.kb_source != '')
         permissions:
             contents: read
@@ -146,7 +145,7 @@ jobs:
                       type=semver,pattern={{version}},suffix=-with-kb
                       type=semver,pattern={{major}}.{{minor}},suffix=-with-kb
                       type=sha,suffix=-with-kb
-                      type=raw,value=latest-with-kb,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+                      type=raw,value=latest-with-kb,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
             - name: Build and push KB image
               if: steps.check-kb.outputs.available == 'true'
@@ -196,7 +195,7 @@ jobs:
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=sha
-                      type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
             - name: Build and push web image
               uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
@@ -243,7 +242,7 @@ jobs:
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=sha
-                      type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
             - name: Build and push CLI image
               uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5


### PR DESCRIPTION

  Summary
  
  - Stop publishing Docker images to GHCR on every push to main; only publish on v* tag pushes and manual workflow_dispatch triggers.
  - Update latest and latest-with-kb tag conditions to apply only on version tags instead of the main branch.
  - Remove dead refs/heads/main check from the build-server-with-kb job condition.

  Motivation

  Previously, every commit to main triggered a full Docker image build and publish for all three images (server, web, CLI) plus the KB variant, tagging them as latest.
  This meant latest could point to an unreleased, potentially unstable commit. With this change, latest only updates on explicit version tag pushes, ensuring it always reflects a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing workflow to apply "latest" image tags exclusively to version releases rather than main branch builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->