### PR TITLE
fix: use SET instead of startup param for read-only mode

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -112,6 +112,13 @@ and this project adheres to
   points now check a closed flag and transparently create a fresh
   client when needed.
 
+- The `default_transaction_read_only` session parameter is now set
+  with a `SET` command after connection instead of as a startup
+  parameter. Connection poolers such as PgBouncer and HAProxy do
+  not support arbitrary startup parameters; the previous approach
+  caused connections to fail with an "unsupported startup parameter"
+  error.
+
 - Ollama embedding generation no longer retries or fails the entire
   batch when a chunk exceeds the model's context length. The builder
   detects the error immediately, progressively truncates the text at

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -23,6 +23,7 @@ import (
 
 	"pgedge-postgres-mcp/internal/config"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -152,17 +153,15 @@ func (c *Client) ConnectTo(connStr string) error {
 		}
 	}
 
-	// Set read-only transaction mode at the session level unless writes are explicitly allowed
-	// This provides defense-in-depth: even if query_database logic fails, writes are blocked
-	if poolConfig.ConnConfig.RuntimeParams == nil {
-		poolConfig.ConnConfig.RuntimeParams = make(map[string]string)
-	}
-	if c.dbConfig != nil && c.dbConfig.AllowWrites {
-		// Write access enabled - don't set read-only mode
-		poolConfig.ConnConfig.RuntimeParams["default_transaction_read_only"] = "off"
-	} else {
-		// Default: read-only for safety
-		poolConfig.ConnConfig.RuntimeParams["default_transaction_read_only"] = "on"
+	// Set read-only transaction mode at the session level unless writes are explicitly allowed.
+	// This provides defense-in-depth: even if query_database logic fails, writes are blocked.
+	// We use AfterConnect instead of RuntimeParams because RuntimeParams sets startup
+	// parameters that connection poolers like PgBouncer and HAProxy do not support.
+	if c.dbConfig == nil || !c.dbConfig.AllowWrites {
+		poolConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+			_, err := conn.Exec(ctx, "SET default_transaction_read_only = 'on'")
+			return err
+		}
 	}
 
 	// Create pool with configured settings


### PR DESCRIPTION
## Summary

- Replace `RuntimeParams` with an `AfterConnect` callback to set `default_transaction_read_only` via a `SET` command after connection, fixing compatibility with PgBouncer and HAProxy.
- When `allow_writes: true`, no action is taken since the PostgreSQL default is already `off`.

Fixes #81

## Test plan

- [x] All existing tests pass (`make test`)
- [ ] Verify connection through PgBouncer with `allow_writes: false` succeeds
- [ ] Verify connection through PgBouncer with `allow_writes: true` succeeds
- [ ] Verify read-only protection still blocks writes when `allow_writes: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed startup failures when using connection poolers (e.g., PgBouncer, HAProxy) that don't support arbitrary startup parameters. Read-only mode is now applied after connection establishment while maintaining the expected read-only behavior throughout the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->