### PR TITLE
feat: add one-command installers for Claude Code and Claude Desktop

### DIFF
--- a/examples/claude-try-it/install.ps1
+++ b/examples/claude-try-it/install.ps1
@@ -13,7 +13,7 @@
 # What it does:
 #   1. Downloads the pgEdge MCP Server binary for Windows (x86_64)
 #   2. Helps you connect to a database (your own or a demo with sample data)
-#   3. Configures Claude Code (.mcp.json) and/or Claude Desktop
+#   3. Configures Claude Code (.claude.json) and/or Claude Desktop
 
 param(
     [switch]$Demo,
@@ -562,7 +562,7 @@ function Confirm-OwnDbConnection {
             Set-OwnDatabase
             return
         }
-        default { Write-Warn "Continuing — you can update .mcp.json later with the correct details." }
+        default { Write-Warn "Continuing — you can update ~/.claude.json later with the correct details." }
     }
 }
 

--- a/examples/claude-try-it/install.ps1
+++ b/examples/claude-try-it/install.ps1
@@ -1,0 +1,811 @@
+# pgEdge MCP Server — one-command installer for Windows
+#
+# Usage (interactive, in PowerShell):
+#   irm https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/claude-try-it/install.ps1 | iex
+#
+# Usage (non-interactive, via Claude Code):
+#   $s = irm https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/claude-try-it/install.ps1; & ([scriptblock]::Create($s)) -Demo
+#
+# Usage (with flags, saved locally):
+#   .\install.ps1 -Demo
+#   .\install.ps1 -OwnDb -DbHost localhost -DbPort 5432 -DbName mydb -DbUser me -DbPass secret
+#
+# What it does:
+#   1. Downloads the pgEdge MCP Server binary for Windows (x86_64)
+#   2. Helps you connect to a database (your own or a demo with sample data)
+#   3. Configures Claude Code (.mcp.json) and/or Claude Desktop
+
+param(
+    [switch]$Demo,
+    [switch]$OwnDb,
+    [switch]$InstallDocker,
+    [string]$DbHost,
+    [string]$DbPort,
+    [string]$DbName,
+    [string]$DbUser,
+    [string]$DbPass
+)
+
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# --- Configuration --------------------------------------------------------
+
+$InstallDir = Join-Path $env:USERPROFILE ".pgedge"
+$BinDir     = Join-Path $InstallDir "bin"
+$DemoDir    = Join-Path $InstallDir "demo"
+$Repo       = "pgEdge/pgedge-postgres-mcp"
+$DemoPort   = 5432
+
+# --- State variables ------------------------------------------------------
+
+$script:Version      = ""
+$script:VersionNum   = ""
+$script:DbHost       = $DbHost
+$script:DbPort       = $DbPort
+$script:DbName       = $DbName
+$script:DbUser       = $DbUser
+$script:DbPass       = $DbPass
+$script:DbConfigured = $false
+$script:DemoPort     = $DemoPort
+
+# --- Helper functions -----------------------------------------------------
+
+function Write-Info  { param([string]$Msg) Write-Host "  i  $Msg" }
+function Write-Ok    { param([string]$Msg) Write-Host "  +  $Msg" -ForegroundColor Green }
+function Write-Warn  { param([string]$Msg) Write-Host "  !  $Msg" -ForegroundColor Yellow }
+function Write-Fail  { param([string]$Msg) Write-Host "  x  $Msg" -ForegroundColor Red; exit 1 }
+
+function Test-Interactive {
+    try {
+        return [Environment]::UserInteractive -and -not [Console]::IsInputRedirected
+    } catch {
+        return $false
+    }
+}
+
+function Read-Prompt {
+    param([string]$Prompt, [string]$Default)
+    if (-not (Test-Interactive)) { return $Default }
+    $response = Read-Host -Prompt $Prompt
+    if ([string]::IsNullOrWhiteSpace($response)) { return $Default }
+    return $response
+}
+
+# --- Detect platform ------------------------------------------------------
+
+function Get-Platform {
+    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+        Write-Fail "ARM64 Windows is not yet supported. Only x86_64 builds are available."
+    }
+    if (-not [System.Environment]::Is64BitOperatingSystem) {
+        Write-Fail "32-bit Windows is not supported."
+    }
+    # Windows x86_64 only
+    $script:OS   = "windows"
+    $script:Arch = "x86_64"
+    $script:Ext  = "zip"
+}
+
+# --- Get latest release version -------------------------------------------
+
+function Get-LatestVersion {
+    try {
+        $release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest"
+        $script:Version = $release.tag_name
+    } catch {
+        Write-Fail "Could not determine latest release version: $_"
+    }
+    if (-not $script:Version) {
+        Write-Fail "Could not determine latest release version"
+    }
+    $script:VersionNum = $script:Version.TrimStart('v')
+}
+
+# --- Download and install binary ------------------------------------------
+
+function Install-Binary {
+    $assetName = "pgedge-postgres-mcp-server_$($script:VersionNum)_$($script:OS)_$($script:Arch).$($script:Ext)"
+    $url = "https://github.com/$Repo/releases/download/$($script:Version)/$assetName"
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+    Write-Info "Downloading pgEdge MCP Server $($script:Version) ($($script:OS)/$($script:Arch))..."
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile (Join-Path $tmpDir $assetName) -UseBasicParsing
+    } catch {
+        Write-Fail "Download failed. Check your internet connection."
+    }
+
+    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+
+    $extractDir = Join-Path $tmpDir "extracted"
+    Expand-Archive -Path (Join-Path $tmpDir $assetName) -DestinationPath $extractDir -Force
+
+    # Find the binary in the extracted archive
+    $binaryName = "pgedge-postgres-mcp.exe"
+    $source = Get-ChildItem -Path $extractDir -Recurse -Filter $binaryName | Select-Object -First 1
+    if (-not $source) {
+        $source = Get-ChildItem -Path $extractDir -Recurse -Filter "pgedge-postgres-mcp*" | Select-Object -First 1
+    }
+    if (-not $source) { Write-Fail "Binary not found in archive" }
+
+    Copy-Item $source.FullName (Join-Path $BinDir $binaryName) -Force
+    Remove-Item $tmpDir -Recurse -Force
+
+    Write-Ok "Binary installed: $(Join-Path $BinDir $binaryName)"
+}
+
+# --- Docker detection and installation ------------------------------------
+
+function Test-DockerDesktopInstalled {
+    # Check standard install path
+    if (Test-Path "C:\Program Files\Docker\Docker\Docker Desktop.exe") { return $true }
+    # Check registry uninstall key (machine-wide and per-user installs)
+    $reg = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Docker Desktop" -ErrorAction SilentlyContinue
+    if ($reg) { return $true }
+    $reg = Get-ItemProperty "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Docker Desktop" -ErrorAction SilentlyContinue
+    if ($reg) { return $true }
+    # Check CLI on PATH (original method, still useful)
+    if (Get-Command docker -ErrorAction SilentlyContinue) { return $true }
+    return $false
+}
+
+function Test-DockerRunning {
+    # Named pipe is reliable and doesn't need docker CLI on PATH
+    if (Test-Path "\\.\pipe\docker_engine") { return $true }
+    # Fallback to docker info if CLI is on PATH
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) { return $false }
+    $prevPref = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    try {
+        $null = & docker info 2>$null
+        return $LASTEXITCODE -eq 0
+    } catch { return $false }
+    finally { $ErrorActionPreference = $prevPref }
+}
+
+function Install-DockerDesktop {
+    # If Docker is already installed but just not running, don't reinstall
+    if (Test-DockerDesktopInstalled) {
+        Write-Host ""
+        Write-Warn "Docker is installed but not running."
+        Write-Host ""
+        Write-Host "  Please open Docker Desktop from the Start menu and wait"
+        Write-Host "  for it to finish starting (the whale icon in the taskbar"
+        Write-Host "  will stop animating when it's ready)."
+        Write-Host ""
+        Write-Host "  Then re-run this installer."
+        Write-Host ""
+        exit 0
+    }
+
+    Write-Host ""
+    Write-Info "Installing Docker Desktop..."
+    Write-Host ""
+
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        Write-Info "Installing via winget (this may take several minutes)..."
+        & winget install -e --id Docker.DockerDesktop --no-upgrade --accept-source-agreements --accept-package-agreements
+        if ($LASTEXITCODE -ne 0) {
+            Write-Fail "winget install failed (exit code $LASTEXITCODE). Please install Docker Desktop manually from https://www.docker.com/products/docker-desktop/"
+        }
+        Write-Host ""
+        Write-Info "Docker Desktop installed. Please open Docker Desktop from"
+        Write-Info "the Start menu, wait for it to start, then re-run this installer."
+        exit 0
+    } else {
+        Write-Host ""
+        Write-Host "  Docker Desktop needs to be installed manually."
+        Write-Host ""
+        Write-Host "  1. Download it from: https://www.docker.com/products/docker-desktop/"
+        Write-Host "  2. Run the installer and follow the prompts"
+        Write-Host "  3. Launch Docker Desktop and wait for it to start"
+        Write-Host "  4. Re-run this installer"
+        Write-Host ""
+        exit 0
+    }
+}
+
+# --- Database choice ------------------------------------------------------
+
+function Select-Database {
+    if ($Demo) {
+        Start-DemoDatabase
+        return
+    }
+    if ($OwnDb) {
+        Set-OwnDatabase
+        return
+    }
+    if ($InstallDocker) {
+        Install-DockerDesktop
+        Start-DemoDatabase
+        return
+    }
+
+    # Non-interactive — output choices for Claude
+    if (-not (Test-Interactive)) {
+        Write-Host ""
+        Write-Host "DATABASE_CHOICE_NEEDED"
+        Write-Host "The MCP server needs a PostgreSQL database to connect to."
+        Write-Host "Options:"
+        Write-Host "  1. Demo database - sample Northwind data, requires Docker"
+        Write-Host "  2. Your own database - provide connection details"
+        Write-Host ""
+        Write-Host "Re-run with flags:"
+        Write-Host "  -Demo                              (start demo database with Docker)"
+        Write-Host "  -InstallDocker                     (install Docker first, then demo)"
+        Write-Host "  -OwnDb -DbHost HOST -DbPort PORT -DbName DB -DbUser USER -DbPass PASS"
+        Write-Host ""
+        $script:DbConfigured = $false
+        return
+    }
+
+    # Interactive
+    Write-Host ""
+    Write-Host "  The MCP server needs a PostgreSQL database to connect to."
+    Write-Host ""
+    Write-Host "  Which would you like?"
+    Write-Host ""
+    Write-Host "    1) Load a sample database (Northwind - customers, orders, products)"
+    Write-Host "       Requires Docker. Great for trying things out."
+    Write-Host ""
+    Write-Host "    2) Connect to my own PostgreSQL database"
+    Write-Host "       You'll provide the connection details."
+    Write-Host ""
+
+    $choice = Read-Prompt "  Enter 1 or 2" "1"
+
+    switch ($choice) {
+        "1" { Start-DemoDatabase }
+        "2" { Set-OwnDatabase }
+        default { Write-Info "Defaulting to sample database..."; Start-DemoDatabase }
+    }
+}
+
+# --- Demo database setup --------------------------------------------------
+
+function Start-DemoDatabase {
+    if (Test-DockerRunning) {
+        Start-DemoPostgres
+        return
+    }
+
+    # Docker installed but not running?
+    if (Test-DockerDesktopInstalled) {
+        Write-Host ""
+        Write-Warn "Docker is installed but not running."
+        Write-Host ""
+        Write-Host "  Please open Docker Desktop from the Start menu and wait"
+        Write-Host "  for it to finish starting, then re-run this installer."
+        Write-Host ""
+
+        if (-not (Test-Interactive)) {
+            Write-Host "DOCKER_NOT_RUNNING"
+            Write-Host "Start Docker Desktop, then re-run with: -Demo"
+            $script:DbConfigured = $false
+            return
+        }
+
+        Write-Host "  Options:"
+        Write-Host ""
+        Write-Host "    1) I'll start Docker Desktop and re-run this later"
+        Write-Host "    2) Connect to my own database instead"
+        Write-Host ""
+
+        $choice = Read-Prompt "  Enter 1 or 2" "1"
+        switch ($choice) {
+            "2" { Set-OwnDatabase }
+            default {
+                Write-Host ""
+                Write-Host "  Open Docker Desktop, wait for it to start, then re-run this installer."
+                Write-Host ""
+                $script:DbConfigured = $false
+            }
+        }
+        return
+    }
+
+    # Docker not installed at all
+    Write-Host ""
+    Write-Warn "Docker is not installed."
+    Write-Host ""
+    Write-Host "  The sample database runs in a Docker container."
+    Write-Host "  Docker Desktop is free and takes about 5 minutes to install."
+    Write-Host ""
+
+    if (-not (Test-Interactive)) {
+        Write-Host "DOCKER_NOT_FOUND"
+        Write-Host "To install Docker and set up the demo, re-run with: -InstallDocker"
+        Write-Host "To skip the demo and use your own database, re-run with: -OwnDb -DbHost ... -DbPort ... -DbName ... -DbUser ... -DbPass ..."
+        $script:DbConfigured = $false
+        return
+    }
+
+    Write-Host "  Would you like me to install Docker for you?"
+    Write-Host ""
+    Write-Host "    1) Yes, install Docker"
+    Write-Host "    2) No, I'll connect to my own database instead"
+    Write-Host "    3) No, I'll install Docker myself and re-run this later"
+    Write-Host ""
+
+    $choice = Read-Prompt "  Enter 1, 2, or 3" "3"
+
+    switch ($choice) {
+        "1" { Install-DockerDesktop; Start-DemoPostgres }
+        "2" { Set-OwnDatabase }
+        default {
+            Write-Host ""
+            Write-Host "  To install Docker Desktop:"
+            Write-Host "    https://www.docker.com/products/docker-desktop/"
+            Write-Host ""
+            Write-Host "  After installing, re-run this installer."
+            Write-Host ""
+            $script:DbConfigured = $false
+        }
+    }
+}
+
+# --- Find a free port -----------------------------------------------------
+
+function Find-FreePort {
+    foreach ($port in 5432, 5433, 5434, 5435, 5436) {
+        try {
+            $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $port)
+            $listener.Start()
+            $listener.Stop()
+            return $port
+        } catch {
+            continue
+        }
+    }
+    # Last resort: let .NET pick
+    try {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+        $listener.Start()
+        $port = $listener.LocalEndpoint.Port
+        $listener.Stop()
+        return $port
+    } catch {
+        return 0
+    }
+}
+
+# --- Remove old demo containers ------------------------------------------
+
+function Remove-OldDemos {
+    try {
+        $old = & docker ps -a --filter "name=pgedge-demo-" --format '{{.Names}}' 2>$null
+    } catch { return }
+    if (-not $old) { return }
+    foreach ($name in $old) {
+        if ([string]::IsNullOrWhiteSpace($name)) { continue }
+        Write-Info "Removing old demo container: $name"
+        & docker stop $name 2>$null | Out-Null
+        & docker rm -v $name 2>$null | Out-Null
+    }
+}
+
+# --- Start demo Postgres container ----------------------------------------
+
+function Start-DemoPostgres {
+    # Clean up any old demo containers from previous installs
+    Remove-OldDemos
+
+    # Generate a unique container name for this run
+    $ContainerName = "pgedge-demo-$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())"
+
+    $script:DemoPort = Find-FreePort
+    if ($script:DemoPort -eq 0) {
+        Write-Warn "Could not find a free port for the demo database."
+        $script:DbConfigured = $false
+        return
+    }
+
+    if ($script:DemoPort -ne 5432) {
+        Write-Info "Port 5432 is in use (probably an existing Postgres instance)."
+        Write-Info "Using port $($script:DemoPort) for the demo database instead."
+    }
+
+    New-Item -ItemType Directory -Path $DemoDir -Force | Out-Null
+
+    # Write docker-compose.yml
+    # Note: $$POSTGRES_USER inside the configs content is docker-compose syntax
+    # (double-dollar escapes the dollar sign). Port is interpolated directly.
+    $composeContent = @"
+services:
+  postgres:
+    image: ghcr.io/pgedge/pgedge-postgres:17-spock5-standard
+    container_name: PGEDGE_CONTAINER_NAME
+    command: postgres -c listen_addresses='*' -c shared_preload_libraries='pg_stat_statements'
+    environment:
+      POSTGRES_USER: demo
+      POSTGRES_PASSWORD: demo123
+      POSTGRES_DB: northwind
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    configs:
+      - source: load-northwind
+        target: /docker-entrypoint-initdb.d/01-load-northwind.sh
+        mode: 0755
+      - source: enable-extensions
+        target: /docker-entrypoint-initdb.d/02-enable-extensions.sh
+        mode: 0755
+    ports:
+      - "$($script:DemoPort):5432"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U demo -d northwind"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+volumes:
+  pgdata:
+    driver: local
+
+configs:
+  load-northwind:
+    content: |-
+      #!/usr/bin/env bash
+      set -e
+      echo "Loading Northwind dataset..."
+      curl -fsSL -o /tmp/northwind.sql https://downloads.pgedge.com/platform/examples/northwind/northwind.sql
+      psql -v ON_ERROR_STOP=1 --username "`$`$POSTGRES_USER" --dbname "`$`$POSTGRES_DB" -f /tmp/northwind.sql
+      rm -f /tmp/northwind.sql
+      echo "Northwind dataset loaded"
+  enable-extensions:
+    content: |-
+      #!/usr/bin/env bash
+      set -e
+      psql -v ON_ERROR_STOP=1 --username "`$`$POSTGRES_USER" --dbname "`$`$POSTGRES_DB" \
+        -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
+      echo "Extensions enabled"
+"@
+
+    $composeContent = $composeContent -replace 'PGEDGE_CONTAINER_NAME', $ContainerName
+    $composeContent | Set-Content (Join-Path $DemoDir "docker-compose.yml") -Encoding UTF8
+
+    Write-Host ""
+    Write-Info "Starting demo Postgres ($ContainerName) with Northwind sample data on port $($script:DemoPort)..."
+    Write-Info "(first run downloads the image - this may take a minute)"
+    Write-Host ""
+
+    $composeFile = Join-Path $DemoDir "docker-compose.yml"
+    $started = $false
+    try {
+        & docker compose -f $composeFile up -d 2>$null
+        if ($LASTEXITCODE -eq 0) { $started = $true }
+    } catch {}
+
+    if (-not $started) {
+        try {
+            & docker-compose -f $composeFile up -d 2>$null
+            if ($LASTEXITCODE -eq 0) { $started = $true }
+        } catch {}
+    }
+
+    if (-not $started) {
+        Write-Warn "Failed to start demo database."
+        $script:DbConfigured = $false
+        return
+    }
+
+    Write-Info "Waiting for database to be ready..."
+    for ($i = 0; $i -lt 24; $i++) {
+        try {
+            & docker exec $ContainerName pg_isready -U demo -d northwind 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Ok "Demo database ready (northwind on localhost:$($script:DemoPort), container: $ContainerName)"
+                $script:DbHost = "localhost"; $script:DbPort = "$($script:DemoPort)"
+                $script:DbName = "northwind"; $script:DbUser = "demo"
+                $script:DbPass = "demo123"; $script:DbConfigured = $true
+                return
+            }
+        } catch {}
+        Start-Sleep -Seconds 5
+    }
+
+    Write-Warn "Database is still starting. It may need another minute."
+    $script:DbHost = "localhost"; $script:DbPort = "$($script:DemoPort)"
+    $script:DbName = "northwind"; $script:DbUser = "demo"
+    $script:DbPass = "demo123"; $script:DbConfigured = $true
+}
+
+# --- Database connection test ---------------------------------------------
+
+function Test-DbConnection {
+    param([string]$Host_, [int]$Port)
+    Write-Info "Testing connection to ${Host_}:${Port}..."
+    try {
+        $tcp = New-Object System.Net.Sockets.TcpClient
+        $completed = $tcp.ConnectAsync($Host_, $Port).Wait(3000)
+        if ($completed -and $tcp.Connected) {
+            $tcp.Close()
+            Write-Ok "Connection to ${Host_}:${Port} succeeded"
+            return $true
+        }
+        $tcp.Close()
+    } catch {
+        try { if ($tcp) { $tcp.Close() } } catch {}
+    }
+    return $false
+}
+
+function Confirm-OwnDbConnection {
+    if (Test-DbConnection $script:DbHost ([int]$script:DbPort)) { return }
+
+    Write-Host ""
+    Write-Warn "Could not reach $($script:DbHost):$($script:DbPort) (TCP connection failed)"
+    Write-Host ""
+
+    if (-not (Test-Interactive)) {
+        Write-Warn "Continuing anyway — verify your connection details are correct."
+        return
+    }
+
+    Write-Host "  What would you like to do?"
+    Write-Host ""
+    Write-Host "    1) Re-enter connection details"
+    Write-Host "    2) Continue anyway (I'll fix it later)"
+    Write-Host ""
+
+    $choice = Read-Prompt "  Enter 1 or 2" "2"
+    switch ($choice) {
+        "1" {
+            # Clear previous values so Set-OwnDatabase re-prompts
+            $script:DbHost = ""; $script:DbPort = ""; $script:DbName = ""
+            $script:DbUser = ""; $script:DbPass = ""
+            Set-OwnDatabase
+            return
+        }
+        default { Write-Warn "Continuing — you can update .mcp.json later with the correct details." }
+    }
+}
+
+# --- Own database setup ---------------------------------------------------
+
+function Set-OwnDatabase {
+    # If connection details were provided via flags
+    if ($script:DbHost -and $script:DbName -and $script:DbUser) {
+        if (-not $script:DbPort) { $script:DbPort = "5432" }
+        $script:DbConfigured = $true
+        Write-Ok "Using database: $($script:DbName) on $($script:DbHost):$($script:DbPort)"
+        Confirm-OwnDbConnection
+        return
+    }
+
+    if (-not (Test-Interactive)) {
+        Write-Host ""
+        Write-Host "OWN_DATABASE_CHOSEN"
+        Write-Host "Re-run with connection details:"
+        Write-Host "  -OwnDb -DbHost HOST -DbPort PORT -DbName DB -DbUser USER -DbPass PASS"
+        $script:DbConfigured = $false
+        return
+    }
+
+    Write-Host ""
+    Write-Host "  Enter your PostgreSQL connection details:"
+    Write-Host ""
+
+    $script:DbHost = Read-Prompt "  Host [localhost]" "localhost"
+    $script:DbPort = Read-Prompt "  Port [5432]" "5432"
+    $script:DbName = Read-Prompt "  Database name" ""
+    if (-not $script:DbName) { Write-Warn "Database name is required."; $script:DbConfigured = $false; return }
+    $script:DbUser = Read-Prompt "  Username" ""
+    if (-not $script:DbUser) { Write-Warn "Username is required."; $script:DbConfigured = $false; return }
+    if (Test-Interactive) {
+        if ($PSVersionTable.PSVersion.Major -ge 7) {
+            $script:DbPass = Read-Host -Prompt "  Password" -MaskInput
+        } else {
+            $secure = Read-Host -Prompt "  Password" -AsSecureString
+            $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+            try {
+                $script:DbPass = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+            } finally {
+                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+            }
+        }
+    } else {
+        $script:DbPass = ""
+    }
+
+    $script:DbConfigured = $true
+    Write-Ok "Using database: $($script:DbName) on $($script:DbHost):$($script:DbPort)"
+    Confirm-OwnDbConnection
+}
+
+# --- Configure Claude Code ------------------------------------------------
+
+function Set-ClaudeCodeConfig {
+    $mcpJson = Join-Path $env:USERPROFILE ".claude.json"
+    $binaryPath = (Join-Path $BinDir "pgedge-postgres-mcp.exe").Replace('\', '/')
+
+    $pgHost = if ($script:DbHost) { $script:DbHost } else { "localhost" }
+    $pgPort = if ($script:DbPort) { $script:DbPort } else { "5432" }
+    $pgDb   = if ($script:DbName) { $script:DbName } else { "your_database" }
+    $pgUser = if ($script:DbUser) { $script:DbUser } else { "your_user" }
+    $pgPass = if ($script:DbPass) { $script:DbPass } else { "your_password" }
+
+    if (Test-Path $mcpJson) {
+        try {
+            $raw = Get-Content $mcpJson -Raw
+            $existing = $raw | ConvertFrom-Json
+
+            # Convert PSCustomObject to allow adding properties
+            if (-not $existing.mcpServers) {
+                $existing | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue (New-Object PSObject) -Force
+            }
+
+            # Add or overwrite the pgedge entry
+            $pgedgeObj = New-Object PSObject
+            $pgedgeObj | Add-Member -NotePropertyName "command" -NotePropertyValue $binaryPath
+            $envObj = New-Object PSObject
+            $envObj | Add-Member -NotePropertyName "PGHOST"     -NotePropertyValue $pgHost
+            $envObj | Add-Member -NotePropertyName "PGPORT"     -NotePropertyValue $pgPort
+            $envObj | Add-Member -NotePropertyName "PGDATABASE" -NotePropertyValue $pgDb
+            $envObj | Add-Member -NotePropertyName "PGUSER"     -NotePropertyValue $pgUser
+            $envObj | Add-Member -NotePropertyName "PGPASSWORD" -NotePropertyValue $pgPass
+            $pgedgeObj | Add-Member -NotePropertyName "env" -NotePropertyValue $envObj
+
+            if ($existing.mcpServers.PSObject.Properties["pgedge"]) {
+                $existing.mcpServers.pgedge = $pgedgeObj
+            } else {
+                $existing.mcpServers | Add-Member -NotePropertyName "pgedge" -NotePropertyValue $pgedgeObj
+            }
+
+            $existing | ConvertTo-Json -Depth 10 | Set-Content $mcpJson -Encoding UTF8
+            Write-Ok "Claude Code: configured in ~/.claude.json (available in all projects)"
+            return
+        } catch {
+            Write-Warn "~/.claude.json contains invalid JSON — backing up to .claude.json.bak"
+            Rename-Item $mcpJson "$mcpJson.bak" -Force
+            # Fall through to write fresh config
+        }
+    }
+
+    # Write fresh config
+    $config = New-Object PSObject
+    $mcpServers = New-Object PSObject
+    $pgedgeObj = New-Object PSObject
+    $pgedgeObj | Add-Member -NotePropertyName "command" -NotePropertyValue $binaryPath
+    $envObj = New-Object PSObject
+    $envObj | Add-Member -NotePropertyName "PGHOST"     -NotePropertyValue $pgHost
+    $envObj | Add-Member -NotePropertyName "PGPORT"     -NotePropertyValue $pgPort
+    $envObj | Add-Member -NotePropertyName "PGDATABASE" -NotePropertyValue $pgDb
+    $envObj | Add-Member -NotePropertyName "PGUSER"     -NotePropertyValue $pgUser
+    $envObj | Add-Member -NotePropertyName "PGPASSWORD" -NotePropertyValue $pgPass
+    $pgedgeObj | Add-Member -NotePropertyName "env" -NotePropertyValue $envObj
+    $mcpServers | Add-Member -NotePropertyName "pgedge" -NotePropertyValue $pgedgeObj
+    $config | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue $mcpServers
+
+    $config | ConvertTo-Json -Depth 10 | Set-Content $mcpJson -Encoding UTF8
+    Write-Ok "Claude Code: configured in ~/.claude.json (available in all projects)"
+}
+
+# --- Configure Claude Desktop ---------------------------------------------
+
+function Set-ClaudeDesktopConfig {
+    $binaryPath = (Join-Path $BinDir "pgedge-postgres-mcp.exe").Replace('\', '/')
+    $configFile = Join-Path $env:APPDATA "Claude\claude_desktop_config.json"
+    $configDir = Split-Path $configFile
+
+    if (-not (Test-Path $configDir)) {
+        Write-Info "Claude Desktop not detected - skipping config"
+        return
+    }
+
+    $pgHost = if ($script:DbHost) { $script:DbHost } else { "localhost" }
+    $pgPort = if ($script:DbPort) { $script:DbPort } else { "5432" }
+    $pgDb   = if ($script:DbName) { $script:DbName } else { "your_database" }
+    $pgUser = if ($script:DbUser) { $script:DbUser } else { "your_user" }
+    $pgPass = if ($script:DbPass) { $script:DbPass } else { "your_password" }
+
+    # Build the pgedge entry as PSCustomObject (PS 5.1 compatible)
+    $pgedgeObj = New-Object PSObject
+    $pgedgeObj | Add-Member -NotePropertyName "command" -NotePropertyValue $binaryPath
+    $envObj = New-Object PSObject
+    $envObj | Add-Member -NotePropertyName "PGHOST"     -NotePropertyValue $pgHost
+    $envObj | Add-Member -NotePropertyName "PGPORT"     -NotePropertyValue $pgPort
+    $envObj | Add-Member -NotePropertyName "PGDATABASE" -NotePropertyValue $pgDb
+    $envObj | Add-Member -NotePropertyName "PGUSER"     -NotePropertyValue $pgUser
+    $envObj | Add-Member -NotePropertyName "PGPASSWORD" -NotePropertyValue $pgPass
+    $pgedgeObj | Add-Member -NotePropertyName "env" -NotePropertyValue $envObj
+
+    $config = $null
+    if (Test-Path $configFile) {
+        try {
+            $raw = Get-Content $configFile -Raw
+            $config = $raw | ConvertFrom-Json
+        } catch {
+            Write-Warn "Claude Desktop config ($configFile) contains invalid JSON — skipping to avoid overwriting."
+            return
+        }
+    }
+
+    if (-not $config) {
+        $config = New-Object PSObject
+    }
+
+    if (-not $config.mcpServers) {
+        $config | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue (New-Object PSObject) -Force
+    }
+
+    if ($config.mcpServers.PSObject.Properties["pgedge"]) {
+        $config.mcpServers.pgedge = $pgedgeObj
+    } else {
+        $config.mcpServers | Add-Member -NotePropertyName "pgedge" -NotePropertyValue $pgedgeObj
+    }
+
+    New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+    $config | ConvertTo-Json -Depth 10 | Set-Content $configFile -Encoding UTF8
+
+    Write-Ok "Claude Desktop: configured (restart Claude Desktop to activate)"
+}
+
+# --- Summary --------------------------------------------------------------
+
+function Write-Summary {
+    Write-Host ""
+    Write-Host (([string][char]0x2550) * 54) # horizontal double line
+    Write-Host "  Installation complete!"
+    Write-Host (([string][char]0x2550) * 54)
+    Write-Host ""
+    Write-Host "  Binary:   $(Join-Path $BinDir 'pgedge-postgres-mcp.exe')"
+
+    if ($script:DbConfigured) {
+        Write-Host "  Database: $($script:DbName) on $($script:DbHost):$($script:DbPort) ($($script:DbUser))"
+        Write-Host ""
+        Write-Host "  Try asking Claude:"
+        Write-Host '    "What tables are in my database?"'
+        Write-Host '    "Show me the top 10 products by sales"'
+        Write-Host '    "Which customers have placed more than 5 orders?"'
+    } else {
+        Write-Host "  Database: not yet configured"
+        Write-Host ""
+        Write-Host "  To configure later, edit:"
+        Write-Host "    Claude Code:    ~/.claude.json"
+        Write-Host "    Claude Desktop: $env:APPDATA\Claude\claude_desktop_config.json"
+    }
+
+    Write-Host ""
+    Write-Host "  Claude Code:    ready - start a new conversation"
+    Write-Host "  Claude Desktop: restart the app, then start chatting"
+    Write-Host ""
+    Write-Host (([string][char]0x2550) * 54)
+    Write-Host ""
+}
+
+# --- Main -----------------------------------------------------------------
+
+function Main {
+    Write-Host ""
+    Write-Host (([string][char]0x2550) * 54)
+    Write-Host "  pgEdge MCP Server - Installer"
+    Write-Host (([string][char]0x2550) * 54)
+    Write-Host ""
+    Write-Host "  This will install the pgEdge MCP Server so you can"
+    Write-Host "  query PostgreSQL databases using natural language"
+    Write-Host "  in Claude Code or Claude Desktop."
+    Write-Host ""
+
+    $script:DbConfigured = $false
+
+    Get-Platform
+    Get-LatestVersion
+    Install-Binary
+
+    Write-Host ""
+    Select-Database
+
+    Write-Host ""
+    Set-ClaudeCodeConfig
+    Set-ClaudeDesktopConfig
+
+    Write-Summary
+}
+
+Main

--- a/examples/claude-try-it/install.sh
+++ b/examples/claude-try-it/install.sh
@@ -11,7 +11,7 @@
 # What it does:
 #   1. Downloads the pgEdge MCP Server binary for your platform
 #   2. Helps you connect to a database (your own or a demo with sample data)
-#   3. Configures Claude Code (.mcp.json) and/or Claude Desktop
+#   3. Configures Claude Code (.claude.json) and/or Claude Desktop
 #
 set -eo pipefail
 
@@ -538,7 +538,7 @@ verify_own_db_connection() {
       setup_own_database
       return
       ;;
-    *) warn "Continuing — you can update .mcp.json later with the correct details." ;;
+    *) warn "Continuing — you can update ~/.claude.json later with the correct details." ;;
   esac
 }
 

--- a/examples/claude-try-it/install.sh
+++ b/examples/claude-try-it/install.sh
@@ -1,0 +1,788 @@
+#!/bin/bash
+# pgEdge MCP Server — one-command installer
+#
+# Usage (interactive, in a terminal):
+#   curl -fsSL https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/claude-try-it/install.sh | bash
+#
+# Usage (non-interactive, via Claude Code):
+#   curl -fsSL .../install.sh | bash -s -- --demo
+#   curl -fsSL .../install.sh | bash -s -- --db-host=localhost --db-port=5432 --db-name=mydb --db-user=me --db-pass=secret
+#
+# What it does:
+#   1. Downloads the pgEdge MCP Server binary for your platform
+#   2. Helps you connect to a database (your own or a demo with sample data)
+#   3. Configures Claude Code (.mcp.json) and/or Claude Desktop
+#
+set -eo pipefail
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+
+INSTALL_DIR="$HOME/.pgedge"
+BIN_DIR="$INSTALL_DIR/bin"
+DEMO_DIR="$INSTALL_DIR/demo"
+REPO="pgEdge/pgedge-postgres-mcp"
+DEMO_PORT=5432
+
+# ─── Parse flags (for non-interactive / Claude Code usage) ───────────────────
+
+MODE=""
+DB_HOST="" DB_PORT="" DB_NAME="" DB_USER="" DB_PASS=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --demo)          MODE="demo" ;;
+    --own-db)        MODE="own" ;;
+    --db-host=*)     DB_HOST="${arg#*=}" ;;
+    --db-port=*)     DB_PORT="${arg#*=}" ;;
+    --db-name=*)     DB_NAME="${arg#*=}" ;;
+    --db-user=*)     DB_USER="${arg#*=}" ;;
+    --db-pass=*)     DB_PASS="${arg#*=}" ;;
+    --install-docker) MODE="install-docker" ;;
+  esac
+done
+
+# ─── Helper functions ────────────────────────────────────────────────────────
+
+info()  { echo "  ℹ  $*"; }
+ok()    { echo "  ✓  $*"; }
+warn()  { echo "  ⚠  $*"; }
+fail()  { echo "  ✗  $*" >&2; exit 1; }
+
+# Read from /dev/tty if available (works even when script is piped from curl)
+ask() {
+  local prompt="$1" var="$2"
+  if [ -t 0 ] || [ -e /dev/tty ]; then
+    # shellcheck disable=SC2229
+    read -r -p "$prompt" "$var" < /dev/tty
+  else
+    # Non-interactive — return empty (caller handles default)
+    eval "$var=''"
+  fi
+}
+
+# Like ask() but hides input (for passwords)
+ask_secret() {
+  local prompt="$1" var="$2"
+  if [ -t 0 ] || [ -e /dev/tty ]; then
+    # shellcheck disable=SC2229
+    read -s -r -p "$prompt" "$var" < /dev/tty
+    echo >&2  # newline after silent input
+  else
+    eval "$var=''"
+  fi
+}
+
+has_tty() {
+  [ -t 0 ] || [ -e /dev/tty ]
+}
+
+# ─── Detect platform ────────────────────────────────────────────────────────
+
+detect_platform() {
+  case "$(uname -s)" in
+    Darwin) OS="darwin" ;;
+    Linux)  OS="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
+    *) fail "Unsupported operating system: $(uname -s)" ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64)  ARCH="x86_64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *) fail "Unsupported architecture: $(uname -m)" ;;
+  esac
+
+  if [ "$OS" = "windows" ]; then EXT="zip"; else EXT="tar.gz"; fi
+}
+
+# ─── Get latest release version ─────────────────────────────────────────────
+
+get_latest_version() {
+  local response
+  response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest") \
+    || fail "Could not fetch latest release from GitHub (network error or rate limit)"
+  VERSION=$(echo "$response" | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4) || true
+  [ -z "$VERSION" ] && fail "Could not determine latest release version"
+  VERSION_NUM="${VERSION#v}"
+}
+
+# ─── Download and install binary ────────────────────────────────────────────
+
+download_binary() {
+  local asset_name="pgedge-postgres-mcp-server_${VERSION_NUM}_${OS}_${ARCH}.${EXT}"
+  local url="https://github.com/$REPO/releases/download/$VERSION/$asset_name"
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+
+  info "Downloading pgEdge MCP Server $VERSION ($OS/$ARCH)..."
+
+  curl -fsSL -o "$tmp_dir/$asset_name" "$url" \
+    || fail "Download failed. Check your internet connection."
+
+  mkdir -p "$BIN_DIR"
+
+  if [ "$EXT" = "zip" ]; then
+    unzip -qo "$tmp_dir/$asset_name" -d "$tmp_dir/extracted"
+  else
+    mkdir -p "$tmp_dir/extracted"
+    tar xzf "$tmp_dir/$asset_name" -C "$tmp_dir/extracted"
+  fi
+
+  # Find the binary in the extracted archive (may be in a subdirectory)
+  local binary
+  binary=$(find "$tmp_dir/extracted" -name "pgedge-postgres-mcp" -type f | head -1)
+  if [ -z "$binary" ]; then
+    binary=$(find "$tmp_dir/extracted" -name "pgedge-postgres-mcp*" -type f | head -1)
+  fi
+  [ -z "$binary" ] && fail "Binary not found in archive"
+
+  cp "$binary" "$BIN_DIR/pgedge-postgres-mcp"
+  chmod +x "$BIN_DIR/pgedge-postgres-mcp"
+  rm -rf "$tmp_dir"
+
+  ok "Binary installed: $BIN_DIR/pgedge-postgres-mcp"
+}
+
+# ─── Docker detection and installation ──────────────────────────────────────
+
+docker_installed() {
+  command -v docker &>/dev/null
+}
+
+docker_running() {
+  docker info >/dev/null 2>&1
+}
+
+install_docker() {
+  echo ""
+  info "Installing Docker..."
+  echo ""
+
+  case "$OS" in
+    darwin)
+      if command -v brew &>/dev/null; then
+        info "Installing Docker Desktop via Homebrew (this may take a few minutes)..."
+        brew install --cask docker
+        info "Docker Desktop installed. Please open Docker Desktop from"
+        info "your Applications folder, wait for it to start, then re-run"
+        info "this installer."
+        exit 0
+      else
+        echo ""
+        echo "  Docker Desktop needs to be installed manually on macOS."
+        echo ""
+        echo "  1. Download it from: https://www.docker.com/products/docker-desktop/"
+        echo "  2. Open the .dmg and drag Docker to Applications"
+        echo "  3. Launch Docker Desktop and wait for it to start"
+        echo "  4. Re-run this installer"
+        echo ""
+        exit 0
+      fi
+      ;;
+    linux)
+      info "Installing Docker Engine..."
+      curl -fsSL https://get.docker.com | sh || true
+      if docker_installed && docker_running; then
+        ok "Docker installed successfully"
+      else
+        warn "Docker installed but may need a logout/login to take effect."
+        warn "Try: sudo usermod -aG docker \$USER && newgrp docker"
+        warn "Then re-run this installer."
+        exit 0
+      fi
+      ;;
+    *)
+      echo "  Please install Docker Desktop from: https://www.docker.com/products/docker-desktop/"
+      exit 0
+      ;;
+  esac
+}
+
+# ─── Database choice ────────────────────────────────────────────────────────
+
+choose_database() {
+  # If mode was set via flags, skip prompts
+  if [ "$MODE" = "demo" ]; then
+    setup_demo_database
+    return
+  fi
+
+  if [ "$MODE" = "own" ]; then
+    setup_own_database
+    return
+  fi
+
+  if [ "$MODE" = "install-docker" ]; then
+    install_docker
+    setup_demo_database
+    return
+  fi
+
+  # Non-interactive (Claude Code without flags) — output choices for Claude
+  if ! has_tty; then
+    echo ""
+    echo "DATABASE_CHOICE_NEEDED"
+    echo "The MCP server needs a PostgreSQL database to connect to."
+    echo "Options:"
+    echo "  1. Demo database — sample Northwind data, requires Docker"
+    echo "  2. Your own database — provide connection details"
+    echo ""
+    echo "Re-run with flags:"
+    echo "  --demo                              (start demo database with Docker)"
+    echo "  --install-docker                    (install Docker first, then demo)"
+    echo "  --own-db --db-host=HOST --db-port=PORT --db-name=DB --db-user=USER --db-pass=PASS"
+    echo ""
+    DB_CONFIGURED=false
+    return
+  fi
+
+  # Interactive (human in terminal)
+  echo ""
+  echo "  The MCP server needs a PostgreSQL database to connect to."
+  echo ""
+  echo "  Which would you like?"
+  echo ""
+  echo "    1) Load a sample database (Northwind — customers, orders, products)"
+  echo "       Requires Docker. Great for trying things out."
+  echo ""
+  echo "    2) Connect to my own PostgreSQL database"
+  echo "       You'll provide the connection details."
+  echo ""
+
+  local choice
+  ask "  Enter 1 or 2: " choice
+
+  case "$choice" in
+    1) setup_demo_database ;;
+    2) setup_own_database ;;
+    *) info "Defaulting to sample database..."; setup_demo_database ;;
+  esac
+}
+
+# ─── Demo database setup ────────────────────────────────────────────────────
+
+setup_demo_database() {
+  if docker_installed && docker_running; then
+    start_demo_postgres
+    return
+  fi
+
+  # Docker installed but not running
+  if docker_installed; then
+    echo ""
+    warn "Docker is installed but not running."
+    echo ""
+    echo "  Please start Docker Desktop and wait for it to finish starting,"
+    echo "  then re-run this installer."
+    echo ""
+
+    if ! has_tty; then
+      echo "DOCKER_NOT_RUNNING"
+      echo "Start Docker Desktop, then re-run with: --demo"
+      DB_CONFIGURED=false
+      return
+    fi
+
+    echo "  Options:"
+    echo ""
+    echo "    1) I'll start Docker Desktop and re-run this later"
+    echo "    2) Connect to my own database instead"
+    echo ""
+
+    local choice
+    ask "  Enter 1 or 2: " choice
+
+    case "$choice" in
+      2) setup_own_database ;;
+      *)
+        echo ""
+        echo "  Start Docker Desktop, wait for it to finish starting,"
+        echo "  then re-run this installer."
+        echo ""
+        DB_CONFIGURED=false
+        ;;
+    esac
+    return
+  fi
+
+  # Docker not installed at all
+  echo ""
+  warn "Docker is not installed."
+  echo ""
+  echo "  The sample database runs in a Docker container."
+  echo "  Docker Desktop is free and takes about 5 minutes to install."
+  echo ""
+
+  if ! has_tty; then
+    echo "DOCKER_NOT_FOUND"
+    echo "To install Docker and set up the demo, re-run with: --install-docker"
+    echo "To skip the demo and use your own database, re-run with: --own-db --db-host=... --db-port=... --db-name=... --db-user=... --db-pass=..."
+    DB_CONFIGURED=false
+    return
+  fi
+
+  echo "  Would you like me to install Docker for you?"
+  echo ""
+  echo "    1) Yes, install Docker"
+  echo "    2) No, I'll connect to my own database instead"
+  echo "    3) No, I'll install Docker myself and re-run this later"
+  echo ""
+
+  local choice
+  ask "  Enter 1, 2, or 3: " choice
+
+  case "$choice" in
+    1) install_docker; start_demo_postgres ;;
+    2) setup_own_database ;;
+    *)
+      echo ""
+      echo "  To install Docker Desktop:"
+      echo "    https://www.docker.com/products/docker-desktop/"
+      echo ""
+      echo "  After installing, re-run this command:"
+      echo "    curl -fsSL https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/claude-try-it/install.sh | bash"
+      echo ""
+      DB_CONFIGURED=false
+      ;;
+  esac
+}
+
+# ─── Find a free port ────────────────────────────────────────────────────────
+
+find_free_port() {
+  # Try preferred ports in order: 5432, 5433, 5434, 5435, 5436
+  for port in 5432 5433 5434 5435 5436; do
+    if ! lsof -i ":$port" >/dev/null 2>&1; then
+      echo "$port"
+      return
+    fi
+  done
+  # Last resort: let the OS pick
+  python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()" 2>/dev/null \
+    || echo "0"
+}
+
+# ─── Clean up old demo containers ─────────────────────────────────────────
+
+cleanup_old_demos() {
+  local old
+  for old in $(docker ps -a --filter "name=pgedge-demo-" \
+               --format '{{.Names}}' 2>/dev/null); do
+    info "Removing old demo container: $old"
+    docker stop "$old" 2>/dev/null || true
+    docker rm -v "$old" 2>/dev/null || true
+  done
+}
+
+# ─── Start demo Postgres container ──────────────────────────────────────────
+
+start_demo_postgres() {
+  # Clean up any old demo containers from previous installs
+  cleanup_old_demos
+
+  # Generate a unique container name for this run
+  CONTAINER_NAME="pgedge-demo-$(date +%s)"
+
+  # Find a free port
+  DEMO_PORT=$(find_free_port)
+  if [ "$DEMO_PORT" = "0" ]; then
+    warn "Could not find a free port for the demo database."
+    DB_CONFIGURED=false
+    return
+  fi
+
+  if [ "$DEMO_PORT" != "5432" ]; then
+    info "Port 5432 is in use (probably an existing Postgres instance)."
+    info "Using port $DEMO_PORT for the demo database instead."
+  fi
+
+  mkdir -p "$DEMO_DIR"
+
+  # Write docker-compose with port and container name substituted via bash
+  # (avoids sed cross-platform issues)
+  COMPOSE_CONTENT=$(cat << 'COMPOSE'
+services:
+  postgres:
+    image: ghcr.io/pgedge/pgedge-postgres:17-spock5-standard
+    container_name: PGEDGE_CONTAINER_NAME
+    command: postgres -c listen_addresses='*' -c shared_preload_libraries='pg_stat_statements'
+    environment:
+      POSTGRES_USER: demo
+      POSTGRES_PASSWORD: demo123
+      POSTGRES_DB: northwind
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    configs:
+      - source: load-northwind
+        target: /docker-entrypoint-initdb.d/01-load-northwind.sh
+        mode: 0755
+      - source: enable-extensions
+        target: /docker-entrypoint-initdb.d/02-enable-extensions.sh
+        mode: 0755
+    ports:
+      - "PGEDGE_HOST_PORT:5432"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U demo -d northwind"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+volumes:
+  pgdata:
+    driver: local
+
+configs:
+  load-northwind:
+    content: |-
+      #!/usr/bin/env bash
+      set -e
+      echo "Loading Northwind dataset..."
+      curl -fsSL -o /tmp/northwind.sql https://downloads.pgedge.com/platform/examples/northwind/northwind.sql
+      psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" -f /tmp/northwind.sql
+      rm -f /tmp/northwind.sql
+      echo "Northwind dataset loaded"
+  enable-extensions:
+    content: |-
+      #!/usr/bin/env bash
+      set -e
+      psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" \
+        -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
+      echo "Extensions enabled"
+COMPOSE
+)
+  local composed="${COMPOSE_CONTENT//PGEDGE_HOST_PORT/$DEMO_PORT}"
+  echo "${composed//PGEDGE_CONTAINER_NAME/$CONTAINER_NAME}" > "$DEMO_DIR/docker-compose.yml"
+
+  echo ""
+  info "Starting demo Postgres ($CONTAINER_NAME) with Northwind sample data on port $DEMO_PORT..."
+  info "(first run downloads the image — this may take a minute)"
+  echo ""
+
+  docker compose -f "$DEMO_DIR/docker-compose.yml" up -d 2>/dev/null \
+    || docker-compose -f "$DEMO_DIR/docker-compose.yml" up -d 2>/dev/null \
+    || { warn "Failed to start demo database."; DB_CONFIGURED=false; return; }
+
+  info "Waiting for database to be ready..."
+  for _ in $(seq 1 24); do
+    if docker exec "$CONTAINER_NAME" pg_isready -U demo -d northwind >/dev/null 2>&1; then
+      ok "Demo database ready (northwind on localhost:$DEMO_PORT, container: $CONTAINER_NAME)"
+      DB_HOST="localhost"; DB_PORT="$DEMO_PORT"; DB_NAME="northwind"
+      DB_USER="demo"; DB_PASS="demo123"; DB_CONFIGURED=true
+      return
+    fi
+    sleep 5
+  done
+
+  warn "Database is still starting. It may need another minute."
+  DB_HOST="localhost"; DB_PORT="$DEMO_PORT"; DB_NAME="northwind"
+  DB_USER="demo"; DB_PASS="demo123"; DB_CONFIGURED=true
+}
+
+# ─── Database connection test ───────────────────────────────────────────────
+
+test_db_connection() {
+  local host="$1" port="$2"
+  # Try pg_isready first (most reliable)
+  if command -v pg_isready &>/dev/null; then
+    if pg_isready -h "$host" -p "$port" -t 3 >/dev/null 2>&1; then
+      return 0
+    fi
+    return 1
+  fi
+  # Fallback: TCP connect via /dev/tcp (bash built-in)
+  if (echo >/dev/tcp/"$host"/"$port") 2>/dev/null; then
+    return 0
+  fi
+  # Fallback: nc/netcat
+  if command -v nc &>/dev/null; then
+    if nc -z -w 3 "$host" "$port" 2>/dev/null; then
+      return 0
+    fi
+    return 1
+  fi
+  # No way to test — assume OK
+  return 0
+}
+
+verify_own_db_connection() {
+  info "Testing connection to $DB_HOST:$DB_PORT..."
+  if test_db_connection "$DB_HOST" "$DB_PORT"; then
+    ok "Connection to $DB_HOST:$DB_PORT succeeded"
+    return
+  fi
+
+  echo ""
+  warn "Could not reach $DB_HOST:$DB_PORT (TCP connection failed)"
+  echo ""
+
+  if ! has_tty; then
+    warn "Continuing anyway — verify your connection details are correct."
+    return
+  fi
+
+  echo "  What would you like to do?"
+  echo ""
+  echo "    1) Re-enter connection details"
+  echo "    2) Continue anyway (I'll fix it later)"
+  echo ""
+
+  local choice
+  ask "  Enter 1 or 2: " choice
+
+  case "$choice" in
+    1)
+      # Clear previous values so setup_own_database re-prompts
+      DB_HOST="" DB_PORT="" DB_NAME="" DB_USER="" DB_PASS=""
+      setup_own_database
+      return
+      ;;
+    *) warn "Continuing — you can update .mcp.json later with the correct details." ;;
+  esac
+}
+
+# ─── Own database setup ─────────────────────────────────────────────────────
+
+setup_own_database() {
+  # If connection details were provided via flags
+  if [ -n "$DB_HOST" ] && [ -n "$DB_NAME" ] && [ -n "$DB_USER" ]; then
+    DB_PORT="${DB_PORT:-5432}"
+    DB_CONFIGURED=true
+    ok "Using database: $DB_NAME on $DB_HOST:$DB_PORT"
+    verify_own_db_connection
+    return
+  fi
+
+  if ! has_tty; then
+    echo ""
+    echo "OWN_DATABASE_CHOSEN"
+    echo "Re-run with connection details:"
+    echo "  --own-db --db-host=HOST --db-port=PORT --db-name=DB --db-user=USER --db-pass=PASS"
+    DB_CONFIGURED=false
+    return
+  fi
+
+  echo ""
+  echo "  Enter your PostgreSQL connection details:"
+  echo ""
+
+  ask "  Host [localhost]: " DB_HOST
+  DB_HOST="${DB_HOST:-localhost}"
+
+  ask "  Port [5432]: " DB_PORT
+  DB_PORT="${DB_PORT:-5432}"
+
+  ask "  Database name: " DB_NAME
+  [ -z "$DB_NAME" ] && { warn "Database name is required."; DB_CONFIGURED=false; return; }
+
+  ask "  Username: " DB_USER
+  [ -z "$DB_USER" ] && { warn "Username is required."; DB_CONFIGURED=false; return; }
+
+  ask_secret "  Password: " DB_PASS
+
+  DB_CONFIGURED=true
+  ok "Using database: $DB_NAME on $DB_HOST:$DB_PORT"
+  verify_own_db_connection
+}
+
+# ─── JSON helper ───────────────────────────────────────────────────────────
+
+# Escape a string for safe embedding in JSON (handles \, ", control chars)
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"    # \ → \\  (must be first)
+  s="${s//\"/\\\"}"    # " → \"
+  s="${s//$'\n'/\\n}"  # newline → \n
+  s="${s//$'\r'/\\r}"  # carriage return → \r
+  s="${s//$'\t'/\\t}"  # tab → \t
+  printf '%s' "$s"
+}
+
+# Write pgedge MCP config into a JSON file using python3 (safe for all values).
+# Usage: write_mcp_config <config_file> <binary_path> [merge]
+# If "merge" is passed and the file exists, merges into existing mcpServers.
+write_mcp_config() {
+  local config_file="$1" binary_path="$2" merge="${3:-}"
+
+  if command -v python3 &>/dev/null; then
+    # Pass values via environment to avoid any shell/python injection
+    _MCP_FILE="$config_file" \
+    _MCP_CMD="$binary_path" \
+    _MCP_HOST="${DB_HOST:-localhost}" \
+    _MCP_PORT="${DB_PORT:-5432}" \
+    _MCP_DB="${DB_NAME:-your_database}" \
+    _MCP_USER="${DB_USER:-your_user}" \
+    _MCP_PASS="${DB_PASS:-your_password}" \
+    _MCP_MERGE="$merge" \
+    python3 -c '
+import json, os, shutil, sys
+
+config_file = os.environ["_MCP_FILE"]
+merge = os.environ.get("_MCP_MERGE") == "merge"
+
+config = {}
+if merge:
+    try:
+        with open(config_file) as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        pass
+    except (json.JSONDecodeError, ValueError) as e:
+        backup = config_file + ".bak"
+        shutil.copy2(config_file, backup)
+        print(f"Warning: invalid JSON in {config_file}; backed up to {backup}", file=sys.stderr)
+
+if "mcpServers" not in config:
+    config["mcpServers"] = {}
+
+config["mcpServers"]["pgedge"] = {
+    "command": os.environ["_MCP_CMD"],
+    "env": {
+        "PGHOST":     os.environ["_MCP_HOST"],
+        "PGPORT":     os.environ["_MCP_PORT"],
+        "PGDATABASE": os.environ["_MCP_DB"],
+        "PGUSER":     os.environ["_MCP_USER"],
+        "PGPASSWORD": os.environ["_MCP_PASS"],
+    }
+}
+
+with open(config_file, "w") as f:
+    json.dump(config, f, indent=2)
+os.chmod(config_file, 0o600)
+' && return 0
+    # python3 failed — fall through to manual JSON fallback
+  fi
+
+  # Fallback: no python3 — build JSON with escaped values
+  if [ "$merge" = "merge" ] && [ -f "$config_file" ]; then
+    warn "python3 not found — cannot safely merge into existing $config_file."
+    warn "Install python3 and re-run to update this config."
+    return 1
+  fi
+
+  local j_cmd j_host j_port j_db j_user j_pass
+  j_cmd=$(json_escape "$binary_path")
+  j_host=$(json_escape "${DB_HOST:-localhost}")
+  j_port=$(json_escape "${DB_PORT:-5432}")
+  j_db=$(json_escape "${DB_NAME:-your_database}")
+  j_user=$(json_escape "${DB_USER:-your_user}")
+  j_pass=$(json_escape "${DB_PASS:-your_password}")
+
+  printf '{\n  "mcpServers": {\n    "pgedge": {\n      "command": "%s",\n      "env": {\n        "PGHOST": "%s",\n        "PGPORT": "%s",\n        "PGDATABASE": "%s",\n        "PGUSER": "%s",\n        "PGPASSWORD": "%s"\n      }\n    }\n  }\n}\n' \
+    "$j_cmd" "$j_host" "$j_port" "$j_db" "$j_user" "$j_pass" > "$config_file"
+  chmod 600 "$config_file"
+  return 0
+}
+
+# ─── Configure Claude Code ──────────────────────────────────────────────────
+
+configure_claude_code() {
+  local mcp_json="$HOME/.claude.json"
+  local binary_path="$BIN_DIR/pgedge-postgres-mcp"
+
+  # Always merge — user-level config may have other MCP servers
+  if write_mcp_config "$mcp_json" "$binary_path" "merge"; then
+    ok "Claude Code: configured in ~/.claude.json (available in all projects)"
+  else
+    warn "Could not write $mcp_json"
+  fi
+}
+
+# ─── Configure Claude Desktop ───────────────────────────────────────────────
+
+configure_claude_desktop() {
+  local config_file binary_path="$BIN_DIR/pgedge-postgres-mcp"
+
+  case "$OS" in
+    darwin) config_file="$HOME/Library/Application Support/Claude/claude_desktop_config.json" ;;
+    linux)  config_file="$HOME/.config/Claude/claude_desktop_config.json" ;;
+    *)      return ;;
+  esac
+
+  local config_dir
+  config_dir=$(dirname "$config_file")
+  if [ ! -d "$config_dir" ]; then
+    info "Claude Desktop not detected — skipping config"
+    return
+  fi
+
+  # Always merge — Claude Desktop config may have other MCP servers
+  if write_mcp_config "$config_file" "$binary_path" "merge"; then
+    ok "Claude Desktop: configured (restart Claude Desktop to activate)"
+  else
+    warn "Could not write Claude Desktop config"
+  fi
+}
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+print_summary() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Installation complete!"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "  Binary:   $BIN_DIR/pgedge-postgres-mcp"
+
+  if [ "$DB_CONFIGURED" = true ]; then
+    echo "  Database: $DB_NAME on $DB_HOST:$DB_PORT ($DB_USER)"
+    echo ""
+    echo "  Try asking Claude:"
+    echo "    \"What tables are in my database?\""
+    echo "    \"Show me the top 10 products by sales\""
+    echo "    \"Which customers have placed more than 5 orders?\""
+  else
+    echo "  Database: not yet configured"
+    echo ""
+    local desktop_config_path
+    if [ "$OS" = "linux" ]; then
+      # shellcheck disable=SC2088  # intentional literal ~ for display
+      desktop_config_path="~/.config/Claude/claude_desktop_config.json"
+    else
+      # shellcheck disable=SC2088  # intentional literal ~ for display
+      desktop_config_path="~/Library/Application Support/Claude/claude_desktop_config.json"
+    fi
+    echo "  To configure later, edit:"
+    echo "    Claude Code:    ~/.claude.json"
+    echo "    Claude Desktop: $desktop_config_path"
+  fi
+
+  echo ""
+  echo "  Claude Code:    ready — start a new conversation"
+  echo "  Claude Desktop: restart the app, then start chatting"
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  pgEdge MCP Server — Installer"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "  This will install the pgEdge MCP Server so you can"
+  echo "  query PostgreSQL databases using natural language"
+  echo "  in Claude Code or Claude Desktop."
+  echo ""
+
+  DB_CONFIGURED=false
+
+  detect_platform
+  get_latest_version
+  download_binary
+
+  echo ""
+  choose_database
+
+  echo ""
+  configure_claude_code
+  configure_claude_desktop
+
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add cross-platform installer scripts (`examples/claude-try-it/`) that
  download the pgEdge MCP Server binary and configure it for Claude Code
  and Claude Desktop.
- `install.sh` covers macOS and Linux with optional Docker demo database.
- `install.ps1` covers Windows PowerShell (5.1+) with Docker Desktop
  support.
- Both scripts support interactive and non-interactive (flag-driven)
  modes for use by humans and by Claude Code agents respectively.

## Test plan

- [ ] Run `install.sh --demo` on macOS with Docker running
- [ ] Run `install.sh --own-db --db-host=... ...` on Linux
- [ ] Run `install.ps1 -Demo` on Windows with Docker Desktop
- [ ] Run `install.ps1 -OwnDb -DbHost ... ...` on Windows
- [ ] Verify non-interactive mode outputs correct flag instructions
- [ ] Verify `~/.claude.json` is correctly written/merged
- [ ] Verify Claude Desktop config is correctly written/merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added interactive installer scripts for pgEdge MCP Server on Windows, macOS, and Linux
* Automated installation with platform-specific binary detection and deployment
* Optional Docker-based PostgreSQL demo database with automatic setup and health checks
* Support for existing PostgreSQL databases with connection validation
* Seamless Claude Code and Claude Desktop configuration with pre-configured environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->