### PR TITLE
fix: don't exit when configured databases are unreachable at startup

### DIFF
--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -494,32 +494,56 @@ func main() {
 	// This will be used as the "default" connection if database is configured
 	var fallbackClient *database.Client
 	if !authEnabled && firstDB != nil && firstDB.User != "" {
-		// Create connection to database using config
-		connStr := firstDB.BuildConnectionString()
-		fallbackClient = database.NewClientWithConnectionString(connStr, firstDB)
+		// Attempt to connect to each configured database at startup.
+		// Failures are logged as warnings; the server continues even
+		// if no databases are reachable. Lazy reconnection in
+		// GetClientForDatabase / GetOrCreateClient will retry on demand.
+		var firstConnected *database.Client
+		for i := range cfg.Databases {
+			db := &cfg.Databases[i]
+			if db.User == "" {
+				continue
+			}
+			connStr := db.BuildConnectionString()
+			client := database.NewClientWithConnectionString(connStr, db)
 
-		// Connect to database
-		if err := fallbackClient.Connect(); err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: Failed to connect to database: %v\n", err)
-			os.Exit(1)
+			if err := client.Connect(); err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: Failed to connect to database '%s' (%s@%s:%d/%s): %v\n",
+					db.Name, db.User, db.Host, db.Port, db.Database, err)
+				client.Close()
+				continue
+			}
+
+			if err := client.LoadMetadata(); err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: Failed to load metadata for database '%s' (%s@%s:%d/%s): %v\n",
+					db.Name, db.User, db.Host, db.Port, db.Database, err)
+				client.Close()
+				continue
+			}
+
+			if err := clientManager.SetClientForDatabase("default", db.Name, client); err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: Failed to register client for database '%s': %v\n",
+					db.Name, err)
+				client.Close()
+				continue
+			}
+
+			fmt.Fprintf(os.Stderr, "Connected to database: %s@%s:%d/%s\n",
+				db.User, db.Host, db.Port, db.Database)
+
+			if firstConnected == nil {
+				firstConnected = client
+			}
 		}
 
-		// Load metadata
-		if err := fallbackClient.LoadMetadata(); err != nil {
-			// Close the connection before exiting to avoid connection leak
-			fallbackClient.Close()
-			fmt.Fprintf(os.Stderr, "ERROR: Failed to load database metadata: %v\n", err)
-			os.Exit(1)
+		if firstConnected != nil {
+			fallbackClient = firstConnected
+		} else {
+			// No databases reachable - start with an unconfigured client.
+			// Tools will attempt to connect on demand.
+			fallbackClient = database.NewClient(nil)
+			fmt.Fprintf(os.Stderr, "WARNING: No databases are currently reachable; the server will retry connections on demand\n")
 		}
-
-		// Set as default connection in client manager
-		if err := clientManager.SetClient("default", fallbackClient); err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: Failed to set default client: %v\n", err)
-			os.Exit(1)
-		}
-
-		fmt.Fprintf(os.Stderr, "Connected to database: %s@%s:%d/%s\n",
-			firstDB.User, firstDB.Host, firstDB.Port, firstDB.Database)
 	} else if authEnabled && firstDB != nil && firstDB.User != "" {
 		// Auth mode - connections will be created per-session on-demand
 		// Create a template client that won't be connected

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,10 @@ and this project adheres to
   transient embedding API errors are retried. The default is 5;
   set to 0 for unlimited retries. Backoff is capped at 60 seconds.
 
+- Connection status field (`connected` or `unavailable`) in the
+  `list_database_connections` tool response; databases with status
+  `unavailable` are connected on demand when selected.
+
 - Trace file logging for deep diagnostics of MCP interactions.
   Enable with `-trace-file <path>`, the `trace_file` configuration
   option, or the `PGEDGE_TRACE_FILE` environment variable. The
@@ -104,6 +108,15 @@ and this project adheres to
       `allow_llm_switching`.
 
 ### Fixed
+
+- The server no longer exits when configured databases are
+  unreachable at startup ([#82](https://github.com/pgEdge/pgedge-postgres-mcp/issues/82)).
+  In STDIO mode, each database connection is now attempted
+  independently; failures are logged as warnings and the server
+  starts with whichever databases are reachable. Unreachable
+  databases are connected on demand when a tool or the user
+  selects them. The `list_database_connections` tool reports
+  each database as `connected` or `unavailable`.
 
 - Closed database clients are no longer returned from the client
   manager cache. Previously, background cleanup or database switching

--- a/docs/guide/multiple_db_config.md
+++ b/docs/guide/multiple_db_config.md
@@ -57,17 +57,29 @@ database:
 authentication is disabled (`--no-auth`), all databases are accessible to
 everyone.
 
+### Startup Behavior
+
+In STDIO mode the server attempts to connect to every configured
+database at startup. Each connection is attempted independently;
+a failure is logged as a warning and does not prevent the server
+from starting. Databases that are unreachable at startup are
+marked `unavailable` and connected on demand when a tool or user
+selects them.
+
+In HTTP mode with authentication enabled, all database connections
+are created on demand; no connections are made at startup.
+
 ### Default Database Selection
 
-When a user connects, the system automatically selects a default database
-using this priority:
+When a user connects, the system automatically selects a default
+database using this priority:
 
-1. **Saved preference**: If the user previously selected a database and it's
-   still accessible, that database is used
-2. **First accessible database**: Otherwise, the first database in the
-   configuration list that the user has access to is selected
-3. **No database**: If no databases are accessible, database operations will
-   fail with an appropriate error message
+1. **Saved preference**: If the user previously selected a database
+   and the database is still accessible, that database is used.
+2. **First accessible database**: Otherwise, the first database in
+   the configuration list that the user has access to is selected.
+3. **No database**: If no databases are accessible, database
+   operations fail with an appropriate error message.
 
 **Example scenarios:**
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -217,7 +217,7 @@ must be enabled in the server configuration.
 * **Database Selection**: Help users find the right database for their
   query.
 * **Connection Overview**: Provide visibility into configured database
-  connections.
+  connections and their current status.
 
 !!! note
 
@@ -268,19 +268,26 @@ The tool returns:
       "database": "app_dev",
       "host": "localhost",
       "port": 5432,
-      "allow_writes": true
+      "allow_writes": true,
+      "status": "connected"
     },
     {
       "name": "staging",
       "database": "app_staging",
       "host": "staging-db.example.com",
       "port": 5432,
-      "allow_writes": false
+      "allow_writes": false,
+      "status": "unavailable"
     }
   ],
   "current": "development"
 }
 ```
+
+Databases with status `unavailable` are connected on demand when
+selected using `select_database_connection`. The server attempts
+the connection at that point and returns an error if the database
+is still unreachable.
 
 
 ## select_database_connection

--- a/internal/database/client_manager.go
+++ b/internal/database/client_manager.go
@@ -364,12 +364,55 @@ func (cm *ClientManager) CloseAll() error {
 	return nil
 }
 
+// IsConnected checks whether a non-closed client exists for the given
+// token hash and database name. It does not create a new connection.
+func (cm *ClientManager) IsConnected(tokenHash, dbName string) bool {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	if tokenClients, exists := cm.clients[tokenHash]; exists {
+		if client, exists := tokenClients[dbName]; exists && !client.IsClosed() {
+			return true
+		}
+	}
+	return false
+}
+
 // GetClientCount returns the number of active database client connections
 // Useful for monitoring and testing
 func (cm *ClientManager) GetClientCount() int {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 	return cm.countClients()
+}
+
+// SetClientForDatabase sets a database client for a specific database name
+// under the given key (token hash or "default").
+func (cm *ClientManager) SetClientForDatabase(key, dbName string, client *Client) error {
+	if key == "" {
+		return fmt.Errorf("key is required")
+	}
+	if dbName == "" {
+		return fmt.Errorf("database name is required")
+	}
+	if client == nil {
+		return fmt.Errorf("client cannot be nil")
+	}
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Close existing client if it exists
+	if tokenClients, exists := cm.clients[key]; exists {
+		if existingClient, exists := tokenClients[dbName]; exists {
+			existingClient.Close()
+		}
+	} else {
+		cm.clients[key] = make(map[string]*Client)
+	}
+
+	cm.clients[key][dbName] = client
+	return nil
 }
 
 // SetClient sets a database client for the given key (token hash or "default")

--- a/internal/database/client_manager_test.go
+++ b/internal/database/client_manager_test.go
@@ -199,6 +199,109 @@ func TestClientManager_CloseAll(t *testing.T) {
 	}
 }
 
+// TestClientManager_SetClientForDatabase tests setting clients for specific databases
+func TestClientManager_SetClientForDatabase(t *testing.T) {
+	cm := NewClientManager(nil)
+	defer cm.CloseAll()
+
+	t.Run("sets client for named database", func(t *testing.T) {
+		client := NewClient(nil)
+		err := cm.SetClientForDatabase("default", "mydb", client)
+		if err != nil {
+			t.Fatalf("SetClientForDatabase returned error: %v", err)
+		}
+		if !cm.IsConnected("default", "mydb") {
+			t.Error("Expected client to be connected after SetClientForDatabase")
+		}
+	})
+
+	t.Run("rejects empty key", func(t *testing.T) {
+		client := NewClient(nil)
+		err := cm.SetClientForDatabase("", "mydb", client)
+		if err == nil {
+			t.Error("Expected error for empty key")
+		}
+	})
+
+	t.Run("rejects empty database name", func(t *testing.T) {
+		client := NewClient(nil)
+		err := cm.SetClientForDatabase("default", "", client)
+		if err == nil {
+			t.Error("Expected error for empty database name")
+		}
+	})
+
+	t.Run("rejects nil client", func(t *testing.T) {
+		err := cm.SetClientForDatabase("default", "mydb", nil)
+		if err == nil {
+			t.Error("Expected error for nil client")
+		}
+	})
+
+	t.Run("multiple databases under same key", func(t *testing.T) {
+		client1 := NewClient(nil)
+		client2 := NewClient(nil)
+		if err := cm.SetClientForDatabase("tok", "db1", client1); err != nil {
+			t.Fatalf("SetClientForDatabase returned error: %v", err)
+		}
+		if err := cm.SetClientForDatabase("tok", "db2", client2); err != nil {
+			t.Fatalf("SetClientForDatabase returned error: %v", err)
+		}
+		if !cm.IsConnected("tok", "db1") {
+			t.Error("Expected db1 to be connected")
+		}
+		if !cm.IsConnected("tok", "db2") {
+			t.Error("Expected db2 to be connected")
+		}
+	})
+}
+
+// TestClientManager_IsConnected tests connection status checking
+func TestClientManager_IsConnected(t *testing.T) {
+	cm := NewClientManager(nil)
+	defer cm.CloseAll()
+
+	t.Run("returns false for unknown token", func(t *testing.T) {
+		if cm.IsConnected("unknown-token", "some-db") {
+			t.Error("Expected IsConnected to return false for unknown token")
+		}
+	})
+
+	t.Run("returns false for unknown database", func(t *testing.T) {
+		// Create a token entry with no clients
+		cm.mu.Lock()
+		cm.clients["test-token"] = make(map[string]*Client)
+		cm.mu.Unlock()
+
+		if cm.IsConnected("test-token", "nonexistent-db") {
+			t.Error("Expected IsConnected to return false for unknown database")
+		}
+	})
+
+	t.Run("returns true for open client", func(t *testing.T) {
+		client := NewClient(nil)
+		cm.mu.Lock()
+		cm.clients["open-token"] = map[string]*Client{"mydb": client}
+		cm.mu.Unlock()
+
+		if !cm.IsConnected("open-token", "mydb") {
+			t.Error("Expected IsConnected to return true for open client")
+		}
+	})
+
+	t.Run("returns false for closed client", func(t *testing.T) {
+		client := NewClient(nil)
+		client.Close()
+		cm.mu.Lock()
+		cm.clients["closed-token"] = map[string]*Client{"mydb": client}
+		cm.mu.Unlock()
+
+		if cm.IsConnected("closed-token", "mydb") {
+			t.Error("Expected IsConnected to return false for closed client")
+		}
+	})
+}
+
 // TestClientManager_Concurrency tests thread-safety of client manager
 func TestClientManager_Concurrency(t *testing.T) {
 	// Skip if no database connection available

--- a/internal/tools/database_switching.go
+++ b/internal/tools/database_switching.go
@@ -63,14 +63,24 @@ func getEffectiveCurrentDB(tokenHash string, clientManager *database.ClientManag
 	return ""
 }
 
-// buildDatabaseListResponse builds the JSON response for list_database_connections
-func buildDatabaseListResponse(databases []config.NamedDatabaseConfig, current string) (mcp.ToolResponse, error) {
+// buildDatabaseListResponse builds the JSON response for list_database_connections.
+// The statusFunc, when non-nil, is called with each database name to determine
+// its connection status ("connected" or "unavailable").
+func buildDatabaseListResponse(
+	databases []config.NamedDatabaseConfig,
+	current string,
+	statusFunc func(dbName string) string,
+) (mcp.ToolResponse, error) {
 	dbList := make([]map[string]interface{}, 0, len(databases))
 	for i := range databases {
-		dbList = append(dbList, map[string]interface{}{
+		entry := map[string]interface{}{
 			"name": databases[i].Name, "database": databases[i].Database,
 			"host": databases[i].Host, "port": databases[i].Port, "allow_writes": databases[i].AllowWrites,
-		})
+		}
+		if statusFunc != nil {
+			entry["status"] = statusFunc(databases[i].Name)
+		}
+		dbList = append(dbList, entry)
 	}
 
 	result := map[string]interface{}{"databases": dbList, "current": current}
@@ -103,8 +113,10 @@ Each database entry includes:
 - host: Database server hostname
 - port: Database server port number
 - allow_writes: Whether write operations are permitted
+- status: Connection status ("connected" or "unavailable")
 
-The response includes which database is currently active.`,
+The response includes which database is currently active. Databases with
+status "unavailable" will be connected on demand when selected.`,
 			InputSchema: mcp.InputSchema{
 				Type:       "object",
 				Properties: map[string]interface{}{},
@@ -121,7 +133,14 @@ The response includes which database is currently active.`,
 			llmAccessible := getLLMAccessibleDatabases(ctx, clientManager, accessChecker)
 			current := getEffectiveCurrentDB(tokenHash, clientManager, llmAccessible)
 
-			return buildDatabaseListResponse(llmAccessible, current)
+			statusFunc := func(dbName string) string {
+				if clientManager.IsConnected(tokenHash, dbName) {
+					return "connected"
+				}
+				return "unavailable"
+			}
+
+			return buildDatabaseListResponse(llmAccessible, current, statusFunc)
 		},
 	}
 }

--- a/internal/tools/database_switching_test.go
+++ b/internal/tools/database_switching_test.go
@@ -90,6 +90,7 @@ func TestListDatabaseConnectionsTool_Basic(t *testing.T) {
 			Host        string `json:"host"`
 			Port        int    `json:"port"`
 			AllowWrites bool   `json:"allow_writes"`
+			Status      string `json:"status"`
 		} `json:"databases"`
 		Current string `json:"current"`
 	}
@@ -118,6 +119,9 @@ func TestListDatabaseConnectionsTool_Basic(t *testing.T) {
 			}
 			if db.AllowWrites != false {
 				t.Errorf("Expected allow_writes false, got %v", db.AllowWrites)
+			}
+			if db.Status == "" {
+				t.Error("Expected status field to be present")
 			}
 		}
 	}
@@ -419,6 +423,130 @@ func TestListDatabaseConnectionsTool_HidesInaccessibleCurrent(t *testing.T) {
 	}
 }
 
+// TestListDatabaseConnectionsTool_IncludesStatus tests that status field is present
+func TestListDatabaseConnectionsTool_IncludesStatus(t *testing.T) {
+	databases := createTestDatabaseConfigs()
+	cfg := &config.Config{Databases: databases}
+	clientManager := database.NewClientManager(databases)
+	defer clientManager.CloseAll()
+
+	tool := ListDatabaseConnectionsTool(clientManager, nil, cfg)
+
+	args := map[string]interface{}{
+		"__context": context.Background(),
+	}
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var result struct {
+		Databases []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"databases"`
+	}
+	if err := json.Unmarshal([]byte(response.Content[0].Text), &result); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// All databases should have status "unavailable" since no actual
+	// connections were established in this unit test
+	for _, db := range result.Databases {
+		if db.Status == "" {
+			t.Errorf("Database %q missing status field", db.Name)
+		}
+		if db.Status != "unavailable" {
+			t.Errorf("Expected status 'unavailable' for %q (no connection), got %q", db.Name, db.Status)
+		}
+	}
+}
+
+// TestListDatabaseConnectionsTool_StatusReflectsConnection tests that status
+// transitions between connected and unavailable based on actual client state
+func TestListDatabaseConnectionsTool_StatusReflectsConnection(t *testing.T) {
+	trueVal := true
+	databases := []config.NamedDatabaseConfig{
+		{
+			Name:              "db1",
+			Host:              "localhost",
+			Port:              5432,
+			Database:          "testdb1",
+			User:              "user1",
+			AllowLLMSwitching: &trueVal,
+		},
+		{
+			Name:              "db2",
+			Host:              "remotehost",
+			Port:              5433,
+			Database:          "testdb2",
+			User:              "user2",
+			AllowLLMSwitching: &trueVal,
+		},
+	}
+	cfg := &config.Config{Databases: databases}
+	clientManager := database.NewClientManager(databases)
+	defer clientManager.CloseAll()
+
+	// Simulate db1 connected at startup, db2 unreachable
+	client := database.NewClient(nil)
+	if err := clientManager.SetClientForDatabase("default", "db1", client); err != nil {
+		t.Fatalf("SetClientForDatabase returned error: %v", err)
+	}
+
+	tool := ListDatabaseConnectionsTool(clientManager, nil, cfg)
+	args := map[string]interface{}{
+		"__context": context.Background(),
+	}
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var result struct {
+		Databases []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"databases"`
+	}
+	if err := json.Unmarshal([]byte(response.Content[0].Text), &result); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	statusMap := make(map[string]string)
+	for _, db := range result.Databases {
+		statusMap[db.Name] = db.Status
+	}
+
+	if statusMap["db1"] != "connected" {
+		t.Errorf("Expected db1 status 'connected', got %q", statusMap["db1"])
+	}
+	if statusMap["db2"] != "unavailable" {
+		t.Errorf("Expected db2 status 'unavailable', got %q", statusMap["db2"])
+	}
+
+	// Close db1 to simulate a dropped connection
+	client.Close()
+
+	response, err = tool.Handler(args)
+	if err != nil {
+		t.Fatalf("Handler returned error after close: %v", err)
+	}
+
+	if err := json.Unmarshal([]byte(response.Content[0].Text), &result); err != nil {
+		t.Fatalf("Failed to parse response after close: %v", err)
+	}
+
+	statusMap = make(map[string]string)
+	for _, db := range result.Databases {
+		statusMap[db.Name] = db.Status
+	}
+
+	if statusMap["db1"] != "unavailable" {
+		t.Errorf("Expected db1 status 'unavailable' after close, got %q", statusMap["db1"])
+	}
+}
+
 // TestListDatabaseConnectionsTool_ToolDescription tests that tool description includes port field
 func TestListDatabaseConnectionsTool_ToolDescription(t *testing.T) {
 	clientManager := database.NewClientManager(nil)
@@ -430,6 +558,11 @@ func TestListDatabaseConnectionsTool_ToolDescription(t *testing.T) {
 	// Verify tool description mentions port
 	if !strings.Contains(tool.Definition.Description, "port") {
 		t.Error("Tool description should mention 'port' field")
+	}
+
+	// Verify tool description mentions status
+	if !strings.Contains(tool.Definition.Description, "status") {
+		t.Error("Tool description should mention 'status' field")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #82. Thanks to @smgladkovskiy for reporting this issue and the
detailed reproduction steps.

- In STDIO mode, the server now attempts each configured database
  independently at startup. Failed connections log a warning instead
  of calling `os.Exit(1)`, so the server starts with whichever
  databases are reachable.
- Unreachable databases are connected on demand when a tool or user
  selects them (the existing lazy-connection logic in
  `GetClientForDatabase` handles this automatically).
- The `list_database_connections` tool now includes a `status` field
  (`"connected"` or `"unavailable"`) for each database entry,
  giving visibility into which databases are currently reachable.
- No background retry mechanism is added; reconnection only happens
  when a tool or user actually needs the database, avoiding log
  spam for intentionally-offline servers.

## Changed files

| File | Change |
|------|--------|
| `cmd/pgedge-pg-mcp-svr/main.go` | Replace fatal exit with per-database warning loop |
| `internal/database/client_manager.go` | Add `IsConnected()` and `SetClientForDatabase()` methods |
| `internal/tools/database_switching.go` | Add `status` field to `list_database_connections` response |
| `docs/changelog.md` | Changelog entries for fix and new status field |
| `docs/guide/multiple_db_config.md` | New "Startup Behavior" section |
| `docs/reference/tools.md` | Updated example output with `status` field |
| `internal/database/client_manager_test.go` | Tests for `IsConnected` and `SetClientForDatabase` |
| `internal/tools/database_switching_test.go` | Tests for status field and status transitions |

## Test plan

- [x] All existing tests pass (`make test`)
- [x] New unit tests for `IsConnected` (open/closed/unknown clients)
- [x] New unit tests for `SetClientForDatabase` (validation, multi-db)
- [x] New test for status field presence in `list_database_connections`
- [x] New test for status transitions (connected → unavailable on close)
- [ ] Manual test: configure two databases, make one unreachable, verify server starts and reports the unreachable one as `unavailable`
- [ ] Manual test: make the unreachable database available, select it, verify it connects on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection status field to database list tool showing each database as "connected" or "unavailable"
  * Unreachable databases are now connected on-demand when selected

* **Bug Fixes**
  * Server no longer exits at startup if configured databases are unreachable; attempts independent connections with warnings logged

* **Documentation**
  * Updated startup behavior documentation for STDIO and HTTP modes
  * Clarified default database selection priority and fallback logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->