### PR TITLE
feat: add GitHub Codespaces demo environment

### DIFF
--- a/.devcontainer/demo/devcontainer.json
+++ b/.devcontainer/demo/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "pgEdge MCP Server Demo",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "forwardPorts": [8081, 8080],
+  "portsAttributes": {
+    "8081": {
+      "label": "pgEdge Web UI",
+      "onAutoForward": "silent"
+    },
+    "8080": {
+      "label": "MCP Server API",
+      "onAutoForward": "silent"
+    }
+  },
+  "onCreateCommand": "if [ ! -f examples/codespaces-demo/.env ]; then cp examples/codespaces-demo/.env.example examples/codespaces-demo/.env; fi",
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "examples/codespaces-demo/README.md"
+      ]
+    },
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "workbench.startupEditor": "none"
+      }
+    }
+  }
+}

--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "pgEdge MCP Server — Development",
+  "image": "mcr.microsoft.com/devcontainers/go:1.24",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["golang.go"]
+    }
+  },
+  "postCreateCommand": "go mod download && cd web && npm ci"
+}

--- a/examples/codespaces-demo/.env.example
+++ b/examples/codespaces-demo/.env.example
@@ -1,0 +1,69 @@
+# =============================================================================
+# pgEdge AIT Quickstart - Environment Configuration
+# =============================================================================
+# Copy this file to .env and customize as needed
+#
+# Quick Start:
+# 1. cp .env.example .env
+# 2. Add your LLM API key below (REQUIRED)
+# 3. docker compose up
+#
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# LLM API KEYS (REQUIRED - choose one or both)
+# -----------------------------------------------------------------------------
+# Anthropic API key for Claude models
+# Get your key from: https://console.anthropic.com/
+PGEDGE_ANTHROPIC_API_KEY=
+
+# OpenAI API key for GPT models
+# Get your key from: https://platform.openai.com/
+PGEDGE_OPENAI_API_KEY=
+
+# -----------------------------------------------------------------------------
+# LLM CONFIGURATION (Optional - defaults provided)
+# -----------------------------------------------------------------------------
+# Provider: anthropic or openai
+PGEDGE_LLM_PROVIDER=anthropic
+
+# Model name
+# Anthropic: claude-sonnet-4-5, claude-opus-4-5, etc.
+# OpenAI: gpt-4o, gpt-4-turbo, etc.
+PGEDGE_LLM_MODEL=claude-sonnet-4-5
+
+# Embedding provider and model (for semantic search)
+PGEDGE_EMBEDDING_PROVIDER=anthropic
+PGEDGE_EMBEDDING_MODEL=voyage-3
+
+# -----------------------------------------------------------------------------
+# SERVICE PORTS (Optional - defaults provided)
+# -----------------------------------------------------------------------------
+# MCP Server HTTP API port
+MCP_SERVER_PORT=8080
+
+# Web Client UI port
+WEB_CLIENT_PORT=8081
+
+# -----------------------------------------------------------------------------
+# DEBUGGING (Optional - defaults to false/none)
+# -----------------------------------------------------------------------------
+# Enable debug output
+PGEDGE_DEBUG=false
+
+# Database operation logging: none, info, debug, trace
+PGEDGE_DB_LOG_LEVEL=none
+
+# LLM operation logging: none, info, debug, trace
+PGEDGE_LLM_LOG_LEVEL=none
+
+# -----------------------------------------------------------------------------
+# DEMO CREDENTIALS (Pre-configured - do not change)
+# -----------------------------------------------------------------------------
+# These credentials are pre-configured in docker-compose.yml
+# Username: demo
+# Password: demo123
+# Database: northwind
+#
+# To change these, edit docker-compose.yml directly
+# -----------------------------------------------------------------------------

--- a/examples/codespaces-demo/.env.example
+++ b/examples/codespaces-demo/.env.example
@@ -1,5 +1,5 @@
 # =============================================================================
-# pgEdge AIT Quickstart - Environment Configuration
+# pgEdge MCP Server Codespaces Demo - Environment Configuration
 # =============================================================================
 # Copy this file to .env and customize as needed
 #

--- a/examples/codespaces-demo/README.md
+++ b/examples/codespaces-demo/README.md
@@ -1,0 +1,77 @@
+# pgEdge MCP Server — Codespaces Demo
+
+Talk to a PostgreSQL database in plain English. This demo gives you
+a running pgEdge MCP Server with the Northwind sample database —
+ready to query in about 60 seconds.
+
+## Before you launch
+
+You'll need an API key from **Anthropic** or **OpenAI** (or both).
+
+For the most secure setup, add your key as a
+[Codespace secret](https://github.com/settings/codespaces) before
+launching:
+
+| Secret name | Where to get a key |
+|---|---|
+| `PGEDGE_ANTHROPIC_API_KEY` | [console.anthropic.com](https://console.anthropic.com/) |
+| `PGEDGE_OPENAI_API_KEY` | [platform.openai.com](https://platform.openai.com/) |
+
+> Your key is encrypted by GitHub. When the demo starts, it is
+> written to a `.env` file inside your private Codespace VM.
+
+Then click **Open in Codespaces** from the repo page.
+
+## Getting started
+
+1. Open the **Terminal** in the bottom pane
+2. Run:
+
+   ```bash
+   ./examples/codespaces-demo/start.sh
+   ```
+
+3. If you didn't set a Codespace secret, the script will prompt
+   you to paste your API key (hidden input, like a password)
+4. Wait ~60 seconds for services to start
+5. The Web UI opens automatically — log in with `demo` / `demo123`
+
+## Try these queries
+
+- "What tables are in the database?"
+- "Show me the top 10 products by sales"
+- "Which customers have placed more than 5 orders?"
+- "Analyze order trends by month"
+- "Show me the slowest queries from pg_stat_statements"
+
+## What's inside
+
+| Component | Details |
+|-----------|---------|
+| PostgreSQL 17 | pgEdge Enterprise with Spock, pg_stat_statements |
+| Northwind dataset | Customers, orders, products (13 tables, ~1000 rows) |
+| pgEdge MCP Server | Natural language to SQL, read-only queries |
+| Web UI | Chat interface on port 8081 |
+
+## Managing the demo
+
+```bash
+docker compose -f examples/codespaces-demo/docker-compose.yml logs -f    # View logs
+docker compose -f examples/codespaces-demo/docker-compose.yml restart    # Restart
+docker compose -f examples/codespaces-demo/docker-compose.yml down       # Stop
+docker compose -f examples/codespaces-demo/docker-compose.yml down -v    # Stop + reset data
+```
+
+## Your API key stays private
+
+Your key is stored as a Codespace secret (encrypted by GitHub) or
+in a `.env` file inside your personal Codespace — a private,
+ephemeral VM that only you can access. The key passes directly to
+the LLM provider. **pgEdge never receives, stores, or proxies your
+API key.** When you delete the Codespace, everything is deleted.
+
+## Learn more
+
+- [pgEdge MCP Server](https://github.com/pgEdge/pgedge-postgres-mcp)
+- [pgEdge docs](https://docs.pgedge.com)
+- [pgEdge website](https://www.pgedge.com)

--- a/examples/codespaces-demo/docker-compose.yml
+++ b/examples/codespaces-demo/docker-compose.yml
@@ -1,0 +1,138 @@
+services:
+    # PostgreSQL service
+    postgres:
+        image: ghcr.io/pgedge/pgedge-postgres:17-spock5-standard
+        container_name: pgedge-quickstart-db
+        command: postgres -c listen_addresses='*' -c shared_preload_libraries='pg_stat_statements'
+        environment:
+            POSTGRES_USER: demo
+            POSTGRES_PASSWORD: demo123
+            POSTGRES_DB: northwind
+        volumes:
+            - postgres-data:/var/lib/postgresql/data
+        configs:
+            - source: load-northwind
+              target: /docker-entrypoint-initdb.d/01-load-northwind.sh
+              mode: 0755
+            - source: enable-pg-stat-statements
+              target: /docker-entrypoint-initdb.d/02-enable-pg-stat-statements.sh
+              mode: 0755
+            - source: relax-pg-hba
+              target: /docker-entrypoint-initdb.d/03-relax-pg-hba.sh
+              mode: 0755
+        networks:
+            - pgedge-quickstart
+        restart: unless-stopped
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U demo -d northwind"]
+            interval: 5s
+            timeout: 5s
+            retries: 10
+            start_period: 30s
+
+    # MCP Server
+    postgres-mcp:
+        image: ghcr.io/pgedge/postgres-mcp:latest
+        container_name: pgedge-quickstart-mcp
+        depends_on:
+            postgres:
+                condition: service_healthy
+        environment:
+            # Database connection
+            PGEDGE_DB_HOST: postgres
+            PGEDGE_DB_PORT: 5432
+            PGEDGE_DB_NAME: northwind
+            PGEDGE_DB_USER: demo
+            PGEDGE_DB_PASSWORD: demo123
+            PGEDGE_DB_SSLMODE: disable
+            # Authentication (demo credentials)
+            INIT_USERS: demo:demo123
+            INIT_TOKENS: demo-token-12345
+            # LLM configuration (user must provide keys)
+            PGEDGE_LLM_ENABLED: ${PGEDGE_LLM_ENABLED:-true}
+            PGEDGE_LLM_PROVIDER: ${PGEDGE_LLM_PROVIDER:-anthropic}
+            PGEDGE_LLM_MODEL: ${PGEDGE_LLM_MODEL:-claude-sonnet-4-5}
+            PGEDGE_LLM_MAX_TOKENS: ${PGEDGE_LLM_MAX_TOKENS:-4096}
+            PGEDGE_LLM_TEMPERATURE: ${PGEDGE_LLM_TEMPERATURE:-0.7}
+            PGEDGE_ANTHROPIC_API_KEY: ${PGEDGE_ANTHROPIC_API_KEY}
+            PGEDGE_OPENAI_API_KEY: ${PGEDGE_OPENAI_API_KEY}
+            PGEDGE_OLLAMA_URL: ${PGEDGE_OLLAMA_URL:-}
+            # Custom base URLs (for proxies or self-hosted endpoints)
+            PGEDGE_ANTHROPIC_BASE_URL: ${PGEDGE_ANTHROPIC_BASE_URL:-}
+            PGEDGE_OPENAI_BASE_URL: ${PGEDGE_OPENAI_BASE_URL:-}
+            PGEDGE_VOYAGE_BASE_URL: ${PGEDGE_VOYAGE_BASE_URL:-}
+            # Embedding configuration
+            PGEDGE_EMBEDDING_PROVIDER: ${PGEDGE_EMBEDDING_PROVIDER:-anthropic}
+            PGEDGE_EMBEDDING_MODEL: ${PGEDGE_EMBEDDING_MODEL:-voyage-3}
+            # Debugging
+            PGEDGE_DEBUG: ${PGEDGE_DEBUG:-false}
+            PGEDGE_DB_LOG_LEVEL: ${PGEDGE_DB_LOG_LEVEL:-none}
+            PGEDGE_LLM_LOG_LEVEL: ${PGEDGE_LLM_LOG_LEVEL:-none}
+        volumes:
+            - mcp-data:/app/data
+        ports:
+            - "${MCP_SERVER_PORT:-8080}:8080"
+        networks:
+            - pgedge-quickstart
+        restart: unless-stopped
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 15s
+
+    # Web Client - MCP chat interface
+    web-client:
+        image: ghcr.io/pgedge/nla-web:latest
+        container_name: pgedge-quickstart-web
+        depends_on:
+            postgres-mcp:
+                condition: service_healthy
+        ports:
+            - "${WEB_CLIENT_PORT:-8081}:8081"
+        networks:
+            - pgedge-quickstart
+        restart: unless-stopped
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+
+volumes:
+    postgres-data:
+        driver: local
+    mcp-data:
+        driver: local
+
+networks:
+    pgedge-quickstart:
+        driver: bridge
+
+configs:
+    load-northwind:
+        content: |-
+            #!/usr/bin/env bash
+            set -e
+            echo "Loading Northwind dataset..."
+            curl -fsSL -o /tmp/northwind.sql https://downloads.pgedge.com/platform/examples/northwind/northwind.sql
+            psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" -f /tmp/northwind.sql
+            rm -f /tmp/northwind.sql
+            echo "Northwind dataset loaded"
+    enable-pg-stat-statements:
+        content: |-
+            #!/usr/bin/env bash
+            set -e
+            echo "Enabling pg_stat_statements..."
+            psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" \
+              -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
+            echo "pg_stat_statements enabled"
+    relax-pg-hba:
+        content: |-
+            #!/usr/bin/env bash
+            set -Eeo pipefail
+            # Network access is restricted to Docker network for security
+            # Users can connect from host using: docker exec -it pgedge-quickstart-db psql -U demo -d northwind
+            echo "PostgreSQL network access limited to Docker network"

--- a/examples/codespaces-demo/start.sh
+++ b/examples/codespaces-demo/start.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Starts the pgEdge MCP Server Codespaces demo.
+#
+# Usage (from repo root):
+#   ./examples/codespaces-demo/start.sh
+#
+# What it does:
+#   1. Checks for API keys (Codespace secrets → .env → interactive prompt)
+#   2. Starts PostgreSQL + MCP Server + Web Client via docker compose
+#   3. Waits for services to be healthy
+#   4. Prints the Web UI URL and login credentials
+set -e
+
+# Resolve paths relative to this script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+
+# Ensure .env exists
+if [ ! -f "$ENV_FILE" ]; then
+  cp "$SCRIPT_DIR/.env.example" "$ENV_FILE"
+fi
+
+MCP_PORT=$(grep '^MCP_SERVER_PORT=' "$ENV_FILE" 2>/dev/null | cut -d= -f2)
+MCP_PORT="${MCP_PORT:-8080}"
+WEB_PORT=$(grep '^WEB_CLIENT_PORT=' "$ENV_FILE" 2>/dev/null | cut -d= -f2)
+WEB_PORT="${WEB_PORT:-8081}"
+
+# ─── 1. Apply Codespace secrets to .env if present ─────────────────────────
+
+# Escape sed replacement metacharacters (& \ /) in a value
+escape_sed() { printf '%s' "$1" | sed 's/[&\\/]/\\&/g'; }
+
+if [ -n "$PGEDGE_ANTHROPIC_API_KEY" ]; then
+  ant_esc=$(escape_sed "$PGEDGE_ANTHROPIC_API_KEY")
+  sed -i "s/^PGEDGE_ANTHROPIC_API_KEY=.*/PGEDGE_ANTHROPIC_API_KEY=$ant_esc/" "$ENV_FILE"
+fi
+if [ -n "$PGEDGE_OPENAI_API_KEY" ]; then
+  oai_esc=$(escape_sed "$PGEDGE_OPENAI_API_KEY")
+  sed -i "s/^PGEDGE_OPENAI_API_KEY=.*/PGEDGE_OPENAI_API_KEY=$oai_esc/" "$ENV_FILE"
+  sed -i "s/^PGEDGE_LLM_PROVIDER=.*/PGEDGE_LLM_PROVIDER=openai/" "$ENV_FILE"
+  sed -i "s/^PGEDGE_LLM_MODEL=.*/PGEDGE_LLM_MODEL=gpt-4o/" "$ENV_FILE"
+fi
+
+# ─── 2. Check if any API key is configured ─────────────────────────────────
+
+ANT_KEY=$(grep '^PGEDGE_ANTHROPIC_API_KEY=' "$ENV_FILE" | cut -d= -f2-)
+OAI_KEY=$(grep '^PGEDGE_OPENAI_API_KEY=' "$ENV_FILE" | cut -d= -f2-)
+
+# ─── 3. If no key, prompt with hidden paste ────────────────────────────────
+
+if [ -z "$ANT_KEY" ] && [ -z "$OAI_KEY" ]; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  pgEdge MCP Server Demo — API Key Setup"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "  An LLM API key is required. Enter at least one below."
+  echo "  (Your input is hidden. Press Enter to skip a provider.)"
+  echo ""
+
+  # Anthropic
+  read -s -r -p "  Anthropic API key (Enter to skip): " ant_input < /dev/tty
+  echo ""
+  if [ -n "$ant_input" ]; then
+    ant_esc=$(escape_sed "$ant_input")
+    sed -i "s/^PGEDGE_ANTHROPIC_API_KEY=.*/PGEDGE_ANTHROPIC_API_KEY=$ant_esc/" "$ENV_FILE"
+    ANT_KEY="$ant_input"
+  fi
+
+  # OpenAI
+  read -s -r -p "  OpenAI API key (Enter to skip):    " oai_input < /dev/tty
+  echo ""
+  if [ -n "$oai_input" ]; then
+    oai_esc=$(escape_sed "$oai_input")
+    sed -i "s/^PGEDGE_OPENAI_API_KEY=.*/PGEDGE_OPENAI_API_KEY=$oai_esc/" "$ENV_FILE"
+    # If no Anthropic key, switch provider to OpenAI
+    if [ -z "$ANT_KEY" ]; then
+      sed -i "s/^PGEDGE_LLM_PROVIDER=.*/PGEDGE_LLM_PROVIDER=openai/" "$ENV_FILE"
+      sed -i "s/^PGEDGE_LLM_MODEL=.*/PGEDGE_LLM_MODEL=gpt-4o/" "$ENV_FILE"
+    fi
+    OAI_KEY="$oai_input"
+  fi
+
+  echo ""
+
+  # Still no key?
+  if [ -z "$ANT_KEY" ] && [ -z "$OAI_KEY" ]; then
+    echo "  ✗  No API key provided. Cannot start the demo."
+    echo ""
+    echo "  Get a key from:"
+    echo "    Anthropic: https://console.anthropic.com/"
+    echo "    OpenAI:    https://platform.openai.com/"
+    echo ""
+    exit 1
+  fi
+
+  echo "  ✓  API key saved"
+  echo ""
+fi
+
+# ─── 4. Start services ────────────────────────────────────────────────────
+
+echo ""
+echo "Starting pgEdge MCP Server demo..."
+echo ""
+
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d
+
+echo ""
+echo "Waiting for services to be healthy..."
+
+# Wait for MCP server health (up to 90 seconds)
+for i in $(seq 1 18); do
+  if curl -sf http://localhost:$MCP_PORT/health > /dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+
+# Build the Web UI URL
+if [ -n "$CODESPACE_NAME" ] && [ -n "$GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN" ]; then
+  WEB_URL="https://${CODESPACE_NAME}-${WEB_PORT}.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+else
+  WEB_URL="http://localhost:$WEB_PORT"
+fi
+
+# Wait for web client (up to 30 more seconds)
+for i in $(seq 1 6); do
+  if curl -sf http://localhost:$WEB_PORT/health > /dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+
+# ─── 5. Print result ──────────────────────────────────────────────────────
+
+if curl -sf http://localhost:$WEB_PORT/health > /dev/null 2>&1; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  pgEdge MCP Server Demo is running!"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "  Web UI:  $WEB_URL"
+  echo "  Login:   demo / demo123"
+  echo ""
+  echo "  Try asking:"
+  echo "    What tables are in the database?"
+  echo "    Show me the top 10 products by sales"
+  echo "    Which customers have placed more than 5 orders?"
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+else
+  echo ""
+  echo "Services are starting. Check progress with:"
+  echo "  docker compose -f $COMPOSE_FILE logs -f"
+  echo ""
+  echo "Once ready, open: $WEB_URL"
+  echo ""
+fi

--- a/examples/codespaces-demo/start.sh
+++ b/examples/codespaces-demo/start.sh
@@ -38,8 +38,11 @@ fi
 if [ -n "$PGEDGE_OPENAI_API_KEY" ]; then
   oai_esc=$(escape_sed "$PGEDGE_OPENAI_API_KEY")
   sed -i "s/^PGEDGE_OPENAI_API_KEY=.*/PGEDGE_OPENAI_API_KEY=$oai_esc/" "$ENV_FILE"
-  sed -i "s/^PGEDGE_LLM_PROVIDER=.*/PGEDGE_LLM_PROVIDER=openai/" "$ENV_FILE"
-  sed -i "s/^PGEDGE_LLM_MODEL=.*/PGEDGE_LLM_MODEL=gpt-4o/" "$ENV_FILE"
+  # Only switch provider to OpenAI if no Anthropic key is present
+  if [ -z "$PGEDGE_ANTHROPIC_API_KEY" ]; then
+    sed -i "s/^PGEDGE_LLM_PROVIDER=.*/PGEDGE_LLM_PROVIDER=openai/" "$ENV_FILE"
+    sed -i "s/^PGEDGE_LLM_MODEL=.*/PGEDGE_LLM_MODEL=gpt-4o/" "$ENV_FILE"
+  fi
 fi
 
 # ─── 2. Check if any API key is configured ─────────────────────────────────


### PR DESCRIPTION
## Summary

- Add a one-click GitHub Codespaces demo that launches PostgreSQL
  (with Northwind sample data), the MCP Server, and the Web Client
  via docker compose.
- `start.sh` handles API key detection (Codespace secrets, `.env`,
  or interactive prompt) and service health checks.
- Includes `.devcontainer/demo/` and `.devcontainer/dev/` configs
  for demo and development environments respectively.

## Test plan

- [ ] Open repo in GitHub Codespaces; verify `.env` is bootstrapped
- [ ] Run `./examples/codespaces-demo/start.sh` in Codespaces
- [ ] Verify Postgres, MCP Server, and Web Client all start healthy
- [ ] Test API key prompt when no secrets are configured
- [ ] Test with `PGEDGE_ANTHROPIC_API_KEY` Codespace secret set
- [ ] Test with `PGEDGE_OPENAI_API_KEY` only (provider switch)
- [ ] Verify Web UI is accessible and login works (demo/demo123)
- [ ] Test locally with `docker compose up` using `.env.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable Codespaces demo that provisions a PostgreSQL dataset, MCP backend, and Web UI with automated startup and health checks.

* **Documentation**
  * Added detailed demo docs and usage guidance, including setup, credentials, example queries, and troubleshooting notes.

* **Chores**
  * Added dev container configurations, an env example, and a demo startup script to streamline development and quickstart usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->