### PR TITLE
Replace CGO SQLite driver with pure Go driver for static binaries

### DIFF
--- a/.goreleaser-amd64.yaml
+++ b/.goreleaser-amd64.yaml
@@ -9,7 +9,7 @@ before:
         # Format code
         - go fmt ./...
         # Build kb-builder for generating kb.db
-        - sh -c 'CGO_ENABLED=1 go build -o pgedge-nla-kb-builder ./cmd/kb-builder'
+        - sh -c 'CGO_ENABLED=0 go build -o pgedge-nla-kb-builder ./cmd/kb-builder'
         # Create bin directory for kb.db output
         - mkdir -p bin
         # Generate kb.db using Ollama Cloud (requires OLLAMA_API_KEY env var)
@@ -54,18 +54,18 @@ builds:
           - -X main.date={{.Date}}
           - -X main.builtBy=goreleaser
 
-    # KB Builder - LINUX ONLY x86_64 (amd64) - native build with CGO
-    - id: pgedge-nla-kb-builder-linux-amd64
+    # KB Builder - amd64 (all platforms, pure Go)
+    - id: pgedge-nla-kb-builder-amd64
       binary: pgedge-nla-kb-builder
       main: ./cmd/kb-builder
       env:
-          - CGO_ENABLED=1
+          - CGO_ENABLED=0
       goos:
-          - linux  # Linux only - KB builder is server-side tool
+          - linux
+          - darwin
+          - windows
       goarch:
           - amd64
-      # Skip if not on Linux (for local testing on macOS/Windows)
-      skip: '{{ ne .Runtime.Goos "linux" }}'
       ldflags:
           - -s -w
           - -X main.version={{.Version}}
@@ -108,11 +108,11 @@ archives:
           - LICENSE.md
           - docs/**/*
 
-    # KB Builder archive for Linux x86_64
-    - id: kb-builder-linux-amd64
+    # KB Builder archive for x86_64
+    - id: kb-builder-amd64
       builds:
-          - pgedge-nla-kb-builder-linux-amd64
-      name_template: "{{ .ProjectName }}-kb-builder_{{ .Version }}_linux_x86_64"
+          - pgedge-nla-kb-builder-amd64
+      name_template: "{{ .ProjectName }}-kb-builder_{{ .Version }}_{{ .Os }}_x86_64"
       allow_different_binary_count: true
       files:
           - README.md

--- a/.goreleaser-arm64.yaml
+++ b/.goreleaser-arm64.yaml
@@ -9,7 +9,7 @@ before:
         # Format code
         - go fmt ./...
         # Build kb-builder for generating kb.db
-        - sh -c 'CGO_ENABLED=1 go build -o pgedge-nla-kb-builder ./cmd/kb-builder'
+        - sh -c 'CGO_ENABLED=0 go build -o pgedge-nla-kb-builder ./cmd/kb-builder'
         # Create bin directory for kb.db output
         - mkdir -p bin
         # Generate kb.db using Ollama Cloud (requires OLLAMA_API_KEY env var)
@@ -52,18 +52,17 @@ builds:
           - -X main.date={{.Date}}
           - -X main.builtBy=goreleaser
 
-    # KB Builder - LINUX ONLY ARM64 - native build with CGO
-    - id: pgedge-nla-kb-builder-linux-arm64
+    # KB Builder - arm64 (all platforms, pure Go)
+    - id: pgedge-nla-kb-builder-arm64
       binary: pgedge-nla-kb-builder
       main: ./cmd/kb-builder
       env:
-          - CGO_ENABLED=1
+          - CGO_ENABLED=0
       goos:
-          - linux  # Linux only - KB builder is server-side tool
+          - linux
+          - darwin
       goarch:
           - arm64
-      # Skip if not on Linux (for local testing on macOS)
-      skip: '{{ ne .Runtime.Goos "linux" }}'
       ldflags:
           - -s -w
           - -X main.version={{.Version}}
@@ -94,11 +93,11 @@ archives:
           - LICENSE.md
           - docs/**/*
 
-    # KB Builder archive for Linux ARM64
-    - id: kb-builder-linux-arm64
+    # KB Builder archive for ARM64
+    - id: kb-builder-arm64
       builds:
-          - pgedge-nla-kb-builder-linux-arm64
-      name_template: "{{ .ProjectName }}-kb-builder_{{ .Version }}_linux_arm64"
+          - pgedge-nla-kb-builder-arm64
+      name_template: "{{ .ProjectName }}-kb-builder_{{ .Version }}_{{ .Os }}_arm64"
       allow_different_binary_count: true
       files:
           - README.md

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,9 +2,6 @@
 # Stage 1: Build the Go binary
 FROM golang:1.24-alpine AS builder
 
-# Install build dependencies for CGO (required by go-sqlite3)
-RUN apk add --no-cache gcc musl-dev
-
 # Set working directory
 WORKDIR /workspace
 
@@ -17,8 +14,8 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the server binary with CGO enabled (required for SQLite knowledgebase)
-RUN CGO_ENABLED=1 GOOS=linux go build -a -o pgedge-postgres-mcp ./cmd/pgedge-pg-mcp-svr
+# Build the server binary (pure Go, no CGO required)
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o pgedge-postgres-mcp ./cmd/pgedge-pg-mcp-svr
 
 # Stage 2: Create minimal runtime image
 # Note: Using ubi9-minimal instead of ubi9-micro to get shadow-utils for user switching

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/chzyer/readline v1.5.1
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.6
-	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/spf13/cobra v1.10.1
 	golang.org/x/crypto v0.44.0
 	golang.org/x/term v0.37.0
@@ -30,7 +30,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,6 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
-github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=

--- a/internal/kbdatabase/database.go
+++ b/internal/kbdatabase/database.go
@@ -17,7 +17,7 @@ import (
 	"math"
 	"strings"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 	"pgedge-postgres-mcp/internal/kbtypes"
 )
 
@@ -28,7 +28,7 @@ type Database struct {
 
 // Open opens or creates the knowledgebase database
 func Open(path string) (*Database, error) {
-	db, err := sql.Open("sqlite3", path)
+	db, err := sql.Open("sqlite", path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}

--- a/internal/tools/search_knowledgebase.go
+++ b/internal/tools/search_knowledgebase.go
@@ -19,7 +19,7 @@ import (
 	"sort"
 	"strings"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 	"pgedge-postgres-mcp/internal/config"
 	"pgedge-postgres-mcp/internal/embedding"
 	"pgedge-postgres-mcp/internal/mcp"
@@ -197,7 +197,7 @@ type KBSearchResult struct {
 
 // listKBProducts returns a formatted list of all products and versions in the knowledgebase
 func listKBProducts(kbPath string) (string, error) {
-	db, err := sql.Open("sqlite3", kbPath)
+	db, err := sql.Open("sqlite", kbPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to open knowledgebase: %w", err)
 	}
@@ -296,7 +296,7 @@ func generateKBQueryEmbedding(serverCfg *config.Config, queryText string) ([]flo
 
 func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVersions []string, topN int, provider string) ([]KBSearchResult, error) {
 	// Open database
-	db, err := sql.Open("sqlite3", kbPath)
+	db, err := sql.Open("sqlite", kbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open knowledgebase: %w", err)
 	}


### PR DESCRIPTION
Summary

  - Replace github.com/mattn/go-sqlite3 (CGO) with modernc.org/sqlite
  (pure Go) in knowledgebase packages, fixing KB search in static builds.
  - Revert the Dockerfile.server CGO workaround (commit 483c0ed) that
  introduced musl/glibc mismatch risk between Alpine build and UBI9
  runtime stages.
  - Enable kb-builder for all platforms (macOS, Linux, Windows) now that
  CGO is no longer required.

  Problem

  The server is built with CGO_ENABLED=0 for fully static binaries. The
  go-sqlite3 driver requires CGO to register itself, so sql.Open
  failed at runtime with "unknown driver" — breaking knowledgebase search.

  A recent workaround set CGO_ENABLED=1 in the Dockerfile with
  gcc musl-dev, but this created a binary dynamically linked against
  musl (Alpine) that runs on a glibc runtime (UBI9), risking crashes or
  silent misbehavior. The goreleaser release binaries remained broken.

  Fix

  modernc.org/sqlite is a pure Go SQLite implementation already used in
  internal/conversations/store.go. Switching to it keeps CGO_ENABLED=0
  everywhere, producing fully static binaries that work on any Linux
  distro regardless of C library.

  Test plan

  - CGO_ENABLED=0 go build ./cmd/pgedge-pg-mcp-svr compiles
  - CGO_ENABLED=0 go build ./cmd/kb-builder compiles
  - make test — all tests pass, including kbdatabase SQLite tests
  - Docker build produces a working container image
  - KB search returns results at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded platform support: build configurations now target Linux, macOS, and Windows for improved accessibility across operating systems.
  * Modernized SQLite database driver to a pure Go implementation for better compatibility and reduced external dependencies.
  * Optimized build process using pure Go compilation, enhancing portability and streamlining deployment across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->