### PR TITLE
Update kb builder sources

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -9,31 +9,31 @@ doc_source_path: "bin/doc-source"
 # Documentation sources
 sources:
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_18_2"
+      tag: "REL_18_3"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "18"
 
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_17_8"
+      tag: "REL_17_9"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "17"
 
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_16_12"
+      tag: "REL_16_13"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "16"
 
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_15_16"
+      tag: "REL_15_17"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "15"
 
     - git_url: "https://github.com/postgres/postgres.git"
-      tag: "REL_14_21"
+      tag: "REL_14_22"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "14"
@@ -313,6 +313,12 @@ sources:
       project_version: "2.56.0"
 
     - git_url: "https://github.com/postgis/postgis.git"
+      tag: "3.5.5"
+      doc_path: "doc"
+      project_name: "PostGIS"
+      project_version: "3.5.5"
+
+    - git_url: "https://github.com/postgis/postgis.git"
       tag: "3.5.4"
       doc_path: "doc"
       project_name: "PostGIS"
@@ -365,6 +371,12 @@ sources:
       doc_path: ""
       project_name: "pgEdge System Stats"
       project_version: "3.2.1"
+
+    - git_url: "https://github.com/PostgREST/postgrest.git"
+      tag: "v14.5"
+      doc_path: "docs"
+      project_name: "PostgREST"
+      project_version: "14.5"
     
     - git_url: "https://github.com/pgEdge/radar.git"
       tag: "v0.2.2"


### PR DESCRIPTION
PostgreSQL version updates:
- PostgreSQL 18: 18.2 → 18.3
- PostgreSQL 17: 17.8 → 17.9
- PostgreSQL 16: 16.12 → 16.13
- PostgreSQL 15: 15.16 → 15.17
- PostgreSQL 14: 14.21 → 14.22

New additions:
- PostGIS 3.5.5
- PostgREST 14.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PostgreSQL documentation references to newer minor releases.

* **Chores**
  * Added PostGIS 3.5.5 and PostgREST v14.5 documentation sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->