### PR TITLE
feat: add OpenAPI 3.0.3 specification and interactive API browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-server build-client build-kb-builder clean clean-server clean-client clean-kb-builder test test-server test-client test-kb-builder run install help lint lint-server lint-client fmt format gofmt kb
+.PHONY: build build-server build-client build-kb-builder clean clean-server clean-client clean-kb-builder test test-server test-client test-kb-builder run install help lint lint-server lint-client fmt format gofmt kb openapi
 
 # Binary names and directories
 SERVER_BINARY=pgedge-postgres-mcp
@@ -48,6 +48,12 @@ kb: kb-builder
 	@echo "Building knowledgebase database..."
 	$(BIN_DIR)/$(KB_BUILDER_BINARY) -c examples/pgedge-nla-kb-builder.yaml
 	@echo "Knowledgebase build complete: $(BIN_DIR)/pgedge-nla-kb.db"
+
+# Regenerate the static OpenAPI specification from the programmatic builder
+openapi:
+	@echo "Generating OpenAPI specification..."
+	$(GO) run ./$(SERVER_CMD_DIR) -openapi > docs/api/openapi.json
+	@echo "OpenAPI spec written to docs/api/openapi.json"
 
 # Build for multiple platforms (server only for now)
 build-all: build-linux build-darwin build-windows
@@ -105,7 +111,7 @@ test: test-server test-client test-kb-builder
 # Run server tests
 test-server:
 	@echo "Running server tests..."
-	$(GO) test -v ./internal/mcp/... ./internal/auth/... ./internal/config/... ./internal/crypto/... ./internal/database/... ./internal/resources/... ./internal/tools/... ./internal/tracing/... ./$(SERVER_CMD_DIR)/...
+	$(GO) test -v ./internal/mcp/... ./internal/auth/... ./internal/config/... ./internal/crypto/... ./internal/database/... ./internal/openapi/... ./internal/resources/... ./internal/tools/... ./internal/tracing/... ./$(SERVER_CMD_DIR)/...
 
 # Run client tests
 test-client:
@@ -239,6 +245,9 @@ help:
 	@echo ""
 	@echo "Knowledgebase:"
 	@echo "  make kb             - Build/update the knowledgebase database in bin/"
+	@echo ""
+	@echo "OpenAPI:"
+	@echo "  make openapi        - Regenerate docs/api/openapi.json from source"
 	@echo ""
 	@echo "Other:"
 	@echo "  make run            - Run server with environment from .env file"

--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -32,6 +32,7 @@ import (
 	"pgedge-postgres-mcp/internal/definitions"
 	"pgedge-postgres-mcp/internal/llmproxy"
 	"pgedge-postgres-mcp/internal/mcp"
+	"pgedge-postgres-mcp/internal/openapi"
 	"pgedge-postgres-mcp/internal/prompts"
 	"pgedge-postgres-mcp/internal/resources"
 	"pgedge-postgres-mcp/internal/tools"
@@ -65,6 +66,7 @@ func main() {
 	debug := flag.Bool("debug", false, "Enable debug logging (logs HTTP requests/responses)")
 	traceFile := flag.String("trace-file", "", "Path to trace output file (JSONL format)")
 	tokenFilePath := flag.String("token-file", "", "Path to API token file")
+	showOpenAPI := flag.Bool("openapi", false, "Output OpenAPI specification as JSON and exit")
 
 	// Database connection flags
 	dbHost := flag.String("db-host", "", "Database host")
@@ -100,6 +102,18 @@ func main() {
 	if flag.NArg() > 0 {
 		fmt.Fprintf(os.Stderr, "Error: unexpected arguments: %s\nRun with -help for usage information.\n", strings.Join(flag.Args(), " "))
 		os.Exit(1)
+	}
+
+	// Handle -openapi flag: output specification and exit
+	if *showOpenAPI {
+		spec := openapi.BuildSpec()
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(spec); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Failed to encode OpenAPI spec: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	// Handle token management commands
@@ -876,6 +890,19 @@ func main() {
 			dbHandler := api.NewDatabaseHandler(clientManager, accessChecker, false, authEnabled)
 			mux.HandleFunc("/api/databases", authWrapper(dbHandler.HandleListDatabases))
 			mux.HandleFunc("/api/databases/select", authWrapper(dbHandler.HandleSelectDatabase))
+
+			// OpenAPI specification endpoint (no auth required)
+			mux.HandleFunc("/api/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+					return
+				}
+				spec := openapi.BuildSpec()
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Cache-Control", "public, max-age=3600")
+				//nolint:errcheck // Encoding a map should not fail
+				json.NewEncoder(w).Encode(spec)
+			})
 
 			// Conversation history endpoints (only if store is available)
 			if convStore != nil && userStore != nil {

--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -869,15 +869,15 @@ func main() {
 					Temperature:      cfg.LLM.Temperature,
 				}
 
-				// Provider/model listing don't require auth (needed for login page)
+				// Provider/model listing requires auth when enabled
 				mux.HandleFunc("/api/llm/providers",
-					func(w http.ResponseWriter, r *http.Request) {
+					authWrapper(func(w http.ResponseWriter, r *http.Request) {
 						llmproxy.HandleProviders(w, r, llmConfig)
-					})
+					}))
 				mux.HandleFunc("/api/llm/models",
-					func(w http.ResponseWriter, r *http.Request) {
+					authWrapper(func(w http.ResponseWriter, r *http.Request) {
 						llmproxy.HandleModels(w, r, llmConfig)
-					})
+					}))
 				// Chat endpoint requires auth (makes actual LLM API calls)
 				mux.HandleFunc("/api/llm/chat",
 					authWrapper(func(w http.ResponseWriter, r *http.Request) {
@@ -891,17 +891,21 @@ func main() {
 			mux.HandleFunc("/api/databases", authWrapper(dbHandler.HandleListDatabases))
 			mux.HandleFunc("/api/databases/select", authWrapper(dbHandler.HandleSelectDatabase))
 
-			// OpenAPI specification endpoint (no auth required)
+			// OpenAPI specification endpoint (no auth required;
+			// bypassed in auth middleware via auth.OpenAPIPath)
+			specJSON, err := json.MarshalIndent(openapi.BuildSpec(), "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to build OpenAPI spec: %w", err)
+			}
 			mux.HandleFunc("/api/openapi.json", func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodGet {
 					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 					return
 				}
-				spec := openapi.BuildSpec()
 				w.Header().Set("Content-Type", "application/json")
 				w.Header().Set("Cache-Control", "public, max-age=3600")
-				//nolint:errcheck // Encoding a map should not fail
-				json.NewEncoder(w).Encode(spec)
+				//nolint:errcheck // Write error only occurs if client disconnects
+				w.Write(specJSON)
 			})
 
 			// Conversation history endpoints (only if store is available)

--- a/docs/api/browser.md
+++ b/docs/api/browser.md
@@ -33,4 +33,4 @@ hide:
 }
 </style>
 
-<redoc src="../openapi.json"/>
+<redoc src="openapi.json"/>

--- a/docs/api/browser.md
+++ b/docs/api/browser.md
@@ -1,0 +1,36 @@
+---
+hide:
+  - toc
+  - navigation
+---
+<style>
+.md-content__inner > h1:nth-child(1) {
+    display: none;
+}
+.md-main__inner {
+    height: 100%;
+    margin-top: 0;
+    padding-top: 0;
+    max-width: 61rem;
+}
+.md-content__inner {
+    margin: 0 auto;
+    padding-top: 0;
+}
+.md-content__inner::before {
+    height: 0;
+}
+.md-content__inner > p {
+    margin-top: 0;
+}
+.md-footer {
+    display: none;
+}
+.redoc-iframe {
+    height: calc(100vh - 60px) !important;
+    display: block;
+    border: none;
+}
+</style>
+
+<redoc src="../openapi.json"/>

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,1431 @@
+{
+  "components": {
+    "schemas": {
+      "ChatMessage": {
+        "description": "A single chat message with a role and content.",
+        "properties": {
+          "content": {
+            "description": "The text content of the message.",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of the message author (e.g., user, assistant, system).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "CompactRequest": {
+        "description": "Request to compact a chat message history.",
+        "properties": {
+          "keep_anchors": {
+            "default": true,
+            "description": "Whether to preserve anchor messages during compaction.",
+            "type": "boolean"
+          },
+          "max_tokens": {
+            "default": 100000,
+            "description": "The maximum token budget for the compacted output.",
+            "type": "integer"
+          },
+          "messages": {
+            "description": "The messages to compact.",
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array"
+          },
+          "options": {
+            "description": "Advanced compaction options.",
+            "properties": {
+              "enable_analytics": {
+                "description": "Enable analytics collection for compaction.",
+                "type": "boolean"
+              },
+              "enable_caching": {
+                "description": "Enable caching of compaction results.",
+                "type": "boolean"
+              },
+              "enable_llm_summarization": {
+                "description": "Enable LLM-based summarisation of dropped messages.",
+                "type": "boolean"
+              },
+              "enable_summarization": {
+                "description": "Enable rule-based summarisation of dropped messages.",
+                "type": "boolean"
+              },
+              "min_important_messages": {
+                "description": "Minimum number of important messages to retain.",
+                "type": "integer"
+              },
+              "preserve_schema_info": {
+                "description": "Keep messages containing schema information.",
+                "type": "boolean"
+              },
+              "preserve_tool_results": {
+                "description": "Keep messages containing tool results.",
+                "type": "boolean"
+              },
+              "token_counter_type": {
+                "description": "The token counting strategy to use.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "recent_window": {
+            "default": 10,
+            "description": "The number of recent messages to always preserve.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "messages"
+        ],
+        "type": "object"
+      },
+      "CompactResponse": {
+        "description": "Result of a chat compaction operation.",
+        "properties": {
+          "compaction_info": {
+            "description": "Statistics about the compaction operation.",
+            "properties": {
+              "anchor_count": {
+                "description": "Number of anchor messages preserved.",
+                "type": "integer"
+              },
+              "compacted_count": {
+                "description": "Number of messages after compaction.",
+                "type": "integer"
+              },
+              "compression_ratio": {
+                "description": "Ratio of output size to input size.",
+                "type": "number"
+              },
+              "dropped_count": {
+                "description": "Number of messages dropped during compaction.",
+                "type": "integer"
+              },
+              "original_count": {
+                "description": "Number of messages before compaction.",
+                "type": "integer"
+              },
+              "tokens_saved": {
+                "description": "Estimated tokens saved by compaction.",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "messages": {
+            "description": "The compacted messages.",
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "description": "A summary of the topics discussed in dropped messages.",
+            "properties": {
+              "description": {
+                "description": "A prose description of the conversation context.",
+                "type": "string"
+              },
+              "tables": {
+                "description": "Database tables referenced in the conversation.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "tools": {
+                "description": "Tools used during the conversation.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "topics": {
+                "description": "Topic keywords extracted from the conversation.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "token_estimate": {
+            "description": "Estimated token count of the compacted output.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "messages",
+          "summary",
+          "token_estimate",
+          "compaction_info"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "description": "A full conversation object including messages.",
+        "properties": {
+          "connection": {
+            "description": "The database connection name.",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "When the conversation was created.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique conversation identifier.",
+            "type": "string"
+          },
+          "messages": {
+            "description": "The conversation messages.",
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array"
+          },
+          "model": {
+            "description": "The LLM model used.",
+            "type": "string"
+          },
+          "provider": {
+            "description": "The LLM provider used.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The conversation title.",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "When the conversation was last updated.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "username": {
+            "description": "The username that owns the conversation.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "title",
+          "provider",
+          "model",
+          "connection",
+          "messages",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "ConversationSummary": {
+        "description": "A summary of a conversation for list views.",
+        "properties": {
+          "connection": {
+            "description": "The database connection name used in the conversation.",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "When the conversation was created.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique conversation identifier.",
+            "type": "string"
+          },
+          "preview": {
+            "description": "A short preview of the conversation content.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The conversation title.",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "When the conversation was last updated.",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "connection",
+          "created_at",
+          "updated_at",
+          "preview"
+        ],
+        "type": "object"
+      },
+      "CreateConversationRequest": {
+        "description": "Request to create or update a conversation.",
+        "properties": {
+          "connection": {
+            "description": "The database connection name.",
+            "type": "string"
+          },
+          "messages": {
+            "description": "The conversation messages.",
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array"
+          },
+          "model": {
+            "description": "The LLM model to use.",
+            "type": "string"
+          },
+          "provider": {
+            "description": "The LLM provider to use.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "model",
+          "connection",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "DatabaseInfo": {
+        "description": "Information about a configured database connection.",
+        "properties": {
+          "allow_writes": {
+            "description": "Whether write operations are permitted on this connection.",
+            "type": "boolean"
+          },
+          "database": {
+            "description": "The database name.",
+            "type": "string"
+          },
+          "host": {
+            "description": "The database server hostname.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The logical name of the database connection.",
+            "type": "string"
+          },
+          "port": {
+            "description": "The database server port.",
+            "type": "integer"
+          },
+          "sslmode": {
+            "description": "The SSL mode for the connection.",
+            "type": "string"
+          },
+          "user": {
+            "description": "The database user.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "host",
+          "port",
+          "database",
+          "user",
+          "sslmode",
+          "allow_writes"
+        ],
+        "type": "object"
+      },
+      "DeleteAllResponse": {
+        "description": "Response after deleting all conversations.",
+        "properties": {
+          "deleted": {
+            "description": "The number of conversations deleted.",
+            "type": "integer"
+          },
+          "success": {
+            "description": "Whether the operation succeeded.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success",
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "description": "A generic error response.",
+        "properties": {
+          "error": {
+            "description": "A human-readable error message.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "HealthResponse": {
+        "description": "Server health check response.",
+        "properties": {
+          "server": {
+            "description": "The server name.",
+            "example": "pgedge-postgres-mcp",
+            "type": "string"
+          },
+          "status": {
+            "description": "Health status indicator.",
+            "example": "ok",
+            "type": "string"
+          },
+          "version": {
+            "description": "The server version.",
+            "example": "1.0.0-beta3",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "server",
+          "version"
+        ],
+        "type": "object"
+      },
+      "JSONRPCRequest": {
+        "description": "A JSON-RPC 2.0 request object for the MCP protocol.",
+        "properties": {
+          "id": {
+            "description": "A unique request identifier. Can be a string or integer."
+          },
+          "jsonrpc": {
+            "description": "The JSON-RPC protocol version. Must be \"2.0\".",
+            "enum": [
+              "2.0"
+            ],
+            "type": "string"
+          },
+          "method": {
+            "description": "The MCP method to invoke.",
+            "enum": [
+              "initialize",
+              "tools/list",
+              "tools/call",
+              "resources/list",
+              "resources/read",
+              "prompts/list",
+              "prompts/get"
+            ],
+            "type": "string"
+          },
+          "params": {
+            "description": "Optional parameters for the method.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id",
+          "method"
+        ],
+        "type": "object"
+      },
+      "JSONRPCResponse": {
+        "description": "A JSON-RPC 2.0 response object.",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/RPCError",
+            "description": "Error information. Present on failure."
+          },
+          "id": {
+            "description": "The request identifier that this response corresponds to."
+          },
+          "jsonrpc": {
+            "description": "The JSON-RPC protocol version.",
+            "enum": [
+              "2.0"
+            ],
+            "type": "string"
+          },
+          "result": {
+            "description": "The result of the method invocation. Present on success."
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id"
+        ],
+        "type": "object"
+      },
+      "LLMChatRequest": {
+        "description": "Request to send a chat completion to an LLM provider.",
+        "properties": {
+          "debug": {
+            "default": false,
+            "description": "Whether to include debug information in the response.",
+            "type": "boolean"
+          },
+          "messages": {
+            "description": "The conversation messages to send.",
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array"
+          },
+          "model": {
+            "description": "The model to use for completion.",
+            "type": "string"
+          },
+          "provider": {
+            "description": "The LLM provider to use.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "Optional tool definitions for function calling.",
+            "items": {
+              "description": "A tool definition.",
+              "properties": {
+                "description": {
+                  "description": "A description of what the tool does.",
+                  "type": "string"
+                },
+                "inputSchema": {
+                  "description": "JSON Schema describing the tool's input parameters.",
+                  "type": "object"
+                },
+                "name": {
+                  "description": "The tool name.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "description",
+                "inputSchema"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "messages",
+          "provider",
+          "model"
+        ],
+        "type": "object"
+      },
+      "LLMChatResponse": {
+        "description": "Response from an LLM chat completion request.",
+        "properties": {
+          "content": {
+            "description": "The response content blocks.",
+            "items": {
+              "description": "A content block from the LLM response.",
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "stop_reason": {
+            "description": "The reason the model stopped generating.",
+            "type": "string"
+          },
+          "token_usage": {
+            "description": "Token usage statistics for the request.",
+            "properties": {
+              "input_tokens": {
+                "description": "Number of input tokens consumed.",
+                "type": "integer"
+              },
+              "output_tokens": {
+                "description": "Number of output tokens generated.",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "content",
+          "stop_reason",
+          "token_usage"
+        ],
+        "type": "object"
+      },
+      "ListDatabasesResponse": {
+        "description": "Response containing the list of databases and the currently selected database.",
+        "properties": {
+          "current": {
+            "description": "The name of the currently selected database.",
+            "type": "string"
+          },
+          "databases": {
+            "description": "The available database connections.",
+            "items": {
+              "$ref": "#/components/schemas/DatabaseInfo"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "databases",
+          "current"
+        ],
+        "type": "object"
+      },
+      "ModelInfo": {
+        "description": "Information about an LLM model.",
+        "properties": {
+          "description": {
+            "description": "A short description of the model.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The model identifier.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object"
+      },
+      "ModelsResponse": {
+        "description": "Response listing models for an LLM provider.",
+        "properties": {
+          "models": {
+            "description": "The available models.",
+            "items": {
+              "$ref": "#/components/schemas/ModelInfo"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "models"
+        ],
+        "type": "object"
+      },
+      "ProviderInfo": {
+        "description": "Information about an LLM provider.",
+        "properties": {
+          "display": {
+            "description": "A human-readable display name for the provider.",
+            "type": "string"
+          },
+          "isDefault": {
+            "description": "Whether this provider is the default.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The provider identifier.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "display",
+          "isDefault"
+        ],
+        "type": "object"
+      },
+      "ProvidersResponse": {
+        "description": "Response listing available LLM providers.",
+        "properties": {
+          "defaultModel": {
+            "description": "The name of the default model.",
+            "type": "string"
+          },
+          "providers": {
+            "description": "The available LLM providers.",
+            "items": {
+              "$ref": "#/components/schemas/ProviderInfo"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "providers",
+          "defaultModel"
+        ],
+        "type": "object"
+      },
+      "RPCError": {
+        "description": "A JSON-RPC 2.0 error object.",
+        "properties": {
+          "code": {
+            "description": "A numeric error code.",
+            "type": "integer"
+          },
+          "data": {
+            "description": "Additional error data."
+          },
+          "message": {
+            "description": "A short description of the error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "RenameConversationRequest": {
+        "description": "Request to rename a conversation.",
+        "properties": {
+          "title": {
+            "description": "The new title for the conversation.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "SelectDatabaseRequest": {
+        "description": "Request to select a database by name.",
+        "properties": {
+          "name": {
+            "description": "The name of the database to select.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SelectDatabaseResponse": {
+        "description": "Response after selecting a database.",
+        "properties": {
+          "current": {
+            "description": "The name of the now-current database.",
+            "type": "string"
+          },
+          "error": {
+            "description": "An error message if the operation failed.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable status message.",
+            "type": "string"
+          },
+          "success": {
+            "description": "Whether the database was selected successfully.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success",
+          "current",
+          "message"
+        ],
+        "type": "object"
+      },
+      "SuccessResponse": {
+        "description": "A generic success response.",
+        "properties": {
+          "success": {
+            "description": "Whether the operation succeeded.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ],
+        "type": "object"
+      },
+      "UserInfoResponse": {
+        "description": "User authentication and identity information.",
+        "properties": {
+          "authenticated": {
+            "description": "Whether the user is authenticated.",
+            "type": "boolean"
+          },
+          "error": {
+            "description": "An error message if user lookup failed.",
+            "type": "string"
+          },
+          "username": {
+            "description": "The username of the authenticated user. Absent when not authenticated.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "authenticated"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "bearerFormat": "token",
+        "description": "Bearer token authentication. Required when auth is enabled on the server.",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "name": "pgEdge",
+      "url": "https://www.pgedge.com"
+    },
+    "description": "REST API for the pgEdge Postgres MCP Server, providing database management, MCP protocol access, LLM proxy, chat compaction, and conversation management.",
+    "license": {
+      "name": "PostgreSQL License"
+    },
+    "title": "pgEdge Postgres MCP Server API",
+    "version": "1.0.0-beta3"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/chat/compact": {
+      "post": {
+        "description": "Compacts a conversation's message history by removing or summarising older messages while preserving important context such as anchors and tool results.",
+        "operationId": "compactChat",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompactRequest"
+              }
+            }
+          },
+          "description": "The messages to compact along with compaction options.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompactResponse"
+                }
+              }
+            },
+            "description": "Compacted message history."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Compact a chat message history",
+        "tags": [
+          "Chat"
+        ]
+      }
+    },
+    "/api/conversations": {
+      "delete": {
+        "description": "Deletes all conversations for the authenticated user. Requires the query parameter all=true.",
+        "operationId": "deleteAllConversations",
+        "parameters": [
+          {
+            "description": "Must be set to true to confirm deletion of all conversations.",
+            "in": "query",
+            "name": "all",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteAllResponse"
+                }
+              }
+            },
+            "description": "All conversations deleted."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Delete all conversations",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "get": {
+        "description": "Returns a paginated list of conversations for the authenticated user.",
+        "operationId": "listConversations",
+        "parameters": [
+          {
+            "description": "Maximum number of conversations to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of conversations to skip.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "conversations": {
+                      "description": "The list of conversation summaries.",
+                      "items": {
+                        "$ref": "#/components/schemas/ConversationSummary"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "A paginated list of conversations."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List conversations",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "post": {
+        "description": "Creates a new conversation with the specified provider, model, connection, and initial messages.",
+        "operationId": "createConversation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateConversationRequest"
+              }
+            }
+          },
+          "description": "The conversation to create.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
+              }
+            },
+            "description": "Conversation created successfully."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Create a conversation",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/api/conversations/{id}": {
+      "delete": {
+        "description": "Deletes a single conversation by identifier.",
+        "operationId": "deleteConversation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            },
+            "description": "Conversation deleted successfully."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Delete a conversation",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "get": {
+        "description": "Returns a single conversation including its full message history.",
+        "operationId": "getConversation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
+              }
+            },
+            "description": "The requested conversation."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get a conversation",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "parameters": [
+        {
+          "description": "The conversation identifier.",
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "patch": {
+        "description": "Updates the title of an existing conversation.",
+        "operationId": "renameConversation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameConversationRequest"
+              }
+            }
+          },
+          "description": "The new conversation title.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            },
+            "description": "Conversation renamed successfully."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Rename a conversation",
+        "tags": [
+          "Conversations"
+        ]
+      },
+      "put": {
+        "description": "Replaces the provider, model, connection, and messages of an existing conversation.",
+        "operationId": "updateConversation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateConversationRequest"
+              }
+            }
+          },
+          "description": "The updated conversation data.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
+              }
+            },
+            "description": "Conversation updated successfully."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Update a conversation",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/api/databases": {
+      "get": {
+        "description": "Returns the list of configured database connections and the currently selected database.",
+        "operationId": "listDatabases",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDatabasesResponse"
+                }
+              }
+            },
+            "description": "A list of available databases."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List available databases",
+        "tags": [
+          "Databases"
+        ]
+      }
+    },
+    "/api/databases/select": {
+      "post": {
+        "description": "Switches the active database connection to the specified database name.",
+        "operationId": "selectDatabase",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SelectDatabaseRequest"
+              }
+            }
+          },
+          "description": "The name of the database to select.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SelectDatabaseResponse"
+                }
+              }
+            },
+            "description": "Database selected successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request body."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Access to the requested database is forbidden."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Database not found."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Select a database",
+        "tags": [
+          "Databases"
+        ]
+      }
+    },
+    "/api/llm/chat": {
+      "post": {
+        "description": "Proxies a chat completion request to the specified LLM provider and model. Supports tool definitions for function calling.",
+        "operationId": "llmChat",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMChatRequest"
+              }
+            }
+          },
+          "description": "The chat request including messages, optional tools, and LLM provider details.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMChatResponse"
+                }
+              }
+            },
+            "description": "LLM chat completion response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Send a chat request to an LLM",
+        "tags": [
+          "LLM Proxy"
+        ]
+      }
+    },
+    "/api/llm/models": {
+      "get": {
+        "description": "Returns the models available for the specified LLM provider. No authentication is required.",
+        "operationId": "listLLMModels",
+        "parameters": [
+          {
+            "description": "The LLM provider name.",
+            "in": "query",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsResponse"
+                }
+              }
+            },
+            "description": "Available models for the provider."
+          }
+        },
+        "summary": "List models for a provider",
+        "tags": [
+          "LLM Proxy"
+        ]
+      }
+    },
+    "/api/llm/providers": {
+      "get": {
+        "description": "Returns the available LLM providers and the default model. No authentication is required because this endpoint is used by the login page.",
+        "operationId": "listLLMProviders",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvidersResponse"
+                }
+              }
+            },
+            "description": "Available LLM providers."
+          }
+        },
+        "summary": "List LLM providers",
+        "tags": [
+          "LLM Proxy"
+        ]
+      }
+    },
+    "/api/openapi.json": {
+      "get": {
+        "description": "Returns this OpenAPI 3.0.3 specification as a JSON document. No authentication is required.",
+        "operationId": "getOpenAPISpec",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "An OpenAPI 3.0.3 specification document.",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The OpenAPI specification."
+          }
+        },
+        "summary": "Get the OpenAPI specification",
+        "tags": [
+          "OpenAPI"
+        ]
+      }
+    },
+    "/api/user/info": {
+      "get": {
+        "description": "Returns authentication status and username. When no bearer token is provided the response indicates an unauthenticated session.",
+        "operationId": "getUserInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserInfoResponse"
+                }
+              }
+            },
+            "description": "User information."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get current user information",
+        "tags": [
+          "User"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Returns the current health status, server name, and version. No authentication is required.",
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            },
+            "description": "Server is healthy."
+          }
+        },
+        "summary": "Check server health",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/mcp/v1": {
+      "post": {
+        "description": "Accepts a JSON-RPC 2.0 request implementing the Model Context Protocol. Supported methods include initialize, tools/list, tools/call, resources/list, resources/read, prompts/list, and prompts/get. Bearer token authentication is required when auth is enabled.",
+        "operationId": "postMCP",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSONRPCRequest"
+              }
+            }
+          },
+          "description": "A JSON-RPC 2.0 request object.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JSONRPCResponse"
+                }
+              }
+            },
+            "description": "JSON-RPC 2.0 response."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Send an MCP JSON-RPC 2.0 request",
+        "tags": [
+          "MCP"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Server health check endpoints.",
+      "name": "Health"
+    },
+    {
+      "description": "Model Context Protocol (JSON-RPC 2.0) endpoints.",
+      "name": "MCP"
+    },
+    {
+      "description": "Database listing and selection endpoints.",
+      "name": "Databases"
+    },
+    {
+      "description": "User information endpoints.",
+      "name": "User"
+    },
+    {
+      "description": "Chat compaction endpoints.",
+      "name": "Chat"
+    },
+    {
+      "description": "LLM provider and chat proxy endpoints.",
+      "name": "LLM Proxy"
+    },
+    {
+      "description": "Conversation management endpoints.",
+      "name": "Conversations"
+    },
+    {
+      "description": "OpenAPI specification endpoint.",
+      "name": "OpenAPI"
+    }
+  ]
+}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -443,7 +443,11 @@
         "description": "A JSON-RPC 2.0 response object.",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/RPCError",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RPCError"
+              }
+            ],
             "description": "Error information. Present on failure."
           },
           "id": {
@@ -794,7 +798,7 @@
   "paths": {
     "/api/chat/compact": {
       "post": {
-        "description": "Compacts a conversation's message history by removing or summarising older messages while preserving important context such as anchors and tool results.",
+        "description": "Compacts a conversation's message history by removing or summarizing older messages while preserving important context such as anchors and tool results.",
         "operationId": "compactChat",
         "requestBody": {
           "content": {
@@ -817,6 +821,26 @@
               }
             },
             "description": "Compacted message history."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -855,6 +879,26 @@
               }
             },
             "description": "All conversations deleted."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -911,6 +955,26 @@
               }
             },
             "description": "A paginated list of conversations."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -947,6 +1011,26 @@
               }
             },
             "description": "Conversation created successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -974,6 +1058,26 @@
               }
             },
             "description": "Conversation deleted successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -999,6 +1103,26 @@
               }
             },
             "description": "The requested conversation."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -1046,6 +1170,26 @@
               }
             },
             "description": "Conversation renamed successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -1082,6 +1226,26 @@
               }
             },
             "description": "Conversation updated successfully."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -1109,6 +1273,26 @@
               }
             },
             "description": "A list of available databases."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -1158,6 +1342,16 @@
             },
             "description": "Invalid request body."
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
           "403": {
             "content": {
               "application/json": {
@@ -1166,7 +1360,7 @@
                 }
               }
             },
-            "description": "Access to the requested database is forbidden."
+            "description": "Insufficient permissions."
           },
           "404": {
             "content": {
@@ -1215,6 +1409,26 @@
               }
             },
             "description": "LLM chat completion response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [
@@ -1230,7 +1444,7 @@
     },
     "/api/llm/models": {
       "get": {
-        "description": "Returns the models available for the specified LLM provider. No authentication is required.",
+        "description": "Returns the models available for the specified LLM provider.",
         "operationId": "listLLMModels",
         "parameters": [
           {
@@ -1253,8 +1467,33 @@
               }
             },
             "description": "Available models for the provider."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "summary": "List models for a provider",
         "tags": [
           "LLM Proxy"
@@ -1263,7 +1502,7 @@
     },
     "/api/llm/providers": {
       "get": {
-        "description": "Returns the available LLM providers and the default model. No authentication is required because this endpoint is used by the login page.",
+        "description": "Returns the available LLM providers and the default model.",
         "operationId": "listLLMProviders",
         "responses": {
           "200": {
@@ -1275,8 +1514,33 @@
               }
             },
             "description": "Available LLM providers."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "summary": "List LLM providers",
         "tags": [
           "LLM Proxy"
@@ -1308,7 +1572,7 @@
     },
     "/api/user/info": {
       "get": {
-        "description": "Returns authentication status and username. When no bearer token is provided the response indicates an unauthenticated session.",
+        "description": "Returns authentication status and username. When no bearer token is provided the response indicates an unauthenticated session. This endpoint does not require authentication.",
         "operationId": "getUserInfo",
         "responses": {
           "200": {
@@ -1322,11 +1586,6 @@
             "description": "User information."
           }
         },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
         "summary": "Get current user information",
         "tags": [
           "User"
@@ -1380,6 +1639,26 @@
               }
             },
             "description": "JSON-RPC 2.0 response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
           }
         },
         "security": [

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,15 @@ and this project adheres to
 
 ### Added
 
+- OpenAPI 3.0.3 specification and interactive API browser. The
+  server now provides a programmatic OpenAPI specification covering
+  all REST endpoints. The specification is available at the
+  `/api/openapi.json` endpoint, through the `-openapi` CLI flag,
+  and as a static file in the documentation. The MkDocs site
+  includes a ReDoc-powered interactive API browser under For
+  Developers. All JSON responses include an RFC 8631 `Link` header
+  for automatic API discovery by tools such as `restish`.
+
 - Write query confirmation in the CLI and Web UI. When a database
   has write access enabled, the user is prompted to confirm DDL and
   DML queries before the server executes the queries. Declining a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,11 +14,13 @@ and this project adheres to
 - OpenAPI 3.0.3 specification and interactive API browser. The
   server now provides a programmatic OpenAPI specification covering
   all REST endpoints. The specification is available at the
-  `/api/openapi.json` endpoint, through the `-openapi` CLI flag,
-  and as a static file in the documentation. The MkDocs site
-  includes a ReDoc-powered interactive API browser under For
-  Developers. All JSON responses include an RFC 8631 `Link` header
-  for automatic API discovery by tools such as `restish`.
+  `/api/openapi.json` endpoint (no authentication required),
+  through the `-openapi` CLI flag, and as a static file in the
+  documentation. Use `make openapi` to regenerate the static
+  copy. The MkDocs site includes a ReDoc-powered interactive API
+  browser under For Developers. API responses include an RFC 8631
+  `Link` header for automatic discovery by tools such as
+  `restish`.
 
 - Write query confirmation in the CLI and Web UI. When a database
   has write access enabled, the user is prompted to confirm DDL and

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -40,6 +40,9 @@ const (
 
 	// UserInfoPath is the path for the user info endpoint (bypasses auth to return auth status)
 	UserInfoPath = "/api/user/info"
+
+	// OpenAPIPath is the path for the OpenAPI specification endpoint (public for API discoverability)
+	OpenAPIPath = "/api/openapi.json"
 )
 
 // GetTokenHashFromContext retrieves the token hash from the request context
@@ -131,7 +134,7 @@ func AuthMiddleware(tokenStore *TokenStore, userStore *UserStore, enabled bool) 
 
 			// Skip authentication for public endpoints (needed before login)
 			switch r.URL.Path {
-			case HealthCheckPath, UserInfoPath:
+			case HealthCheckPath, UserInfoPath, OpenAPIPath:
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -74,6 +74,33 @@ func TestAuthMiddleware_HealthCheck(t *testing.T) {
 	}
 }
 
+// TestAuthMiddleware_OpenAPIBypass tests that OpenAPI spec endpoint bypasses auth
+func TestAuthMiddleware_OpenAPIBypass(t *testing.T) {
+	tokenStore := &TokenStore{
+		Tokens: make(map[string]*Token),
+	}
+
+	middleware := AuthMiddleware(tokenStore, nil, true)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("openapi spec"))
+	}))
+
+	req := httptest.NewRequest("GET", OpenAPIPath, nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status OK for OpenAPI endpoint, got %d", rr.Code)
+	}
+
+	if body := rr.Body.String(); body != "openapi spec" {
+		t.Errorf("Expected 'openapi spec', got %q", body)
+	}
+}
+
 // TestAuthMiddleware_MissingAuthHeader tests rejection of requests without Authorization header
 func TestAuthMiddleware_MissingAuthHeader(t *testing.T) {
 	tokenStore := &TokenStore{

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -129,12 +129,15 @@ func (s *Server) loadTLSConfig(config *HTTPConfig) (*tls.Config, error) {
 
 // securityHeadersMiddleware adds standard HTTP security headers to all
 // responses to mitigate clickjacking, MIME-type confusion, and XSS.
+// It also adds the RFC 8631 Link header for API discoverability.
 func securityHeadersMiddleware(tlsEnabled bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.Header().Set("X-Frame-Options", "DENY")
 			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			w.Header().Set("Link",
+				`</api/openapi.json>; rel="service-desc"`)
 			if tlsEnabled {
 				w.Header().Set("Strict-Transport-Security",
 					"max-age=63072000; includeSubDomains")

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"pgedge-postgres-mcp/internal/auth"
@@ -129,15 +130,18 @@ func (s *Server) loadTLSConfig(config *HTTPConfig) (*tls.Config, error) {
 
 // securityHeadersMiddleware adds standard HTTP security headers to all
 // responses to mitigate clickjacking, MIME-type confusion, and XSS.
-// It also adds the RFC 8631 Link header for API discoverability.
+// It also adds the RFC 8631 Link header on /api/* paths for API
+// discoverability.
 func securityHeadersMiddleware(tlsEnabled bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.Header().Set("X-Frame-Options", "DENY")
 			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-			w.Header().Set("Link",
-				`</api/openapi.json>; rel="service-desc"`)
+			if strings.HasPrefix(r.URL.Path, "/api/") {
+				w.Header().Set("Link",
+					`</api/openapi.json>; rel="service-desc"`)
+			}
 			if tlsEnabled {
 				w.Header().Set("Strict-Transport-Security",
 					"max-age=63072000; includeSubDomains")

--- a/internal/mcp/http_server_test.go
+++ b/internal/mcp/http_server_test.go
@@ -933,7 +933,8 @@ func TestSecurityHeadersMiddleware_LinkHeader(t *testing.T) {
 
 	wrapped := securityHeadersMiddleware(false)(handler)
 
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	// Link header should be present on /api/* paths
+	req := httptest.NewRequest(http.MethodGet, "/api/databases", nil)
 	w := httptest.NewRecorder()
 
 	wrapped.ServeHTTP(w, req)
@@ -941,10 +942,20 @@ func TestSecurityHeadersMiddleware_LinkHeader(t *testing.T) {
 	link := w.Header().Get("Link")
 	expected := `</api/openapi.json>; rel="service-desc"`
 	if link != expected {
-		t.Errorf("expected Link header %q, got %q", expected, link)
+		t.Errorf("expected Link header %q on /api/ path, got %q", expected, link)
 	}
 
-	// Verify other security headers are still present
+	// Link header should NOT be present on non-API paths
+	req = httptest.NewRequest(http.MethodGet, "/health", nil)
+	w = httptest.NewRecorder()
+
+	wrapped.ServeHTTP(w, req)
+
+	if link := w.Header().Get("Link"); link != "" {
+		t.Errorf("expected no Link header on /health, got %q", link)
+	}
+
+	// Verify other security headers are still present on all paths
 	if w.Header().Get("X-Content-Type-Options") != "nosniff" {
 		t.Error("missing X-Content-Type-Options header")
 	}

--- a/internal/mcp/http_server_test.go
+++ b/internal/mcp/http_server_test.go
@@ -926,6 +926,33 @@ func TestHTTPConfigStruct(t *testing.T) {
 	}
 }
 
+func TestSecurityHeadersMiddleware_LinkHeader(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := securityHeadersMiddleware(false)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(w, req)
+
+	link := w.Header().Get("Link")
+	expected := `</api/openapi.json>; rel="service-desc"`
+	if link != expected {
+		t.Errorf("expected Link header %q, got %q", expected, link)
+	}
+
+	// Verify other security headers are still present
+	if w.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Error("missing X-Content-Type-Options header")
+	}
+	if w.Header().Get("X-Frame-Options") != "DENY" {
+		t.Error("missing X-Frame-Options header")
+	}
+}
+
 func TestRunHTTP_NilConfig(t *testing.T) {
 	tools := &mockToolProvider{}
 	server := NewServer(tools)

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -1,0 +1,1279 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Package openapi provides a programmatic OpenAPI 3.0.3 specification
+// builder for the pgEdge Postgres MCP Server REST API.
+package openapi
+
+import (
+	"pgedge-postgres-mcp/internal/mcp"
+)
+
+// M is a shorthand alias for building nested map structures.
+type M = map[string]interface{}
+
+// A is a shorthand alias for building slices in the spec.
+type A = []interface{}
+
+// BuildSpec returns the complete OpenAPI 3.0.3 specification as a
+// map that can be serialised to JSON with encoding/json.
+func BuildSpec() map[string]interface{} {
+	return M{
+		"openapi": "3.0.3",
+		"info":    buildInfo(),
+		"paths":   buildPaths(),
+		"components": M{
+			"securitySchemes": buildSecuritySchemes(),
+			"schemas":         buildSchemas(),
+		},
+		"tags": buildTags(),
+	}
+}
+
+// buildInfo returns the info object for the specification.
+func buildInfo() M {
+	return M{
+		"title":       "pgEdge Postgres MCP Server API",
+		"description": "REST API for the pgEdge Postgres MCP Server, providing database management, MCP protocol access, LLM proxy, chat compaction, and conversation management.",
+		"version":     mcp.ServerVersion,
+		"license": M{
+			"name": "PostgreSQL License",
+		},
+		"contact": M{
+			"name": "pgEdge",
+			"url":  "https://www.pgedge.com",
+		},
+	}
+}
+
+// buildTags returns the tag definitions used to group endpoints.
+func buildTags() A {
+	return A{
+		M{"name": "Health", "description": "Server health check endpoints."},
+		M{"name": "MCP", "description": "Model Context Protocol (JSON-RPC 2.0) endpoints."},
+		M{"name": "Databases", "description": "Database listing and selection endpoints."},
+		M{"name": "User", "description": "User information endpoints."},
+		M{"name": "Chat", "description": "Chat compaction endpoints."},
+		M{"name": "LLM Proxy", "description": "LLM provider and chat proxy endpoints."},
+		M{"name": "Conversations", "description": "Conversation management endpoints."},
+		M{"name": "OpenAPI", "description": "OpenAPI specification endpoint."},
+	}
+}
+
+// buildSecuritySchemes returns the security scheme definitions.
+func buildSecuritySchemes() M {
+	return M{
+		"BearerAuth": M{
+			"type":         "http",
+			"scheme":       "bearer",
+			"description":  "Bearer token authentication. Required when auth is enabled on the server.",
+			"bearerFormat": "token",
+		},
+	}
+}
+
+// bearerSecurity returns the security requirement for bearer auth.
+func bearerSecurity() A {
+	return A{M{"BearerAuth": A{}}}
+}
+
+// ref returns a JSON reference object pointing to a component schema.
+func ref(name string) M {
+	return M{"$ref": "#/components/schemas/" + name}
+}
+
+// jsonContent wraps a schema reference in an application/json content
+// block suitable for request or response bodies.
+func jsonContent(schemaRef M) M {
+	return M{
+		"application/json": M{
+			"schema": schemaRef,
+		},
+	}
+}
+
+// buildPaths returns every path item in the specification.
+func buildPaths() M {
+	return M{
+		"/health":                 buildHealthPath(),
+		"/mcp/v1":                 buildMCPPath(),
+		"/api/databases":          buildDatabasesPath(),
+		"/api/databases/select":   buildDatabasesSelectPath(),
+		"/api/user/info":          buildUserInfoPath(),
+		"/api/chat/compact":       buildChatCompactPath(),
+		"/api/llm/providers":      buildLLMProvidersPath(),
+		"/api/llm/models":         buildLLMModelsPath(),
+		"/api/llm/chat":           buildLLMChatPath(),
+		"/api/conversations":      buildConversationsPath(),
+		"/api/conversations/{id}": buildConversationByIDPath(),
+		"/api/openapi.json":       buildOpenAPISpecPath(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Path builders
+// ---------------------------------------------------------------------------
+
+func buildHealthPath() M {
+	return M{
+		"get": M{
+			"tags":        A{"Health"},
+			"summary":     "Check server health",
+			"description": "Returns the current health status, server name, and version. No authentication is required.",
+			"operationId": "getHealth",
+			"responses": M{
+				"200": M{
+					"description": "Server is healthy.",
+					"content":     jsonContent(ref("HealthResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildMCPPath() M {
+	return M{
+		"post": M{
+			"tags":        A{"MCP"},
+			"summary":     "Send an MCP JSON-RPC 2.0 request",
+			"description": "Accepts a JSON-RPC 2.0 request implementing the Model Context Protocol. Supported methods include initialize, tools/list, tools/call, resources/list, resources/read, prompts/list, and prompts/get. Bearer token authentication is required when auth is enabled.",
+			"operationId": "postMCP",
+			"security":    bearerSecurity(),
+			"requestBody": M{
+				"required":    true,
+				"description": "A JSON-RPC 2.0 request object.",
+				"content":     jsonContent(ref("JSONRPCRequest")),
+			},
+			"responses": M{
+				"200": M{
+					"description": "JSON-RPC 2.0 response.",
+					"content":     jsonContent(ref("JSONRPCResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildDatabasesPath() M {
+	return M{
+		"get": M{
+			"tags":        A{"Databases"},
+			"summary":     "List available databases",
+			"description": "Returns the list of configured database connections and the currently selected database.",
+			"operationId": "listDatabases",
+			"security":    bearerSecurity(),
+			"responses": M{
+				"200": M{
+					"description": "A list of available databases.",
+					"content":     jsonContent(ref("ListDatabasesResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildDatabasesSelectPath() M {
+	return M{
+		"post": M{
+			"tags":        A{"Databases"},
+			"summary":     "Select a database",
+			"description": "Switches the active database connection to the specified database name.",
+			"operationId": "selectDatabase",
+			"security":    bearerSecurity(),
+			"requestBody": M{
+				"required":    true,
+				"description": "The name of the database to select.",
+				"content":     jsonContent(ref("SelectDatabaseRequest")),
+			},
+			"responses": M{
+				"200": M{
+					"description": "Database selected successfully.",
+					"content":     jsonContent(ref("SelectDatabaseResponse")),
+				},
+				"400": M{
+					"description": "Invalid request body.",
+					"content":     jsonContent(ref("ErrorResponse")),
+				},
+				"403": M{
+					"description": "Access to the requested database is forbidden.",
+					"content":     jsonContent(ref("ErrorResponse")),
+				},
+				"404": M{
+					"description": "Database not found.",
+					"content":     jsonContent(ref("ErrorResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildUserInfoPath() M {
+	return M{
+		"get": M{
+			"tags":        A{"User"},
+			"summary":     "Get current user information",
+			"description": "Returns authentication status and username. When no bearer token is provided the response indicates an unauthenticated session.",
+			"operationId": "getUserInfo",
+			"security":    bearerSecurity(),
+			"responses": M{
+				"200": M{
+					"description": "User information.",
+					"content":     jsonContent(ref("UserInfoResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildChatCompactPath() M {
+	return M{
+		"post": M{
+			"tags":        A{"Chat"},
+			"summary":     "Compact a chat message history",
+			"description": "Compacts a conversation's message history by removing or summarising older messages while preserving important context such as anchors and tool results.",
+			"operationId": "compactChat",
+			"security":    bearerSecurity(),
+			"requestBody": M{
+				"required":    true,
+				"description": "The messages to compact along with compaction options.",
+				"content":     jsonContent(ref("CompactRequest")),
+			},
+			"responses": M{
+				"200": M{
+					"description": "Compacted message history.",
+					"content":     jsonContent(ref("CompactResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildLLMProvidersPath() M {
+	return M{
+		"get": M{
+			"tags":        A{"LLM Proxy"},
+			"summary":     "List LLM providers",
+			"description": "Returns the available LLM providers and the default model. No authentication is required because this endpoint is used by the login page.",
+			"operationId": "listLLMProviders",
+			"responses": M{
+				"200": M{
+					"description": "Available LLM providers.",
+					"content":     jsonContent(ref("ProvidersResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildLLMModelsPath() M {
+	return M{
+		"get": M{
+			"tags":        A{"LLM Proxy"},
+			"summary":     "List models for a provider",
+			"description": "Returns the models available for the specified LLM provider. No authentication is required.",
+			"operationId": "listLLMModels",
+			"parameters": A{
+				M{
+					"name":        "provider",
+					"in":          "query",
+					"required":    true,
+					"description": "The LLM provider name.",
+					"schema": M{
+						"type": "string",
+					},
+				},
+			},
+			"responses": M{
+				"200": M{
+					"description": "Available models for the provider.",
+					"content":     jsonContent(ref("ModelsResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildLLMChatPath() M {
+	return M{
+		"post": M{
+			"tags":        A{"LLM Proxy"},
+			"summary":     "Send a chat request to an LLM",
+			"description": "Proxies a chat completion request to the specified LLM provider and model. Supports tool definitions for function calling.",
+			"operationId": "llmChat",
+			"security":    bearerSecurity(),
+			"requestBody": M{
+				"required":    true,
+				"description": "The chat request including messages, optional tools, and LLM provider details.",
+				"content":     jsonContent(ref("LLMChatRequest")),
+			},
+			"responses": M{
+				"200": M{
+					"description": "LLM chat completion response.",
+					"content":     jsonContent(ref("LLMChatResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildConversationsPath() M {
+	return M{
+		"get": M{
+			"tags":        A{"Conversations"},
+			"summary":     "List conversations",
+			"description": "Returns a paginated list of conversations for the authenticated user.",
+			"operationId": "listConversations",
+			"security":    bearerSecurity(),
+			"parameters": A{
+				M{
+					"name":        "limit",
+					"in":          "query",
+					"required":    false,
+					"description": "Maximum number of conversations to return.",
+					"schema": M{
+						"type":    "integer",
+						"default": 50,
+					},
+				},
+				M{
+					"name":        "offset",
+					"in":          "query",
+					"required":    false,
+					"description": "Number of conversations to skip.",
+					"schema": M{
+						"type":    "integer",
+						"default": 0,
+					},
+				},
+			},
+			"responses": M{
+				"200": M{
+					"description": "A paginated list of conversations.",
+					"content": jsonContent(M{
+						"type": "object",
+						"properties": M{
+							"conversations": M{
+								"type":        "array",
+								"description": "The list of conversation summaries.",
+								"items":       ref("ConversationSummary"),
+							},
+						},
+					}),
+				},
+			},
+		},
+		"post": M{
+			"tags":        A{"Conversations"},
+			"summary":     "Create a conversation",
+			"description": "Creates a new conversation with the specified provider, model, connection, and initial messages.",
+			"operationId": "createConversation",
+			"security":    bearerSecurity(),
+			"requestBody": M{
+				"required":    true,
+				"description": "The conversation to create.",
+				"content":     jsonContent(ref("CreateConversationRequest")),
+			},
+			"responses": M{
+				"201": M{
+					"description": "Conversation created successfully.",
+					"content":     jsonContent(ref("Conversation")),
+				},
+			},
+		},
+		"delete": M{
+			"tags":        A{"Conversations"},
+			"summary":     "Delete all conversations",
+			"description": "Deletes all conversations for the authenticated user. Requires the query parameter all=true.",
+			"operationId": "deleteAllConversations",
+			"security":    bearerSecurity(),
+			"parameters": A{
+				M{
+					"name":        "all",
+					"in":          "query",
+					"required":    true,
+					"description": "Must be set to true to confirm deletion of all conversations.",
+					"schema": M{
+						"type": "boolean",
+					},
+				},
+			},
+			"responses": M{
+				"200": M{
+					"description": "All conversations deleted.",
+					"content":     jsonContent(ref("DeleteAllResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildConversationByIDPath() M {
+	return M{
+		"parameters": A{
+			M{
+				"name":        "id",
+				"in":          "path",
+				"required":    true,
+				"description": "The conversation identifier.",
+				"schema": M{
+					"type": "string",
+				},
+			},
+		},
+		"get": M{
+			"tags":        A{"Conversations"},
+			"summary":     "Get a conversation",
+			"description": "Returns a single conversation including its full message history.",
+			"operationId": "getConversation",
+			"security":    bearerSecurity(),
+			"responses": M{
+				"200": M{
+					"description": "The requested conversation.",
+					"content":     jsonContent(ref("Conversation")),
+				},
+			},
+		},
+		"put": M{
+			"tags":        A{"Conversations"},
+			"summary":     "Update a conversation",
+			"description": "Replaces the provider, model, connection, and messages of an existing conversation.",
+			"operationId": "updateConversation",
+			"security":    bearerSecurity(),
+			"requestBody": M{
+				"required":    true,
+				"description": "The updated conversation data.",
+				"content":     jsonContent(ref("CreateConversationRequest")),
+			},
+			"responses": M{
+				"200": M{
+					"description": "Conversation updated successfully.",
+					"content":     jsonContent(ref("Conversation")),
+				},
+			},
+		},
+		"patch": M{
+			"tags":        A{"Conversations"},
+			"summary":     "Rename a conversation",
+			"description": "Updates the title of an existing conversation.",
+			"operationId": "renameConversation",
+			"security":    bearerSecurity(),
+			"requestBody": M{
+				"required":    true,
+				"description": "The new conversation title.",
+				"content":     jsonContent(ref("RenameConversationRequest")),
+			},
+			"responses": M{
+				"200": M{
+					"description": "Conversation renamed successfully.",
+					"content":     jsonContent(ref("SuccessResponse")),
+				},
+			},
+		},
+		"delete": M{
+			"tags":        A{"Conversations"},
+			"summary":     "Delete a conversation",
+			"description": "Deletes a single conversation by identifier.",
+			"operationId": "deleteConversation",
+			"security":    bearerSecurity(),
+			"responses": M{
+				"200": M{
+					"description": "Conversation deleted successfully.",
+					"content":     jsonContent(ref("SuccessResponse")),
+				},
+			},
+		},
+	}
+}
+
+func buildOpenAPISpecPath() M {
+	return M{
+		"get": M{
+			"tags":        A{"OpenAPI"},
+			"summary":     "Get the OpenAPI specification",
+			"description": "Returns this OpenAPI 3.0.3 specification as a JSON document. No authentication is required.",
+			"operationId": "getOpenAPISpec",
+			"responses": M{
+				"200": M{
+					"description": "The OpenAPI specification.",
+					"content": M{
+						"application/json": M{
+							"schema": M{
+								"type":        "object",
+								"description": "An OpenAPI 3.0.3 specification document.",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Component schemas
+// ---------------------------------------------------------------------------
+
+// buildSchemas returns all reusable schema definitions.
+func buildSchemas() M {
+	return M{
+		"ErrorResponse":             schemaErrorResponse(),
+		"HealthResponse":            schemaHealthResponse(),
+		"JSONRPCRequest":            schemaJSONRPCRequest(),
+		"JSONRPCResponse":           schemaJSONRPCResponse(),
+		"RPCError":                  schemaRPCError(),
+		"DatabaseInfo":              schemaDatabaseInfo(),
+		"ListDatabasesResponse":     schemaListDatabasesResponse(),
+		"SelectDatabaseRequest":     schemaSelectDatabaseRequest(),
+		"SelectDatabaseResponse":    schemaSelectDatabaseResponse(),
+		"UserInfoResponse":          schemaUserInfoResponse(),
+		"ChatMessage":               schemaChatMessage(),
+		"CompactRequest":            schemaCompactRequest(),
+		"CompactResponse":           schemaCompactResponse(),
+		"ProviderInfo":              schemaProviderInfo(),
+		"ProvidersResponse":         schemaProvidersResponse(),
+		"ModelInfo":                 schemaModelInfo(),
+		"ModelsResponse":            schemaModelsResponse(),
+		"LLMChatRequest":            schemaLLMChatRequest(),
+		"LLMChatResponse":           schemaLLMChatResponse(),
+		"ConversationSummary":       schemaConversationSummary(),
+		"Conversation":              schemaConversation(),
+		"CreateConversationRequest": schemaCreateConversationRequest(),
+		"RenameConversationRequest": schemaRenameConversationRequest(),
+		"SuccessResponse":           schemaSuccessResponse(),
+		"DeleteAllResponse":         schemaDeleteAllResponse(),
+	}
+}
+
+func schemaErrorResponse() M {
+	return M{
+		"type":        "object",
+		"description": "A generic error response.",
+		"properties": M{
+			"error": M{
+				"type":        "string",
+				"description": "A human-readable error message.",
+			},
+		},
+		"required": A{"error"},
+	}
+}
+
+func schemaHealthResponse() M {
+	return M{
+		"type":        "object",
+		"description": "Server health check response.",
+		"properties": M{
+			"status": M{
+				"type":        "string",
+				"description": "Health status indicator.",
+				"example":     "ok",
+			},
+			"server": M{
+				"type":        "string",
+				"description": "The server name.",
+				"example":     mcp.ServerName,
+			},
+			"version": M{
+				"type":        "string",
+				"description": "The server version.",
+				"example":     mcp.ServerVersion,
+			},
+		},
+		"required": A{"status", "server", "version"},
+	}
+}
+
+func schemaJSONRPCRequest() M {
+	return M{
+		"type":        "object",
+		"description": "A JSON-RPC 2.0 request object for the MCP protocol.",
+		"properties": M{
+			"jsonrpc": M{
+				"type":        "string",
+				"description": "The JSON-RPC protocol version. Must be \"2.0\".",
+				"enum":        A{"2.0"},
+			},
+			"id": M{
+				"description": "A unique request identifier. Can be a string or integer.",
+			},
+			"method": M{
+				"type":        "string",
+				"description": "The MCP method to invoke.",
+				"enum": A{
+					"initialize",
+					"tools/list",
+					"tools/call",
+					"resources/list",
+					"resources/read",
+					"prompts/list",
+					"prompts/get",
+				},
+			},
+			"params": M{
+				"type":        "object",
+				"description": "Optional parameters for the method.",
+			},
+		},
+		"required": A{"jsonrpc", "id", "method"},
+	}
+}
+
+func schemaJSONRPCResponse() M {
+	return M{
+		"type":        "object",
+		"description": "A JSON-RPC 2.0 response object.",
+		"properties": M{
+			"jsonrpc": M{
+				"type":        "string",
+				"description": "The JSON-RPC protocol version.",
+				"enum":        A{"2.0"},
+			},
+			"id": M{
+				"description": "The request identifier that this response corresponds to.",
+			},
+			"result": M{
+				"description": "The result of the method invocation. Present on success.",
+			},
+			"error": M{
+				"description": "Error information. Present on failure.",
+				"$ref":        "#/components/schemas/RPCError",
+			},
+		},
+		"required": A{"jsonrpc", "id"},
+	}
+}
+
+func schemaRPCError() M {
+	return M{
+		"type":        "object",
+		"description": "A JSON-RPC 2.0 error object.",
+		"properties": M{
+			"code": M{
+				"type":        "integer",
+				"description": "A numeric error code.",
+			},
+			"message": M{
+				"type":        "string",
+				"description": "A short description of the error.",
+			},
+			"data": M{
+				"description": "Additional error data.",
+			},
+		},
+		"required": A{"code", "message"},
+	}
+}
+
+func schemaDatabaseInfo() M {
+	return M{
+		"type":        "object",
+		"description": "Information about a configured database connection.",
+		"properties": M{
+			"name": M{
+				"type":        "string",
+				"description": "The logical name of the database connection.",
+			},
+			"host": M{
+				"type":        "string",
+				"description": "The database server hostname.",
+			},
+			"port": M{
+				"type":        "integer",
+				"description": "The database server port.",
+			},
+			"database": M{
+				"type":        "string",
+				"description": "The database name.",
+			},
+			"user": M{
+				"type":        "string",
+				"description": "The database user.",
+			},
+			"sslmode": M{
+				"type":        "string",
+				"description": "The SSL mode for the connection.",
+			},
+			"allow_writes": M{
+				"type":        "boolean",
+				"description": "Whether write operations are permitted on this connection.",
+			},
+		},
+		"required": A{
+			"name", "host", "port", "database",
+			"user", "sslmode", "allow_writes",
+		},
+	}
+}
+
+func schemaListDatabasesResponse() M {
+	return M{
+		"type":        "object",
+		"description": "Response containing the list of databases and the currently selected database.",
+		"properties": M{
+			"databases": M{
+				"type":        "array",
+				"description": "The available database connections.",
+				"items":       ref("DatabaseInfo"),
+			},
+			"current": M{
+				"type":        "string",
+				"description": "The name of the currently selected database.",
+			},
+		},
+		"required": A{"databases", "current"},
+	}
+}
+
+func schemaSelectDatabaseRequest() M {
+	return M{
+		"type":        "object",
+		"description": "Request to select a database by name.",
+		"properties": M{
+			"name": M{
+				"type":        "string",
+				"description": "The name of the database to select.",
+			},
+		},
+		"required": A{"name"},
+	}
+}
+
+func schemaSelectDatabaseResponse() M {
+	return M{
+		"type":        "object",
+		"description": "Response after selecting a database.",
+		"properties": M{
+			"success": M{
+				"type":        "boolean",
+				"description": "Whether the database was selected successfully.",
+			},
+			"current": M{
+				"type":        "string",
+				"description": "The name of the now-current database.",
+			},
+			"message": M{
+				"type":        "string",
+				"description": "A human-readable status message.",
+			},
+			"error": M{
+				"type":        "string",
+				"description": "An error message if the operation failed.",
+			},
+		},
+		"required": A{"success", "current", "message"},
+	}
+}
+
+func schemaUserInfoResponse() M {
+	return M{
+		"type":        "object",
+		"description": "User authentication and identity information.",
+		"properties": M{
+			"authenticated": M{
+				"type":        "boolean",
+				"description": "Whether the user is authenticated.",
+			},
+			"username": M{
+				"type":        "string",
+				"description": "The username of the authenticated user. Absent when not authenticated.",
+			},
+			"error": M{
+				"type":        "string",
+				"description": "An error message if user lookup failed.",
+			},
+		},
+		"required": A{"authenticated"},
+	}
+}
+
+func schemaChatMessage() M {
+	return M{
+		"type":        "object",
+		"description": "A single chat message with a role and content.",
+		"properties": M{
+			"role": M{
+				"type":        "string",
+				"description": "The role of the message author (e.g., user, assistant, system).",
+			},
+			"content": M{
+				"type":        "string",
+				"description": "The text content of the message.",
+			},
+		},
+		"required": A{"role", "content"},
+	}
+}
+
+func schemaCompactRequest() M {
+	return M{
+		"type":        "object",
+		"description": "Request to compact a chat message history.",
+		"properties": M{
+			"messages": M{
+				"type":        "array",
+				"description": "The messages to compact.",
+				"items":       ref("ChatMessage"),
+			},
+			"max_tokens": M{
+				"type":        "integer",
+				"description": "The maximum token budget for the compacted output.",
+				"default":     100000,
+			},
+			"recent_window": M{
+				"type":        "integer",
+				"description": "The number of recent messages to always preserve.",
+				"default":     10,
+			},
+			"keep_anchors": M{
+				"type":        "boolean",
+				"description": "Whether to preserve anchor messages during compaction.",
+				"default":     true,
+			},
+			"options": M{
+				"type":        "object",
+				"description": "Advanced compaction options.",
+				"properties": M{
+					"preserve_tool_results": M{
+						"type":        "boolean",
+						"description": "Keep messages containing tool results.",
+					},
+					"preserve_schema_info": M{
+						"type":        "boolean",
+						"description": "Keep messages containing schema information.",
+					},
+					"enable_summarization": M{
+						"type":        "boolean",
+						"description": "Enable rule-based summarisation of dropped messages.",
+					},
+					"min_important_messages": M{
+						"type":        "integer",
+						"description": "Minimum number of important messages to retain.",
+					},
+					"token_counter_type": M{
+						"type":        "string",
+						"description": "The token counting strategy to use.",
+					},
+					"enable_llm_summarization": M{
+						"type":        "boolean",
+						"description": "Enable LLM-based summarisation of dropped messages.",
+					},
+					"enable_caching": M{
+						"type":        "boolean",
+						"description": "Enable caching of compaction results.",
+					},
+					"enable_analytics": M{
+						"type":        "boolean",
+						"description": "Enable analytics collection for compaction.",
+					},
+				},
+			},
+		},
+		"required": A{"messages"},
+	}
+}
+
+func schemaCompactResponse() M {
+	return M{
+		"type":        "object",
+		"description": "Result of a chat compaction operation.",
+		"properties": M{
+			"messages": M{
+				"type":        "array",
+				"description": "The compacted messages.",
+				"items":       ref("ChatMessage"),
+			},
+			"summary": M{
+				"type":        "object",
+				"description": "A summary of the topics discussed in dropped messages.",
+				"properties": M{
+					"topics": M{
+						"type":        "array",
+						"description": "Topic keywords extracted from the conversation.",
+						"items":       M{"type": "string"},
+					},
+					"tables": M{
+						"type":        "array",
+						"description": "Database tables referenced in the conversation.",
+						"items":       M{"type": "string"},
+					},
+					"tools": M{
+						"type":        "array",
+						"description": "Tools used during the conversation.",
+						"items":       M{"type": "string"},
+					},
+					"description": M{
+						"type":        "string",
+						"description": "A prose description of the conversation context.",
+					},
+				},
+			},
+			"token_estimate": M{
+				"type":        "integer",
+				"description": "Estimated token count of the compacted output.",
+			},
+			"compaction_info": M{
+				"type":        "object",
+				"description": "Statistics about the compaction operation.",
+				"properties": M{
+					"original_count": M{
+						"type":        "integer",
+						"description": "Number of messages before compaction.",
+					},
+					"compacted_count": M{
+						"type":        "integer",
+						"description": "Number of messages after compaction.",
+					},
+					"dropped_count": M{
+						"type":        "integer",
+						"description": "Number of messages dropped during compaction.",
+					},
+					"anchor_count": M{
+						"type":        "integer",
+						"description": "Number of anchor messages preserved.",
+					},
+					"tokens_saved": M{
+						"type":        "integer",
+						"description": "Estimated tokens saved by compaction.",
+					},
+					"compression_ratio": M{
+						"type":        "number",
+						"description": "Ratio of output size to input size.",
+					},
+				},
+			},
+		},
+		"required": A{"messages", "summary", "token_estimate", "compaction_info"},
+	}
+}
+
+func schemaProviderInfo() M {
+	return M{
+		"type":        "object",
+		"description": "Information about an LLM provider.",
+		"properties": M{
+			"name": M{
+				"type":        "string",
+				"description": "The provider identifier.",
+			},
+			"display": M{
+				"type":        "string",
+				"description": "A human-readable display name for the provider.",
+			},
+			"isDefault": M{
+				"type":        "boolean",
+				"description": "Whether this provider is the default.",
+			},
+		},
+		"required": A{"name", "display", "isDefault"},
+	}
+}
+
+func schemaProvidersResponse() M {
+	return M{
+		"type":        "object",
+		"description": "Response listing available LLM providers.",
+		"properties": M{
+			"providers": M{
+				"type":        "array",
+				"description": "The available LLM providers.",
+				"items":       ref("ProviderInfo"),
+			},
+			"defaultModel": M{
+				"type":        "string",
+				"description": "The name of the default model.",
+			},
+		},
+		"required": A{"providers", "defaultModel"},
+	}
+}
+
+func schemaModelInfo() M {
+	return M{
+		"type":        "object",
+		"description": "Information about an LLM model.",
+		"properties": M{
+			"name": M{
+				"type":        "string",
+				"description": "The model identifier.",
+			},
+			"description": M{
+				"type":        "string",
+				"description": "A short description of the model.",
+			},
+		},
+		"required": A{"name", "description"},
+	}
+}
+
+func schemaModelsResponse() M {
+	return M{
+		"type":        "object",
+		"description": "Response listing models for an LLM provider.",
+		"properties": M{
+			"models": M{
+				"type":        "array",
+				"description": "The available models.",
+				"items":       ref("ModelInfo"),
+			},
+		},
+		"required": A{"models"},
+	}
+}
+
+func schemaLLMChatRequest() M {
+	return M{
+		"type":        "object",
+		"description": "Request to send a chat completion to an LLM provider.",
+		"properties": M{
+			"messages": M{
+				"type":        "array",
+				"description": "The conversation messages to send.",
+				"items":       ref("ChatMessage"),
+			},
+			"tools": M{
+				"type":        "array",
+				"description": "Optional tool definitions for function calling.",
+				"items": M{
+					"type":        "object",
+					"description": "A tool definition.",
+					"properties": M{
+						"name": M{
+							"type":        "string",
+							"description": "The tool name.",
+						},
+						"description": M{
+							"type":        "string",
+							"description": "A description of what the tool does.",
+						},
+						"inputSchema": M{
+							"type":        "object",
+							"description": "JSON Schema describing the tool's input parameters.",
+						},
+					},
+					"required": A{"name", "description", "inputSchema"},
+				},
+			},
+			"provider": M{
+				"type":        "string",
+				"description": "The LLM provider to use.",
+			},
+			"model": M{
+				"type":        "string",
+				"description": "The model to use for completion.",
+			},
+			"debug": M{
+				"type":        "boolean",
+				"description": "Whether to include debug information in the response.",
+				"default":     false,
+			},
+		},
+		"required": A{"messages", "provider", "model"},
+	}
+}
+
+func schemaLLMChatResponse() M {
+	return M{
+		"type":        "object",
+		"description": "Response from an LLM chat completion request.",
+		"properties": M{
+			"content": M{
+				"type":        "array",
+				"description": "The response content blocks.",
+				"items": M{
+					"type":        "object",
+					"description": "A content block from the LLM response.",
+				},
+			},
+			"stop_reason": M{
+				"type":        "string",
+				"description": "The reason the model stopped generating.",
+			},
+			"token_usage": M{
+				"type":        "object",
+				"description": "Token usage statistics for the request.",
+				"properties": M{
+					"input_tokens": M{
+						"type":        "integer",
+						"description": "Number of input tokens consumed.",
+					},
+					"output_tokens": M{
+						"type":        "integer",
+						"description": "Number of output tokens generated.",
+					},
+				},
+			},
+		},
+		"required": A{"content", "stop_reason", "token_usage"},
+	}
+}
+
+func schemaConversationSummary() M {
+	return M{
+		"type":        "object",
+		"description": "A summary of a conversation for list views.",
+		"properties": M{
+			"id": M{
+				"type":        "string",
+				"description": "The unique conversation identifier.",
+			},
+			"title": M{
+				"type":        "string",
+				"description": "The conversation title.",
+			},
+			"connection": M{
+				"type":        "string",
+				"description": "The database connection name used in the conversation.",
+			},
+			"created_at": M{
+				"type":        "string",
+				"format":      "date-time",
+				"description": "When the conversation was created.",
+			},
+			"updated_at": M{
+				"type":        "string",
+				"format":      "date-time",
+				"description": "When the conversation was last updated.",
+			},
+			"preview": M{
+				"type":        "string",
+				"description": "A short preview of the conversation content.",
+			},
+		},
+		"required": A{
+			"id", "title", "connection",
+			"created_at", "updated_at", "preview",
+		},
+	}
+}
+
+func schemaConversation() M {
+	return M{
+		"type":        "object",
+		"description": "A full conversation object including messages.",
+		"properties": M{
+			"id": M{
+				"type":        "string",
+				"description": "The unique conversation identifier.",
+			},
+			"username": M{
+				"type":        "string",
+				"description": "The username that owns the conversation.",
+			},
+			"title": M{
+				"type":        "string",
+				"description": "The conversation title.",
+			},
+			"provider": M{
+				"type":        "string",
+				"description": "The LLM provider used.",
+			},
+			"model": M{
+				"type":        "string",
+				"description": "The LLM model used.",
+			},
+			"connection": M{
+				"type":        "string",
+				"description": "The database connection name.",
+			},
+			"messages": M{
+				"type":        "array",
+				"description": "The conversation messages.",
+				"items":       ref("ChatMessage"),
+			},
+			"created_at": M{
+				"type":        "string",
+				"format":      "date-time",
+				"description": "When the conversation was created.",
+			},
+			"updated_at": M{
+				"type":        "string",
+				"format":      "date-time",
+				"description": "When the conversation was last updated.",
+			},
+		},
+		"required": A{
+			"id", "username", "title", "provider", "model",
+			"connection", "messages", "created_at", "updated_at",
+		},
+	}
+}
+
+func schemaCreateConversationRequest() M {
+	return M{
+		"type":        "object",
+		"description": "Request to create or update a conversation.",
+		"properties": M{
+			"provider": M{
+				"type":        "string",
+				"description": "The LLM provider to use.",
+			},
+			"model": M{
+				"type":        "string",
+				"description": "The LLM model to use.",
+			},
+			"connection": M{
+				"type":        "string",
+				"description": "The database connection name.",
+			},
+			"messages": M{
+				"type":        "array",
+				"description": "The conversation messages.",
+				"items":       ref("ChatMessage"),
+			},
+		},
+		"required": A{"provider", "model", "connection", "messages"},
+	}
+}
+
+func schemaRenameConversationRequest() M {
+	return M{
+		"type":        "object",
+		"description": "Request to rename a conversation.",
+		"properties": M{
+			"title": M{
+				"type":        "string",
+				"description": "The new title for the conversation.",
+			},
+		},
+		"required": A{"title"},
+	}
+}
+
+func schemaSuccessResponse() M {
+	return M{
+		"type":        "object",
+		"description": "A generic success response.",
+		"properties": M{
+			"success": M{
+				"type":        "boolean",
+				"description": "Whether the operation succeeded.",
+			},
+		},
+		"required": A{"success"},
+	}
+}
+
+func schemaDeleteAllResponse() M {
+	return M{
+		"type":        "object",
+		"description": "Response after deleting all conversations.",
+		"properties": M{
+			"success": M{
+				"type":        "boolean",
+				"description": "Whether the operation succeeded.",
+			},
+			"deleted": M{
+				"type":        "integer",
+				"description": "The number of conversations deleted.",
+			},
+		},
+		"required": A{"success", "deleted"},
+	}
+}

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -23,7 +23,7 @@ type M = map[string]interface{}
 type A = []interface{}
 
 // BuildSpec returns the complete OpenAPI 3.0.3 specification as a
-// map that can be serialised to JSON with encoding/json.
+// map that can be serialized to JSON with encoding/json.
 func BuildSpec() map[string]interface{} {
 	return M{
 		"openapi": "3.0.3",
@@ -89,6 +89,30 @@ func ref(name string) M {
 	return M{"$ref": "#/components/schemas/" + name}
 }
 
+// authErrorResponses returns the standard 401 and 403 error responses
+// that apply to all endpoints requiring bearer authentication.
+func authErrorResponses() M {
+	return M{
+		"401": M{
+			"description": "Missing or invalid authentication token.",
+			"content":     jsonContent(ref("ErrorResponse")),
+		},
+		"403": M{
+			"description": "Insufficient permissions.",
+			"content":     jsonContent(ref("ErrorResponse")),
+		},
+	}
+}
+
+// mergeResponses combines a base response map with the standard
+// authentication error responses.
+func mergeResponses(base M) M {
+	for k, v := range authErrorResponses() {
+		base[k] = v
+	}
+	return base
+}
+
 // jsonContent wraps a schema reference in an application/json content
 // block suitable for request or response bodies.
 func jsonContent(schemaRef M) M {
@@ -151,12 +175,12 @@ func buildMCPPath() M {
 				"description": "A JSON-RPC 2.0 request object.",
 				"content":     jsonContent(ref("JSONRPCRequest")),
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "JSON-RPC 2.0 response.",
 					"content":     jsonContent(ref("JSONRPCResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -169,12 +193,12 @@ func buildDatabasesPath() M {
 			"description": "Returns the list of configured database connections and the currently selected database.",
 			"operationId": "listDatabases",
 			"security":    bearerSecurity(),
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "A list of available databases.",
 					"content":     jsonContent(ref("ListDatabasesResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -192,7 +216,7 @@ func buildDatabasesSelectPath() M {
 				"description": "The name of the database to select.",
 				"content":     jsonContent(ref("SelectDatabaseRequest")),
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "Database selected successfully.",
 					"content":     jsonContent(ref("SelectDatabaseResponse")),
@@ -201,15 +225,11 @@ func buildDatabasesSelectPath() M {
 					"description": "Invalid request body.",
 					"content":     jsonContent(ref("ErrorResponse")),
 				},
-				"403": M{
-					"description": "Access to the requested database is forbidden.",
-					"content":     jsonContent(ref("ErrorResponse")),
-				},
 				"404": M{
 					"description": "Database not found.",
 					"content":     jsonContent(ref("ErrorResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -219,9 +239,8 @@ func buildUserInfoPath() M {
 		"get": M{
 			"tags":        A{"User"},
 			"summary":     "Get current user information",
-			"description": "Returns authentication status and username. When no bearer token is provided the response indicates an unauthenticated session.",
+			"description": "Returns authentication status and username. When no bearer token is provided the response indicates an unauthenticated session. This endpoint does not require authentication.",
 			"operationId": "getUserInfo",
-			"security":    bearerSecurity(),
 			"responses": M{
 				"200": M{
 					"description": "User information.",
@@ -237,7 +256,7 @@ func buildChatCompactPath() M {
 		"post": M{
 			"tags":        A{"Chat"},
 			"summary":     "Compact a chat message history",
-			"description": "Compacts a conversation's message history by removing or summarising older messages while preserving important context such as anchors and tool results.",
+			"description": "Compacts a conversation's message history by removing or summarizing older messages while preserving important context such as anchors and tool results.",
 			"operationId": "compactChat",
 			"security":    bearerSecurity(),
 			"requestBody": M{
@@ -245,12 +264,12 @@ func buildChatCompactPath() M {
 				"description": "The messages to compact along with compaction options.",
 				"content":     jsonContent(ref("CompactRequest")),
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "Compacted message history.",
 					"content":     jsonContent(ref("CompactResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -260,14 +279,15 @@ func buildLLMProvidersPath() M {
 		"get": M{
 			"tags":        A{"LLM Proxy"},
 			"summary":     "List LLM providers",
-			"description": "Returns the available LLM providers and the default model. No authentication is required because this endpoint is used by the login page.",
+			"description": "Returns the available LLM providers and the default model.",
 			"operationId": "listLLMProviders",
-			"responses": M{
+			"security":    bearerSecurity(),
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "Available LLM providers.",
 					"content":     jsonContent(ref("ProvidersResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -277,8 +297,9 @@ func buildLLMModelsPath() M {
 		"get": M{
 			"tags":        A{"LLM Proxy"},
 			"summary":     "List models for a provider",
-			"description": "Returns the models available for the specified LLM provider. No authentication is required.",
+			"description": "Returns the models available for the specified LLM provider.",
 			"operationId": "listLLMModels",
+			"security":    bearerSecurity(),
 			"parameters": A{
 				M{
 					"name":        "provider",
@@ -290,12 +311,12 @@ func buildLLMModelsPath() M {
 					},
 				},
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "Available models for the provider.",
 					"content":     jsonContent(ref("ModelsResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -313,12 +334,12 @@ func buildLLMChatPath() M {
 				"description": "The chat request including messages, optional tools, and LLM provider details.",
 				"content":     jsonContent(ref("LLMChatRequest")),
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "LLM chat completion response.",
 					"content":     jsonContent(ref("LLMChatResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -353,7 +374,7 @@ func buildConversationsPath() M {
 					},
 				},
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "A paginated list of conversations.",
 					"content": jsonContent(M{
@@ -367,7 +388,7 @@ func buildConversationsPath() M {
 						},
 					}),
 				},
-			},
+			}),
 		},
 		"post": M{
 			"tags":        A{"Conversations"},
@@ -380,12 +401,12 @@ func buildConversationsPath() M {
 				"description": "The conversation to create.",
 				"content":     jsonContent(ref("CreateConversationRequest")),
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"201": M{
 					"description": "Conversation created successfully.",
 					"content":     jsonContent(ref("Conversation")),
 				},
-			},
+			}),
 		},
 		"delete": M{
 			"tags":        A{"Conversations"},
@@ -404,12 +425,12 @@ func buildConversationsPath() M {
 					},
 				},
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "All conversations deleted.",
 					"content":     jsonContent(ref("DeleteAllResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -433,12 +454,12 @@ func buildConversationByIDPath() M {
 			"description": "Returns a single conversation including its full message history.",
 			"operationId": "getConversation",
 			"security":    bearerSecurity(),
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "The requested conversation.",
 					"content":     jsonContent(ref("Conversation")),
 				},
-			},
+			}),
 		},
 		"put": M{
 			"tags":        A{"Conversations"},
@@ -451,12 +472,12 @@ func buildConversationByIDPath() M {
 				"description": "The updated conversation data.",
 				"content":     jsonContent(ref("CreateConversationRequest")),
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "Conversation updated successfully.",
 					"content":     jsonContent(ref("Conversation")),
 				},
-			},
+			}),
 		},
 		"patch": M{
 			"tags":        A{"Conversations"},
@@ -469,12 +490,12 @@ func buildConversationByIDPath() M {
 				"description": "The new conversation title.",
 				"content":     jsonContent(ref("RenameConversationRequest")),
 			},
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "Conversation renamed successfully.",
 					"content":     jsonContent(ref("SuccessResponse")),
 				},
-			},
+			}),
 		},
 		"delete": M{
 			"tags":        A{"Conversations"},
@@ -482,12 +503,12 @@ func buildConversationByIDPath() M {
 			"description": "Deletes a single conversation by identifier.",
 			"operationId": "deleteConversation",
 			"security":    bearerSecurity(),
-			"responses": M{
+			"responses": mergeResponses(M{
 				"200": M{
 					"description": "Conversation deleted successfully.",
 					"content":     jsonContent(ref("SuccessResponse")),
 				},
-			},
+			}),
 		},
 	}
 }
@@ -643,7 +664,7 @@ func schemaJSONRPCResponse() M {
 			},
 			"error": M{
 				"description": "Error information. Present on failure.",
-				"$ref":        "#/components/schemas/RPCError",
+				"allOf":       A{ref("RPCError")},
 			},
 		},
 		"required": A{"jsonrpc", "id"},

--- a/internal/openapi/openapi_test.go
+++ b/internal/openapi/openapi_test.go
@@ -254,8 +254,8 @@ func TestBuildSpec_DatabasesSelectResponses(t *testing.T) {
 	post := selectPath["post"].(M)
 	responses := post["responses"].(M)
 
-	// Should have 200, 400, 403, 404
-	expectedCodes := []string{"200", "400", "403", "404"}
+	// Should have 200, 400, 401, 403, 404
+	expectedCodes := []string{"200", "400", "401", "403", "404"}
 	for _, code := range expectedCodes {
 		if _, ok := responses[code]; !ok {
 			t.Errorf("/api/databases/select should have %s response",
@@ -292,5 +292,66 @@ func TestBuildSpec_Refs(t *testing.T) {
 			t.Errorf("$ref points to non-existent schema: %s", schemaName)
 		}
 		idx = end
+	}
+}
+
+func TestBuildSpec_UniqueOperationIDs(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+
+	seen := map[string]string{}
+	methods := []string{
+		"get", "post", "put", "patch", "delete",
+	}
+
+	for path, pathItem := range paths {
+		pi := pathItem.(M)
+		for _, method := range methods {
+			op, ok := pi[method].(M)
+			if !ok {
+				continue
+			}
+			opID, _ := op["operationId"].(string)
+			if opID == "" {
+				t.Errorf("%s %s has no operationId", method, path)
+				continue
+			}
+			if prev, dup := seen[opID]; dup {
+				t.Errorf("duplicate operationId %q on %s %s "+
+					"(first seen on %s)", opID, method, path, prev)
+			}
+			seen[opID] = strings.ToUpper(method) + " " + path
+		}
+	}
+}
+
+func TestBuildSpec_AuthEndpointsHaveErrorResponses(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+
+	methods := []string{
+		"get", "post", "put", "patch", "delete",
+	}
+
+	for path, pathItem := range paths {
+		pi := pathItem.(M)
+		for _, method := range methods {
+			op, ok := pi[method].(M)
+			if !ok {
+				continue
+			}
+			if _, hasSecurity := op["security"]; !hasSecurity {
+				continue
+			}
+			responses := op["responses"].(M)
+			if _, ok := responses["401"]; !ok {
+				t.Errorf("%s %s has security but no 401 response",
+					strings.ToUpper(method), path)
+			}
+			if _, ok := responses["403"]; !ok {
+				t.Errorf("%s %s has security but no 403 response",
+					strings.ToUpper(method), path)
+			}
+		}
 	}
 }

--- a/internal/openapi/openapi_test.go
+++ b/internal/openapi/openapi_test.go
@@ -1,0 +1,296 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package openapi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"pgedge-postgres-mcp/internal/mcp"
+)
+
+func TestBuildSpec_TopLevel(t *testing.T) {
+	spec := BuildSpec()
+
+	if spec["openapi"] != "3.0.3" {
+		t.Errorf("expected openapi 3.0.3, got %v", spec["openapi"])
+	}
+
+	info, ok := spec["info"].(M)
+	if !ok {
+		t.Fatal("info is not a map")
+	}
+	if info["title"] != "pgEdge Postgres MCP Server API" {
+		t.Errorf("unexpected title: %v", info["title"])
+	}
+	if info["version"] != mcp.ServerVersion {
+		t.Errorf("expected version %s, got %v",
+			mcp.ServerVersion, info["version"])
+	}
+
+	if _, ok := spec["paths"].(M); !ok {
+		t.Error("paths should be a map")
+	}
+	if _, ok := spec["components"].(M); !ok {
+		t.Error("components should be a map")
+	}
+	if _, ok := spec["tags"].(A); !ok {
+		t.Error("tags should be an array")
+	}
+}
+
+func TestBuildSpec_RequiredPaths(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+
+	requiredPaths := []string{
+		"/health",
+		"/mcp/v1",
+		"/api/databases",
+		"/api/databases/select",
+		"/api/user/info",
+		"/api/chat/compact",
+		"/api/llm/providers",
+		"/api/llm/models",
+		"/api/llm/chat",
+		"/api/conversations",
+		"/api/conversations/{id}",
+		"/api/openapi.json",
+	}
+
+	for _, path := range requiredPaths {
+		if _, ok := paths[path]; !ok {
+			t.Errorf("missing required path: %s", path)
+		}
+	}
+}
+
+func TestBuildSpec_HealthEndpoint(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+	health := paths["/health"].(M)
+
+	get, ok := health["get"].(M)
+	if !ok {
+		t.Fatal("/health should have a GET operation")
+	}
+
+	tags := get["tags"].(A)
+	if len(tags) == 0 || tags[0] != "Health" {
+		t.Error("health endpoint should be tagged 'Health'")
+	}
+
+	// Health should not require auth (no security field)
+	if _, hasSecurity := get["security"]; hasSecurity {
+		t.Error("health endpoint should not require authentication")
+	}
+}
+
+func TestBuildSpec_MCPEndpoint(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+	mcpPath := paths["/mcp/v1"].(M)
+
+	post, ok := mcpPath["post"].(M)
+	if !ok {
+		t.Fatal("/mcp/v1 should have a POST operation")
+	}
+
+	// Should require auth
+	if _, hasSecurity := post["security"]; !hasSecurity {
+		t.Error("/mcp/v1 should require authentication")
+	}
+
+	// Should have request body
+	if _, hasBody := post["requestBody"]; !hasBody {
+		t.Error("/mcp/v1 should have a request body")
+	}
+}
+
+func TestBuildSpec_ConversationsEndpoint(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+	convPath := paths["/api/conversations"].(M)
+
+	// Should have GET, POST, DELETE
+	for _, method := range []string{"get", "post", "delete"} {
+		if _, ok := convPath[method].(M); !ok {
+			t.Errorf("/api/conversations should have %s operation",
+				strings.ToUpper(method))
+		}
+	}
+}
+
+func TestBuildSpec_ConversationByIDEndpoint(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+	convIDPath := paths["/api/conversations/{id}"].(M)
+
+	// Should have GET, PUT, PATCH, DELETE
+	for _, method := range []string{"get", "put", "patch", "delete"} {
+		if _, ok := convIDPath[method].(M); !ok {
+			t.Errorf("/api/conversations/{id} should have %s operation",
+				strings.ToUpper(method))
+		}
+	}
+
+	// Should have path parameter
+	params, ok := convIDPath["parameters"].(A)
+	if !ok || len(params) == 0 {
+		t.Error("should have path parameter for id")
+	}
+}
+
+func TestBuildSpec_SecurityScheme(t *testing.T) {
+	spec := BuildSpec()
+	components := spec["components"].(M)
+	schemes := components["securitySchemes"].(M)
+	bearer := schemes["BearerAuth"].(M)
+
+	if bearer["type"] != "http" {
+		t.Errorf("expected type 'http', got %v", bearer["type"])
+	}
+	if bearer["scheme"] != "bearer" {
+		t.Errorf("expected scheme 'bearer', got %v", bearer["scheme"])
+	}
+}
+
+func TestBuildSpec_RequiredSchemas(t *testing.T) {
+	spec := BuildSpec()
+	components := spec["components"].(M)
+	schemas := components["schemas"].(M)
+
+	requiredSchemas := []string{
+		"ErrorResponse",
+		"HealthResponse",
+		"JSONRPCRequest",
+		"JSONRPCResponse",
+		"RPCError",
+		"DatabaseInfo",
+		"ListDatabasesResponse",
+		"SelectDatabaseRequest",
+		"SelectDatabaseResponse",
+		"UserInfoResponse",
+		"ChatMessage",
+		"CompactRequest",
+		"CompactResponse",
+		"ProviderInfo",
+		"ProvidersResponse",
+		"ModelInfo",
+		"ModelsResponse",
+		"LLMChatRequest",
+		"LLMChatResponse",
+		"ConversationSummary",
+		"Conversation",
+		"CreateConversationRequest",
+		"RenameConversationRequest",
+		"SuccessResponse",
+		"DeleteAllResponse",
+	}
+
+	for _, name := range requiredSchemas {
+		if _, ok := schemas[name]; !ok {
+			t.Errorf("missing required schema: %s", name)
+		}
+	}
+}
+
+func TestBuildSpec_JSONSerializable(t *testing.T) {
+	spec := BuildSpec()
+
+	data, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		t.Fatalf("spec should be JSON serializable: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("serialized spec should not be empty")
+	}
+
+	// Verify round-trip
+	var parsed M
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("should parse back as JSON: %v", err)
+	}
+
+	if parsed["openapi"] != "3.0.3" {
+		t.Error("round-trip should preserve openapi version")
+	}
+}
+
+func TestBuildSpec_LLMModelsParameters(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+	modelsPath := paths["/api/llm/models"].(M)
+	get := modelsPath["get"].(M)
+
+	params, ok := get["parameters"].(A)
+	if !ok || len(params) == 0 {
+		t.Fatal("/api/llm/models should have parameters")
+	}
+
+	param := params[0].(M)
+	if param["name"] != "provider" {
+		t.Errorf("expected parameter 'provider', got %v", param["name"])
+	}
+	if param["required"] != true {
+		t.Error("provider parameter should be required")
+	}
+}
+
+func TestBuildSpec_DatabasesSelectResponses(t *testing.T) {
+	spec := BuildSpec()
+	paths := spec["paths"].(M)
+	selectPath := paths["/api/databases/select"].(M)
+	post := selectPath["post"].(M)
+	responses := post["responses"].(M)
+
+	// Should have 200, 400, 403, 404
+	expectedCodes := []string{"200", "400", "403", "404"}
+	for _, code := range expectedCodes {
+		if _, ok := responses[code]; !ok {
+			t.Errorf("/api/databases/select should have %s response",
+				code)
+		}
+	}
+}
+
+func TestBuildSpec_Refs(t *testing.T) {
+	// Verify all $ref values point to existing schemas
+	spec := BuildSpec()
+	components := spec["components"].(M)
+	schemas := components["schemas"].(M)
+
+	data, _ := json.Marshal(spec)
+	specStr := string(data)
+
+	// Find all $ref values
+	prefix := "#/components/schemas/"
+	idx := 0
+	for {
+		pos := strings.Index(specStr[idx:], prefix)
+		if pos == -1 {
+			break
+		}
+		start := idx + pos + len(prefix)
+		end := start
+		for end < len(specStr) && specStr[end] != '"' {
+			end++
+		}
+		schemaName := specStr[start:end]
+
+		if _, exists := schemas[schemaName]; !exists {
+			t.Errorf("$ref points to non-existent schema: %s", schemaName)
+		}
+		idx = end
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ markdown_extensions:
 
 plugins:
   - search
+  - redoc-tag
   - macros:
       j2_variable_start_string: "<<"
       j2_variable_end_string: ">>"
@@ -113,6 +114,7 @@ nav:
       - For Developers - Overview: developers/overview.md
       - MCP Protocol: developers/mcp-protocol.md
       - API Reference: developers/api-reference.md
+      - API Browser: api/browser.md
       - Client Examples: developers/client-examples.md
       - Building Chat Clients:
           - Overview: developers/building-chat-clients.md


### PR DESCRIPTION
Add a programmatic OpenAPI 3.0.3 specification builder that documents
all REST API endpoints, along with an interactive ReDoc-powered API
browser in the MkDocs documentation site.

Components added:

- internal/openapi/openapi.go: BuildSpec() returns the complete
  OpenAPI 3.0.3 spec covering all 12 path items and 24 schemas
- internal/openapi/openapi_test.go: 12 tests for spec structure,
  paths, schemas, security, JSON serialization, and $ref integrity
- GET /api/openapi.json endpoint: serves the spec at runtime
- -openapi CLI flag: outputs the spec to stdout for static generation
- RFC 8631 Link header on all responses for API discoverability
- docs/api/browser.md: ReDoc browser page with full-height styling
- docs/api/openapi.json: pre-generated static spec for MkDocs
- mkdocs.yml: redoc-tag plugin and API Browser nav entry
- docs/changelog.md: feature entry for the new capability

https://claude.ai/code/session_015y16Q5gumRg945PQ71EXEj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI 3.0.3 spec available at /api/openapi.json and via a -openapi CLI flag
  * Interactive ReDoc API browser added to developer docs
  * Provider/model listing endpoints now require authentication when auth is enabled

* **Documentation**
  * Full OpenAPI specification added to docs (regeneratable via a make target)

* **Tests**
  * Added tests validating the OpenAPI spec and security headers/auth bypass for the spec endpoint
<!-- end of auto-generated comment: release notes by coderabbit.ai -->