### PR TITLE
Improve MCP tool selection priority for AI agents

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ and this project adheres to
 
 ### Added
 
+- MCP tool selection guidance for AI agents. The server now sends
+  a server-level `instructions` field during the MCP initialize
+  handshake, directing agents to prefer MCP tools over `psql` and
+  shell commands. Tool descriptions include explicit "use this
+  instead of..." language to steer tool selection. A new
+  documentation page covers recommended `CLAUDE.md` and
+  `.cursorrules` configuration for reinforcing tool preference.
+
 - Cursor IDE plugin manifest and setup guide.
 
 - OpenAPI 3.0.3 specification and interactive API browser. The

--- a/docs/guide/agent-integration.md
+++ b/docs/guide/agent-integration.md
@@ -60,7 +60,7 @@ Cursor reads project instructions from a
 In the following example, the `.cursorrules` file
 includes a tool selection instruction:
 
-```
+```text
 For all PostgreSQL database operations, use the
 pgEdge MCP server tools instead of psql or shell
 commands. The MCP tools handle connection

--- a/docs/guide/agent-integration.md
+++ b/docs/guide/agent-integration.md
@@ -1,0 +1,90 @@
+# Configuring AI Agent Tool Selection
+
+AI coding agents such as Claude Code and Cursor
+sometimes prefer shell commands over MCP tools for
+database operations. Training data for these agents
+contains many examples of shell-based workflows
+using `psql` and similar utilities. The
+MCP server includes built-in guidance to steer agents
+toward its tools, but project-level configuration
+can reinforce this behavior.
+
+## Server-Level Instructions
+
+The MCP server automatically sends instructions to
+compatible clients during initialization. These
+instructions tell the agent to prefer the MCP
+server tools over shell commands. The server sends
+the instructions through the MCP protocol's
+`instructions` field during the `initialize`
+handshake.
+
+No user configuration is required for this feature.
+The server delivers tool-preference guidance to any
+MCP-compatible client automatically.
+
+## Project-Level Configuration
+
+Users can add instructions to project configuration
+files to reinforce tool selection. Each AI coding
+agent reads a specific configuration file from the
+project root directory.
+
+### Claude Code
+
+Claude Code reads project instructions from a
+`CLAUDE.md` file in the project root directory.
+
+In the following example, the `CLAUDE.md` file
+includes a database access constraint:
+
+```markdown
+## Database Access
+
+All PostgreSQL operations in this project use the
+pgEdge MCP tools. Do not use psql or direct shell
+database commands for querying or schema inspection.
+```
+
+Add this block to the `CLAUDE.md` file in your
+project root. Framing the instruction as a project
+constraint rather than a preference makes the
+instruction more effective. Agents treat constraints
+as rules rather than suggestions.
+
+### Cursor
+
+Cursor reads project instructions from a
+`.cursorrules` file in the project root directory.
+
+In the following example, the `.cursorrules` file
+includes a tool selection instruction:
+
+```
+For all PostgreSQL database operations, use the
+pgEdge MCP server tools instead of psql or shell
+commands. The MCP tools handle connection
+management, authentication, and access control
+automatically.
+```
+
+Add this block to the `.cursorrules` file in your
+project root. Cursor applies these rules to all
+conversations within the project.
+
+## Tips for Effective Tool Selection
+
+The following tips help maintain consistent tool
+selection across agent sessions:
+
+- Keep agent instructions concise and frame them
+  as project constraints.
+- The MCP server tool descriptions include
+  "use this instead of..." guidance that agents
+  read when deciding which tool to call.
+- If an agent still defaults to shell commands,
+  explicitly ask the agent to use the MCP tools
+  for the current task.
+- Long sessions may cause instruction drift;
+  reinforce the tool preference if the agent
+  reverts to shell commands.

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -293,6 +293,7 @@ func (s *Server) handleInitializeHTTP(req JSONRPCRequest) JSONRPCResponse {
 			Name:    ServerName,
 			Version: ServerVersion,
 		},
+		Instructions: ServerInstructions,
 	}
 
 	return JSONRPCResponse{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -27,7 +27,7 @@ const (
 	ServerVersion   = "1.0.0-beta3"
 
 	// ServerInstructions provides guidance to MCP clients about tool usage
-	ServerInstructions = "For all PostgreSQL database operations, use the tools provided by this server instead of psql or other shell commands. These tools handle connection management, authentication, access control, and audit logging automatically. Use get_schema_info to discover database structure, query_database to run SQL queries, execute_explain for query performance analysis, and count_rows for row counts. Do not access the database through any other means."
+	ServerInstructions = "For PostgreSQL database operations, prefer the tools advertised by this server in tools/list instead of psql or other shell commands. Use the available MCP tools for schema discovery, query execution, performance analysis, row counts, and database management. These tools apply the server's connection handling, authentication, access control, and logging policies automatically."
 )
 
 // ToolProvider is an interface for listing and executing tools

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -25,6 +25,9 @@ const (
 	ProtocolVersion = "2024-11-05"
 	ServerName      = "pgedge-postgres-mcp"
 	ServerVersion   = "1.0.0-beta3"
+
+	// ServerInstructions provides guidance to MCP clients about tool usage
+	ServerInstructions = "For all PostgreSQL database operations, use the tools provided by this server instead of psql or other shell commands. These tools handle connection management, authentication, access control, and audit logging automatically. Use get_schema_info to discover database structure, query_database to run SQL queries, execute_explain for query performance analysis, and count_rows for row counts. Do not access the database through any other means."
 )
 
 // ToolProvider is an interface for listing and executing tools
@@ -196,6 +199,7 @@ func (s *Server) handleInitialize(req JSONRPCRequest) {
 			Name:    ServerName,
 			Version: ServerVersion,
 		},
+		Instructions: ServerInstructions,
 	}
 
 	sendResponse(req.ID, result)

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -57,6 +57,7 @@ type InitializeResult struct {
 	ProtocolVersion string                 `json:"protocolVersion"`
 	Capabilities    map[string]interface{} `json:"capabilities"`
 	ServerInfo      Implementation         `json:"serverInfo"`
+	Instructions    string                 `json:"instructions,omitempty"`
 }
 
 // ToolAnnotations provides hints about tool behavior per MCP spec 2025-03-26

--- a/internal/tools/count_rows.go
+++ b/internal/tools/count_rows.go
@@ -25,7 +25,7 @@ func CountRowsTool(dbClient *database.Client) Tool {
 	return Tool{
 		Definition: mcp.Tool{
 			Name: "count_rows",
-			Description: `Get the row count of a table with optional filtering.
+			Description: `Get the row count of a table with optional filtering. Use this tool instead of running SELECT COUNT(*) through psql or shell commands — it provides efficient counting with proper access control.
 
 <usecase>
 Use count_rows to efficiently determine data volume:

--- a/internal/tools/database_switching.go
+++ b/internal/tools/database_switching.go
@@ -101,7 +101,7 @@ func ListDatabaseConnectionsTool(
 	return Tool{
 		Definition: mcp.Tool{
 			Name: "list_database_connections",
-			Description: `List available database connections that you can switch to.
+			Description: `List available database connections that you can switch to. Use this tool instead of checking connection parameters manually — it shows all configured databases with their status.
 
 Returns a list of database connections configured for this session, along with
 the currently active database. Use this to discover what databases are available
@@ -155,7 +155,7 @@ func SelectDatabaseConnectionTool(
 	return Tool{
 		Definition: mcp.Tool{
 			Name: "select_database_connection",
-			Description: `Switch to a different database connection for subsequent queries.
+			Description: `Switch to a different database connection for subsequent queries. Use this tool instead of reconnecting through psql — it manages connection lifecycle and preserves session state.
 
 Use list_database_connections first to see available options. After switching,
 all subsequent database tools (query_database, get_schema_info, etc.) will

--- a/internal/tools/execute_explain.go
+++ b/internal/tools/execute_explain.go
@@ -26,7 +26,7 @@ func ExecuteExplainTool(dbClient *database.Client) Tool {
 	return Tool{
 		Definition: mcp.Tool{
 			Name: "execute_explain",
-			Description: `Execute EXPLAIN ANALYZE on a query to diagnose performance.
+			Description: `Execute EXPLAIN ANALYZE on a query to diagnose performance. Use this tool instead of running EXPLAIN directly through psql — it provides structured analysis with optimization recommendations.
 
 <usecase>
 Use when:

--- a/internal/tools/generate_embedding.go
+++ b/internal/tools/generate_embedding.go
@@ -26,7 +26,7 @@ func GenerateEmbeddingTool(cfg *config.Config) Tool {
 	return Tool{
 		Definition: mcp.Tool{
 			Name:        "generate_embedding",
-			Description: "Generate embedding vector from text using configured provider (OpenAI, Anthropic Voyage, or Ollama). Returns the embedding vector for storage or semantic search operations.",
+			Description: "Generate embedding vector from text using the configured provider (OpenAI, Anthropic Voyage, or Ollama). Use this tool instead of calling embedding APIs directly — it handles provider configuration and returns vectors ready for storage or semantic search operations.",
 			InputSchema: mcp.InputSchema{
 				Type: "object",
 				Properties: map[string]interface{}{

--- a/internal/tools/get_schema_info.go
+++ b/internal/tools/get_schema_info.go
@@ -23,7 +23,7 @@ func GetSchemaInfoTool(dbClient *database.Client) Tool {
 	return Tool{
 		Definition: mcp.Tool{
 			Name: "get_schema_info",
-			Description: `PRIMARY TOOL for discovering database structure and available tables.
+			Description: `Discover database structure and available tables. Use this tool instead of psql meta-commands (\dt, \d, \dn) or information_schema queries — it provides comprehensive schema details with filtering and token-efficient output.
 
 <usecase>
 Use get_schema_info when you need to:

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -50,7 +50,7 @@ func QueryDatabaseTool(dbClient *database.Client) Tool {
 		Definition: mcp.Tool{
 			Name:        "query_database",
 			Annotations: annotations,
-			Description: fmt.Sprintf(`Execute SQL queries for STRUCTURED, EXACT data retrieval.
+			Description: fmt.Sprintf(`Execute SQL queries against the connected PostgreSQL database. Use this tool instead of psql, shell commands, or direct database connections for all SQL operations — it handles connection management, authentication, and access control automatically.
 
 <usecase>
 Use query_database when you need:

--- a/internal/tools/similarity_search.go
+++ b/internal/tools/similarity_search.go
@@ -30,7 +30,7 @@ func SimilaritySearchTool(dbClient *database.Client, cfg *config.Config) Tool {
 			Name: "similarity_search",
 			Description: `⚠️  IMPORTANT: Use this tool to retrieve database content BEFORE answering questions about it. Do NOT answer from memory!
 
-Semantic search for NATURAL LANGUAGE and CONCEPT-BASED queries.
+Semantic search for NATURAL LANGUAGE and CONCEPT-BASED queries. Use this tool instead of manual text search queries through psql — it combines vector similarity with lexical ranking for superior results.
 
 <critical_usage_note>
 MANDATORY RULE: When a user asks about content that you know EXISTS in the database (e.g., "tell me about X", "what is Y", "describe Z", "summarize A", "what are the capabilities of X"), you MUST ALWAYS use this tool FIRST to retrieve the current information from the database.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Using the Go Chat Client: guide/cli-client.md
       - Configuring the Server for use with Claude Desktop: guide/claude_desktop.md
       - Configuring the Server for use with Cursor: guide/cursor.md
+      - Configuring AI Agent Tool Selection: guide/agent-integration.md
   - Reviewing Server Logs: guide/server_logs.md
   - Authentication and Security:
       - Authentication:


### PR DESCRIPTION
AI coding agents (Claude Code, Cursor, etc.) tend to prefer shell commands like psql over MCP tools because their training data contains more examples of shell-based database workflows. This makes users manually tell agents to use MCP tools, which is a poor experience.

This commit addresses the problem through three complementary changes:

1. Server-level instructions: Add an `instructions` field to the MCP initialize response per the MCP spec. This is the strongest lever available to MCP server authors — the instructions are always present in the client context without the "ignore if irrelevant" caveat that applies to CLAUDE.md content.

2. Assertive tool descriptions: Update all tool descriptions to include explicit "use this instead of X" language. Models read these when deciding which tool to call, and the direct comparison with competing alternatives steers selection toward the MCP tools.

3. Agent integration documentation: Add a new docs page covering server-level instructions, recommended CLAUDE.md/cursorrules configuration, and tips for maintaining consistent tool selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server now sends initialization instructions to guide AI agents toward using MCP tools instead of psql/shell commands.

* **Documentation**
  * Added a guide for configuring AI agent tool selection with example project-level files and tips.
  * Updated MCP tool descriptions to recommend using the corresponding tools (e.g., counting, schema, explain, embeddings, search, DB switching) instead of manual psql/shell usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->