### PR TITLE
Add multi-host connection support for HA and failover (#96)

### DIFF
--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -75,6 +75,8 @@ func main() {
 	dbUser := flag.String("db-user", "", "Database user")
 	dbPassword := flag.String("db-password", "", "Database password")
 	dbSSLMode := flag.String("db-sslmode", "", "Database SSL mode (disable, require, verify-ca, verify-full)")
+	dbHosts := flag.String("db-hosts", "", "Comma-separated host:port pairs for multi-host connections (e.g., \"host1:5432,host2:5433\")")
+	dbTargetSessionAttrs := flag.String("db-target-session-attrs", "", "Target session attributes for multi-host (e.g., \"read-write\", \"any\", \"primary\", \"standby\")")
 
 	// Token management commands
 	addTokenCmd := flag.Bool("add-token", false, "Add a new API token")
@@ -346,6 +348,12 @@ func main() {
 		case "db-sslmode":
 			cliFlags.DBSSLSet = true
 			cliFlags.DBSSLMode = *dbSSLMode
+		case "db-hosts":
+			cliFlags.DBHostsSet = true
+			cliFlags.DBHosts = *dbHosts
+		case "db-target-session-attrs":
+			cliFlags.DBTargetSessionAttrsSet = true
+			cliFlags.DBTargetSessionAttrs = *dbTargetSessionAttrs
 		case "trace-file":
 			cliFlags.TraceFileSet = true
 			cliFlags.TraceFile = *traceFile
@@ -355,6 +363,13 @@ func main() {
 	// Validate basic flag dependencies before loading full config
 	if !*httpMode && (*tlsMode || *certFile != "" || *keyFile != "" || *chainFile != "") {
 		fmt.Fprintf(os.Stderr, "ERROR: TLS options (-tls, -cert, -key, -chain) require -http flag\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Validate mutual exclusion of --db-host and --db-hosts
+	if cliFlags.DBHostSet && cliFlags.DBHostsSet {
+		fmt.Fprintf(os.Stderr, "ERROR: -db-host and -db-hosts are mutually exclusive\n")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -958,15 +973,27 @@ func main() {
 		}
 
 		// Set up SIGHUP handler for configuration reload (HTTP mode only)
-		cliFlags := config.CLIFlags{
-			DBHost:     *dbHost,
-			DBPort:     *dbPort,
-			DBName:     *dbName,
-			DBUser:     *dbUser,
-			DBPassword: *dbPassword,
-			DBSSLMode:  *dbSSLMode,
+		// Re-use the outer cliFlags (populated by flag.Visit) so that
+		// the reload path knows which flags were explicitly provided.
+		reloadCLIFlags := config.CLIFlags{
+			DBHost:                  *dbHost,
+			DBHostSet:               cliFlags.DBHostSet,
+			DBPort:                  *dbPort,
+			DBPortSet:               cliFlags.DBPortSet,
+			DBName:                  *dbName,
+			DBNameSet:               cliFlags.DBNameSet,
+			DBUser:                  *dbUser,
+			DBUserSet:               cliFlags.DBUserSet,
+			DBPassword:              *dbPassword,
+			DBPassSet:               cliFlags.DBPassSet,
+			DBSSLMode:               *dbSSLMode,
+			DBSSLSet:                cliFlags.DBSSLSet,
+			DBHosts:                 *dbHosts,
+			DBHostsSet:              cliFlags.DBHostsSet,
+			DBTargetSessionAttrs:    *dbTargetSessionAttrs,
+			DBTargetSessionAttrsSet: cliFlags.DBTargetSessionAttrsSet,
 		}
-		reloadableCfg := config.NewReloadableConfig(cfg, configPath, cliFlags)
+		reloadableCfg := config.NewReloadableConfig(cfg, configPath, reloadCLIFlags)
 
 		// Register callback to update client manager when databases change
 		reloadableCfg.OnReload(func(newCfg *config.Config) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,41 @@ and this project adheres to
   health checks, and `recommend_indexes` for two-tier index
   recommendations with optional HypoPG simulation.
 
+- Multi-host database connection support for high availability
+  and failover. The `hosts` array replaces the single `host` and
+  `port` fields when connecting to multiple PostgreSQL servers.
+  The server generates a libpq-compatible multi-host connection
+  string and passes the list to pgx for automatic failover.
+
+- The `target_session_attrs` option controls read-write routing
+  for multi-host connections. Accepted values include
+  `any`, `read-write`, `read-only`, `primary`, `standby`, and
+  `prefer-standby`.
+
+- Pool health check and connection lifetime settings for
+  database connections. The `pool_health_check_period` option
+  sets the interval for background health checks; the
+  `pool_max_conn_lifetime` option sets the maximum age of a
+  pooled connection before the server closes the connection.
+
+- The `PGEDGE_DB_HOSTS` environment variable configures
+  multi-host connections as a comma-separated list of
+  `host:port` pairs.
+
+- The `--db-hosts` CLI flag specifies multiple database hosts
+  as a comma-separated `host:port` list. The
+  `--db-target-session-attrs` flag sets the session routing
+  attribute for multi-host connections.
+
+- Configuration validation rejects entries that specify both
+  the single-host `host` field and the multi-host `hosts`
+  array. The validator also checks that `target_session_attrs`
+  contains a recognized value.
+
+- The web client displays multi-host connection details in the
+  database selector, showing each configured host and port
+  alongside the connection status.
+
 - `--max-retries` flag for the kb-builder controls how many times
   transient embedding API errors are retried. The default is 5;
   set to 0 for unlimited retries. Backoff is capped at 60 seconds.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -55,9 +55,9 @@ details on configuring multiple databases and access control.
 |--------------------------|----------|---------------------|-------------|
 | `databases[].name` | N/A | `PGEDGE_DB_N_NAME` | Unique name for the database connection (required) |
 | `databases[].host` | `-db-host` | `PGEDGE_DB_HOST`, `PGHOST` | Database server hostname (default: "localhost"). Mutually exclusive with `hosts`. |
-| `databases[].port` | `-db-port` | `PGEDGE_DB_PORT`, `PGPORT` | Database server port (default: 5432). Mutually exclusive with `hosts`. |
-| `databases[].hosts` | `-db-hosts` | `PGEDGE_DB_HOSTS` | List of `host`/`port` pairs for multi-host failover. Mutually exclusive with `host`/`port`. |
-| `databases[].target_session_attrs` | `-db-target-session-attrs` | N/A | Session routing for multi-host: `any`, `read-write`, `read-only`, `primary`, `standby`, `prefer-standby` (libpq default: `any`) |
+| `databases[].port` | `-db-port` | `PGEDGE_DB_PORT`, `PGPORT` | Database server port (default: 5432) |
+| `databases[].hosts` | `-db-hosts` | `PGEDGE_DB_HOSTS` | List of `host`/`port` pairs for multi-host failover. Mutually exclusive with `host`. |
+| `databases[].target_session_attrs` | `-db-target-session-attrs` | `PGEDGE_DB_TARGET_SESSION_ATTRS` | Session routing for multi-host: `any`, `read-write`, `read-only`, `primary`, `standby`, `prefer-standby` (libpq default: `any`) |
 | `databases[].database` | `-db-name` | `PGEDGE_DB_NAME`, `PGDATABASE` | Database name (default: "postgres") |
 | `databases[].user` | `-db-user` | `PGEDGE_DB_USER`, `PGUSER` | Database user |
 | `databases[].password` | `-db-password` | `PGEDGE_DB_PASSWORD`, `PGPASSWORD` | Database password (uses `.pgpass` if not set) |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -54,8 +54,10 @@ details on configuring multiple databases and access control.
 | Configuration File Option | CLI Flag | Environment Variable | Description |
 |--------------------------|----------|---------------------|-------------|
 | `databases[].name` | N/A | `PGEDGE_DB_N_NAME` | Unique name for the database connection (required) |
-| `databases[].host` | `-db-host` | `PGEDGE_DB_HOST`, `PGHOST` | Database server hostname (default: "localhost") |
-| `databases[].port` | `-db-port` | `PGEDGE_DB_PORT`, `PGPORT` | Database server port (default: 5432) |
+| `databases[].host` | `-db-host` | `PGEDGE_DB_HOST`, `PGHOST` | Database server hostname (default: "localhost"). Mutually exclusive with `hosts`. |
+| `databases[].port` | `-db-port` | `PGEDGE_DB_PORT`, `PGPORT` | Database server port (default: 5432). Mutually exclusive with `hosts`. |
+| `databases[].hosts` | `-db-hosts` | `PGEDGE_DB_HOSTS` | List of `host`/`port` pairs for multi-host failover. Mutually exclusive with `host`/`port`. |
+| `databases[].target_session_attrs` | `-db-target-session-attrs` | N/A | Session routing for multi-host: `any`, `read-write`, `read-only`, `primary`, `standby`, `prefer-standby` (libpq default: `any`) |
 | `databases[].database` | `-db-name` | `PGEDGE_DB_NAME`, `PGDATABASE` | Database name (default: "postgres") |
 | `databases[].user` | `-db-user` | `PGEDGE_DB_USER`, `PGUSER` | Database user |
 | `databases[].password` | `-db-password` | `PGEDGE_DB_PASSWORD`, `PGPASSWORD` | Database password (uses `.pgpass` if not set) |
@@ -67,6 +69,8 @@ details on configuring multiple databases and access control.
 | `databases[].pool_max_conns` | N/A | N/A | Maximum connections in the pool (default: 4) |
 | `databases[].pool_min_conns` | N/A | N/A | Minimum connections in the pool (default: 0) |
 | `databases[].pool_max_conn_idle_time` | N/A | N/A | Maximum idle time before a connection is closed (default: "30m") |
+| `databases[].pool_health_check_period` | N/A | N/A | Interval for background pool health checks (default: disabled) |
+| `databases[].pool_max_conn_lifetime` | N/A | N/A | Maximum lifetime of a connection before the pool closes the connection (default: "1h") |
 
 CLI flags and single-database environment variables (`PGEDGE_DB_*`,
 `PG*`) apply to the first database in the list. Use numbered
@@ -235,6 +239,10 @@ options:
 - `-db-password` - Database password
 - `-db-sslmode` - Database SSL mode (disable, require, verify-ca,
   verify-full)
+- `-db-hosts` - Comma-separated `host:port` pairs for multi-host
+  failover (e.g., `host1:5432,host2:5432`)
+- `-db-target-session-attrs` - Session routing attribute for
+  multi-host connections (libpq default: `any`)
 
 These flags apply to the first database in the configuration list.
 

--- a/examples/pgedge-postgres-mcp-http.yaml.example
+++ b/examples/pgedge-postgres-mcp-http.yaml.example
@@ -70,6 +70,25 @@ databases:
     #   allow_llm_switching: false  # Hide from LLM switching
     #   allowed_pl_languages: ["plpgsql"]  # Strict - only safe PL languages
 
+    # Multi-host connection example (for high availability / failover):
+    # - name: "mydb-ha"
+    #   hosts:
+    #       - host: "primary.example.com"
+    #         port: 5432
+    #       - host: "replica.example.com"
+    #         port: 5432
+    #   target_session_attrs: "read-write"
+    #   database: "mydb"
+    #   user: "postgres"
+    #   password: ""
+    #   sslmode: "prefer"
+    #   pool_max_conns: 10
+    #   pool_min_conns: 2
+    #   pool_health_check_period: "30s"
+    #   pool_max_conn_lifetime: "5m"
+    #   allow_writes: false
+    #   allow_llm_switching: true
+
 # Built-in tools configuration
 # Enable or disable specific MCP tools
 builtins:

--- a/examples/pgedge-postgres-mcp-stdio.yaml.example
+++ b/examples/pgedge-postgres-mcp-stdio.yaml.example
@@ -40,6 +40,25 @@ databases:
     #   sslmode: "prefer"
     #   allow_llm_switching: true
 
+    # Multi-host connection example (for high availability / failover):
+    # - name: "mydb-ha"
+    #   hosts:
+    #       - host: "primary.example.com"
+    #         port: 5432
+    #       - host: "replica.example.com"
+    #         port: 5432
+    #   target_session_attrs: "read-write"
+    #   database: "mydb"
+    #   user: "postgres"
+    #   password: ""
+    #   sslmode: "prefer"
+    #   pool_max_conns: 10
+    #   pool_min_conns: 2
+    #   pool_health_check_period: "30s"
+    #   pool_max_conn_lifetime: "5m"
+    #   allow_writes: false
+    #   allow_llm_switching: true
+
 # Built-in tools configuration
 # Enable or disable specific MCP tools
 builtins:

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -19,15 +19,23 @@ import (
 	"pgedge-postgres-mcp/internal/database"
 )
 
+// HostInfo represents a single host:port pair in the API response
+type HostInfo struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
 // DatabaseInfo represents a database in the API response
 type DatabaseInfo struct {
-	Name        string `json:"name"`
-	Host        string `json:"host"`
-	Port        int    `json:"port"`
-	Database    string `json:"database"`
-	User        string `json:"user"`
-	SSLMode     string `json:"sslmode"`
-	AllowWrites bool   `json:"allow_writes"`
+	Name               string     `json:"name"`
+	Host               string     `json:"host"`
+	Port               int        `json:"port"`
+	Database           string     `json:"database"`
+	User               string     `json:"user"`
+	SSLMode            string     `json:"sslmode"`
+	AllowWrites        bool       `json:"allow_writes"`
+	Hosts              []HostInfo `json:"hosts,omitempty"`
+	TargetSessionAttrs string     `json:"target_session_attrs,omitempty"`
 }
 
 // ListDatabasesResponse is the response for GET /api/databases
@@ -100,7 +108,7 @@ func (h *DatabaseHandler) HandleListDatabases(w http.ResponseWriter, r *http.Req
 	databases := make([]DatabaseInfo, 0, len(accessibleConfigs))
 	for i := range accessibleConfigs {
 		cfg := &accessibleConfigs[i]
-		databases = append(databases, DatabaseInfo{
+		info := DatabaseInfo{
 			Name:        cfg.Name,
 			Host:        cfg.Host,
 			Port:        cfg.Port,
@@ -108,7 +116,19 @@ func (h *DatabaseHandler) HandleListDatabases(w http.ResponseWriter, r *http.Req
 			User:        cfg.User,
 			SSLMode:     cfg.SSLMode,
 			AllowWrites: cfg.AllowWrites,
-		})
+		}
+		if len(cfg.Hosts) > 0 {
+			info.Hosts = make([]HostInfo, len(cfg.Hosts))
+			for j, h := range cfg.Hosts {
+				info.Hosts[j] = HostInfo{Host: h.Host, Port: h.Port}
+			}
+			info.TargetSessionAttrs = cfg.TargetSessionAttrs
+			// Backward compatibility: populate Host/Port from the
+			// first configured host entry.
+			info.Host = cfg.Hosts[0].Host
+			info.Port = cfg.Hosts[0].Port
+		}
+		databases = append(databases, info)
 	}
 
 	// Get current database for this token

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -57,6 +57,15 @@ type SelectDatabaseResponse struct {
 	Error   string `json:"error,omitempty"`
 }
 
+// effectivePort returns the port or 5432 if zero, matching
+// BuildConnectionString behavior when YAML omits the port.
+func effectivePort(port int) int {
+	if port == 0 {
+		return 5432
+	}
+	return port
+}
+
 // DatabaseHandler handles database listing and selection API endpoints
 type DatabaseHandler struct {
 	clientManager *database.ClientManager
@@ -111,7 +120,7 @@ func (h *DatabaseHandler) HandleListDatabases(w http.ResponseWriter, r *http.Req
 		info := DatabaseInfo{
 			Name:        cfg.Name,
 			Host:        cfg.Host,
-			Port:        cfg.Port,
+			Port:        effectivePort(cfg.Port),
 			Database:    cfg.Database,
 			User:        cfg.User,
 			SSLMode:     cfg.SSLMode,
@@ -120,13 +129,13 @@ func (h *DatabaseHandler) HandleListDatabases(w http.ResponseWriter, r *http.Req
 		if len(cfg.Hosts) > 0 {
 			info.Hosts = make([]HostInfo, len(cfg.Hosts))
 			for j, h := range cfg.Hosts {
-				info.Hosts[j] = HostInfo{Host: h.Host, Port: h.Port}
+				info.Hosts[j] = HostInfo{Host: h.Host, Port: effectivePort(h.Port)}
 			}
 			info.TargetSessionAttrs = cfg.TargetSessionAttrs
 			// Backward compatibility: populate Host/Port from the
 			// first configured host entry.
 			info.Host = cfg.Hosts[0].Host
-			info.Port = cfg.Hosts[0].Port
+			info.Port = effectivePort(cfg.Hosts[0].Port)
 		}
 		databases = append(databases, info)
 	}

--- a/internal/api/databases_test.go
+++ b/internal/api/databases_test.go
@@ -386,6 +386,167 @@ func TestDatabaseInfoStruct(t *testing.T) {
 	}
 }
 
+func TestDatabaseInfoStruct_MultiHost(t *testing.T) {
+	info := DatabaseInfo{
+		Name:     "multihost",
+		Host:     "node1.example.com",
+		Port:     5432,
+		Database: "mydb",
+		User:     "postgres",
+		SSLMode:  "require",
+		Hosts: []HostInfo{
+			{Host: "node1.example.com", Port: 5432},
+			{Host: "node2.example.com", Port: 5432},
+		},
+		TargetSessionAttrs: "read-write",
+	}
+
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var decoded DatabaseInfo
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(decoded.Hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(decoded.Hosts))
+	}
+	if decoded.Hosts[0].Host != "node1.example.com" {
+		t.Errorf("expected first host 'node1.example.com', got %q", decoded.Hosts[0].Host)
+	}
+	if decoded.Hosts[1].Host != "node2.example.com" {
+		t.Errorf("expected second host 'node2.example.com', got %q", decoded.Hosts[1].Host)
+	}
+	if decoded.TargetSessionAttrs != "read-write" {
+		t.Errorf("expected target_session_attrs 'read-write', got %q", decoded.TargetSessionAttrs)
+	}
+	// Backward compatibility: Host/Port from first configured host
+	if decoded.Host != "node1.example.com" {
+		t.Errorf("expected Host 'node1.example.com', got %q", decoded.Host)
+	}
+}
+
+func TestDatabaseInfoStruct_SingleHost_OmitsMultiHostFields(t *testing.T) {
+	info := DatabaseInfo{
+		Name:     "singlehost",
+		Host:     "localhost",
+		Port:     5432,
+		Database: "testdb",
+		User:     "user",
+		SSLMode:  "disable",
+	}
+
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	// Verify that hosts and target_session_attrs are omitted from JSON
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+	if _, exists := raw["hosts"]; exists {
+		t.Error("expected 'hosts' to be omitted from JSON for single-host config")
+	}
+	if _, exists := raw["target_session_attrs"]; exists {
+		t.Error("expected 'target_session_attrs' to be omitted from JSON for single-host config")
+	}
+}
+
+func TestHandleListDatabases_MultiHost(t *testing.T) {
+	databases := []config.NamedDatabaseConfig{
+		{
+			Name:     "singledb",
+			Host:     "localhost",
+			Port:     5432,
+			Database: "db1",
+			User:     "user1",
+			SSLMode:  "disable",
+		},
+		{
+			Name:     "multidb",
+			Host:     "node1.example.com",
+			Port:     5432,
+			Database: "db2",
+			User:     "user2",
+			SSLMode:  "require",
+			Hosts: []config.HostEntry{
+				{Host: "node1.example.com", Port: 5432},
+				{Host: "node2.example.com", Port: 5433},
+			},
+			TargetSessionAttrs: "prefer-standby",
+		},
+	}
+	cm := database.NewClientManager(databases)
+	handler := NewDatabaseHandler(cm, nil, false, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/databases", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleListDatabases(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var response ListDatabasesResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.Databases) != 2 {
+		t.Fatalf("expected 2 databases, got %d", len(response.Databases))
+	}
+
+	// Find the multi-host database
+	var multiDB DatabaseInfo
+	for _, db := range response.Databases {
+		if db.Name == "multidb" {
+			multiDB = db
+			break
+		}
+	}
+
+	if len(multiDB.Hosts) != 2 {
+		t.Fatalf("expected 2 hosts for multidb, got %d", len(multiDB.Hosts))
+	}
+	if multiDB.Hosts[0].Host != "node1.example.com" || multiDB.Hosts[0].Port != 5432 {
+		t.Errorf("unexpected first host: %+v", multiDB.Hosts[0])
+	}
+	if multiDB.Hosts[1].Host != "node2.example.com" || multiDB.Hosts[1].Port != 5433 {
+		t.Errorf("unexpected second host: %+v", multiDB.Hosts[1])
+	}
+	if multiDB.TargetSessionAttrs != "prefer-standby" {
+		t.Errorf("expected target_session_attrs 'prefer-standby', got %q", multiDB.TargetSessionAttrs)
+	}
+	// Backward compatibility
+	if multiDB.Host != "node1.example.com" {
+		t.Errorf("expected Host from first entry, got %q", multiDB.Host)
+	}
+	if multiDB.Port != 5432 {
+		t.Errorf("expected Port from first entry, got %d", multiDB.Port)
+	}
+
+	// Verify single-host database has no hosts field
+	var singleDB DatabaseInfo
+	for _, db := range response.Databases {
+		if db.Name == "singledb" {
+			singleDB = db
+			break
+		}
+	}
+	if len(singleDB.Hosts) != 0 {
+		t.Errorf("expected no hosts for singledb, got %d", len(singleDB.Hosts))
+	}
+	if singleDB.TargetSessionAttrs != "" {
+		t.Errorf("expected empty target_session_attrs for singledb, got %q", singleDB.TargetSessionAttrs)
+	}
+}
+
 func TestSelectDatabaseResponseStruct(t *testing.T) {
 	// Test success response
 	success := SelectDatabaseResponse{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -166,15 +167,60 @@ type TLSConfig struct {
 	ChainFile string `yaml:"chain_file"`
 }
 
+// HostEntry represents a single host:port pair for multi-host connection strings.
+type HostEntry struct {
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+}
+
+// ParseHostEntries parses a comma-separated list of host:port pairs.
+// Port defaults to 5432 if omitted.
+func ParseHostEntries(s string) ([]HostEntry, error) {
+	var entries []HostEntry
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		host, portStr, hasPort := strings.Cut(part, ":")
+		port := 5432
+		if hasPort {
+			var err error
+			port, err = strconv.Atoi(portStr)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"invalid port in host entry %q: %w", part, err)
+			}
+		}
+		if port < 1 || port > 65535 {
+			return nil, fmt.Errorf(
+				"port %d out of range (1-65535) in host entry %q",
+				port, part)
+		}
+		entries = append(entries, HostEntry{Host: host, Port: port})
+	}
+	return entries, nil
+}
+
 // NamedDatabaseConfig holds named database connection settings with access control
 type NamedDatabaseConfig struct {
-	Name              string   `yaml:"name"`                          // Unique name for this database connection (required)
-	Host              string   `yaml:"host"`                          // Database host (default: localhost)
-	Port              int      `yaml:"port"`                          // Database port (default: 5432)
-	Database          string   `yaml:"database"`                      // Database name (default: postgres)
-	User              string   `yaml:"user"`                          // Database user (required)
-	Password          string   `yaml:"password"`                      // Database password (optional, will use PGEDGE_DB_PASSWORD env var or .pgpass if not set)
-	SSLMode           string   `yaml:"sslmode"`                       // SSL mode: disable, require, verify-ca, verify-full (default: prefer)
+	Name     string `yaml:"name"`     // Unique name for this database connection (required)
+	Host     string `yaml:"host"`     // Database host (default: localhost)
+	Port     int    `yaml:"port"`     // Database port (default: 5432)
+	Database string `yaml:"database"` // Database name (default: postgres)
+	User     string `yaml:"user"`     // Database user (required)
+	Password string `yaml:"password"` // Database password (optional, will use PGEDGE_DB_PASSWORD env var or .pgpass if not set)
+	SSLMode  string `yaml:"sslmode"`  // SSL mode: disable, require, verify-ca, verify-full (default: prefer)
+
+	// Multi-host connection support (optional; overrides Host/Port when set).
+	// Each entry specifies a host:port pair. pgx/v5 tries hosts in order for failover.
+	Hosts []HostEntry `yaml:"hosts,omitempty"`
+
+	// Target session attributes for multi-host connections.
+	// Valid values: any, read-write, read-only, primary, standby, prefer-standby.
+	// Only used when Hosts is set.
+	TargetSessionAttrs string `yaml:"target_session_attrs,omitempty"`
+
 	AvailableToUsers  []string `yaml:"available_to_users,omitempty"`  // List of usernames allowed to access this database (empty = all users)
 	AllowWrites       bool     `yaml:"allow_writes"`                  // Allow LLM to execute write queries (default: false - read-only)
 	AllowLLMSwitching *bool    `yaml:"allow_llm_switching,omitempty"` // Allow LLM to discover/switch to this database (default: true when feature enabled)
@@ -183,21 +229,38 @@ type NamedDatabaseConfig struct {
 	AllowedPLLanguages []string `yaml:"allowed_pl_languages,omitempty"` // PL languages allowed for custom tools (e.g., ["plpgsql", "plpython3u"]). Use ["*"] for all.
 
 	// Connection pool settings
-	PoolMaxConns        int    `yaml:"pool_max_conns"`          // Maximum number of connections (default: 4)
-	PoolMinConns        int    `yaml:"pool_min_conns"`          // Minimum number of connections (default: 0)
-	PoolMaxConnIdleTime string `yaml:"pool_max_conn_idle_time"` // Max time a connection can be idle before being closed (default: 30m)
+	PoolMaxConns          int    `yaml:"pool_max_conns"`           // Maximum number of connections (default: 4)
+	PoolMinConns          int    `yaml:"pool_min_conns"`           // Minimum number of connections (default: 0)
+	PoolMaxConnIdleTime   string `yaml:"pool_max_conn_idle_time"`  // Max time a connection can be idle before being closed (default: 30m)
+	PoolHealthCheckPeriod string `yaml:"pool_health_check_period"` // How often idle connections are checked (default: 1m for multi-host, 0 for single-host)
+	PoolMaxConnLifetime   string `yaml:"pool_max_conn_lifetime"`   // Max lifetime of a connection before it is closed and recreated (default: 0 = unlimited)
 }
 
 // BuildConnectionString creates a PostgreSQL connection string from NamedDatabaseConfig
 // If password is not set, pgx will automatically look it up from .pgpass file
 func (cfg *NamedDatabaseConfig) BuildConnectionString() string {
-	// Use url.URL to properly encode special characters in userinfo
-	// (e.g., @, :, /, ?) that are meaningful in URI syntax.
 	u := &url.URL{
 		Scheme: "postgres",
-		Host:   fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
-		Path:   cfg.Database,
 	}
+
+	// Determine host portion
+	if len(cfg.Hosts) > 0 {
+		// Multi-host: build comma-separated host:port list
+		parts := make([]string, len(cfg.Hosts))
+		for i, h := range cfg.Hosts {
+			port := h.Port
+			if port == 0 {
+				port = 5432
+			}
+			parts[i] = fmt.Sprintf("%s:%d", h.Host, port)
+		}
+		u.Host = strings.Join(parts, ",")
+	} else {
+		// Single host (existing behavior)
+		u.Host = fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	}
+
+	u.Path = cfg.Database
 
 	// Set user info with proper encoding
 	if cfg.Password != "" {
@@ -206,14 +269,81 @@ func (cfg *NamedDatabaseConfig) BuildConnectionString() string {
 		u.User = url.User(cfg.User)
 	}
 
-	// Add SSL mode as query parameter
+	// Add query parameters
+	q := u.Query()
 	if cfg.SSLMode != "" {
-		q := u.Query()
 		q.Set("sslmode", cfg.SSLMode)
+	}
+	if cfg.TargetSessionAttrs != "" && len(cfg.Hosts) > 0 {
+		q.Set("target_session_attrs", cfg.TargetSessionAttrs)
+	}
+	if len(q) > 0 {
 		u.RawQuery = q.Encode()
 	}
 
 	return u.String()
+}
+
+// validTargetSessionAttrs lists the valid values for
+// target_session_attrs per the libpq specification.
+var validTargetSessionAttrs = map[string]bool{
+	"any":            true,
+	"read-write":     true,
+	"read-only":      true,
+	"primary":        true,
+	"standby":        true,
+	"prefer-standby": true,
+}
+
+// Validate checks the NamedDatabaseConfig for invalid combinations.
+func (cfg *NamedDatabaseConfig) Validate() error {
+	// Cannot set both host/port and hosts list
+	if len(cfg.Hosts) > 0 && cfg.Host != "" {
+		return fmt.Errorf(
+			"database %q: cannot set both 'host' and 'hosts'; "+
+				"use 'hosts' for multi-host or 'host' for single-host",
+			cfg.Name,
+		)
+	}
+
+	// Validate each host entry
+	for i, h := range cfg.Hosts {
+		if h.Host == "" {
+			return fmt.Errorf(
+				"database %q: hosts[%d] has empty host",
+				cfg.Name, i,
+			)
+		}
+		if h.Port != 0 && (h.Port < 1 || h.Port > 65535) {
+			return fmt.Errorf(
+				"database %q: hosts[%d] has invalid port %d",
+				cfg.Name, i, h.Port,
+			)
+		}
+	}
+
+	// target_session_attrs only valid with multi-host
+	if cfg.TargetSessionAttrs != "" && len(cfg.Hosts) == 0 {
+		return fmt.Errorf(
+			"database %q: target_session_attrs requires 'hosts' "+
+				"to be set for multi-host connections",
+			cfg.Name,
+		)
+	}
+
+	// Validate target_session_attrs value
+	if cfg.TargetSessionAttrs != "" {
+		if !validTargetSessionAttrs[cfg.TargetSessionAttrs] {
+			return fmt.Errorf(
+				"database %q: invalid target_session_attrs %q; "+
+					"valid values: any, read-write, read-only, "+
+					"primary, standby, prefer-standby",
+				cfg.Name, cfg.TargetSessionAttrs,
+			)
+		}
+	}
+
+	return nil
 }
 
 // IsAllowedForLLMSwitching returns true if LLM is allowed to switch to this database
@@ -297,7 +427,9 @@ func LoadConfig(configPath string, cliFlags CLIFlags) (*Config, error) {
 	applyEnvironmentVariables(cfg)
 
 	// Override with command line flags (highest priority)
-	applyCLIFlags(cfg, cliFlags)
+	if err := applyCLIFlags(cfg, cliFlags); err != nil {
+		return nil, fmt.Errorf("applying CLI flags: %w", err)
+	}
 
 	// Validate final configuration
 	if err := validateConfig(cfg); err != nil {
@@ -349,6 +481,12 @@ type CLIFlags struct {
 	DBPassSet  bool
 	DBSSLMode  string
 	DBSSLSet   bool
+
+	// Multi-host database flags
+	DBHosts                 string
+	DBHostsSet              bool
+	DBTargetSessionAttrs    string
+	DBTargetSessionAttrsSet bool
 
 	// Secret file flags
 	SecretFile    string
@@ -744,6 +882,16 @@ func applyEnvironmentVariables(cfg *Config) {
 		if cfg.Databases[0].SSLMode == "prefer" {
 			setStringFromEnv(&cfg.Databases[0].SSLMode, "PGSSLMODE")
 		}
+
+		// Multi-host connection support via environment variable
+		if hostsEnv := os.Getenv("PGEDGE_DB_HOSTS"); hostsEnv != "" {
+			if entries, err := ParseHostEntries(hostsEnv); err == nil {
+				cfg.Databases[0].Hosts = entries
+				cfg.Databases[0].Host = "" // Clear single host to avoid conflict
+			}
+		}
+
+		setStringFromEnv(&cfg.Databases[0].TargetSessionAttrs, "PGEDGE_DB_TARGET_SESSION_ATTRS")
 	}
 
 	// Embedding
@@ -854,7 +1002,7 @@ func applyEnvironmentVariables(cfg *Config) {
 }
 
 // applyCLIFlags overrides config with CLI flags if they were explicitly set
-func applyCLIFlags(cfg *Config, flags CLIFlags) {
+func applyCLIFlags(cfg *Config, flags CLIFlags) error {
 	// HTTP
 	if flags.HTTPEnabledSet {
 		cfg.HTTP.Enabled = flags.HTTPEnabled
@@ -890,7 +1038,7 @@ func applyCLIFlags(cfg *Config, flags CLIFlags) {
 
 	// Database CLI flags apply to the first database in the list
 	// Create a default database if none exists and any DB flag is set
-	if len(cfg.Databases) == 0 && (flags.DBHostSet || flags.DBPortSet || flags.DBNameSet || flags.DBUserSet || flags.DBPassSet || flags.DBSSLSet) {
+	if len(cfg.Databases) == 0 && (flags.DBHostSet || flags.DBPortSet || flags.DBNameSet || flags.DBUserSet || flags.DBPassSet || flags.DBSSLSet || flags.DBHostsSet || flags.DBTargetSessionAttrsSet) {
 		cfg.Databases = []NamedDatabaseConfig{{
 			Name:                "default",
 			Host:                "localhost",
@@ -922,6 +1070,16 @@ func applyCLIFlags(cfg *Config, flags CLIFlags) {
 		if flags.DBSSLSet {
 			cfg.Databases[0].SSLMode = flags.DBSSLMode
 		}
+		if flags.DBHostsSet {
+			entries, err := ParseHostEntries(flags.DBHosts)
+			if err != nil {
+				return fmt.Errorf("invalid --db-hosts value: %w", err)
+			}
+			cfg.Databases[0].Hosts = entries
+		}
+		if flags.DBTargetSessionAttrsSet {
+			cfg.Databases[0].TargetSessionAttrs = flags.DBTargetSessionAttrs
+		}
 	}
 
 	// Secret file
@@ -933,6 +1091,8 @@ func applyCLIFlags(cfg *Config, flags CLIFlags) {
 	if flags.TraceFileSet {
 		cfg.TraceFile = flags.TraceFile
 	}
+
+	return nil
 }
 
 // validateConfig checks if the configuration is valid
@@ -971,6 +1131,11 @@ func validateConfig(cfg *Config) error {
 		// Require user field
 		if db.User == "" {
 			return fmt.Errorf("database '%s': user is required (set via -db-user, PGEDGE_DB_USER, PGUSER env var, or config file)", db.Name)
+		}
+
+		// Validate multi-host settings
+		if err := db.Validate(); err != nil {
+			return err
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -268,8 +268,8 @@ type NamedDatabaseConfig struct {
 	PoolMaxConns          int    `yaml:"pool_max_conns"`           // Maximum number of connections (default: 4)
 	PoolMinConns          int    `yaml:"pool_min_conns"`           // Minimum number of connections (default: 0)
 	PoolMaxConnIdleTime   string `yaml:"pool_max_conn_idle_time"`  // Max time a connection can be idle before being closed (default: 30m)
-	PoolHealthCheckPeriod string `yaml:"pool_health_check_period"` // How often idle connections are checked (default: 1m for multi-host, 0 for single-host)
-	PoolMaxConnLifetime   string `yaml:"pool_max_conn_lifetime"`   // Max lifetime of a connection before it is closed and recreated (default: 0 = unlimited)
+	PoolHealthCheckPeriod string `yaml:"pool_health_check_period"` // How often idle connections are checked (default: 30s for multi-host, 0 for single-host)
+	PoolMaxConnLifetime   string `yaml:"pool_max_conn_lifetime"`   // Max lifetime of a connection before it is closed and recreated (default: 5m for multi-host, 0 for single-host)
 }
 
 // formatHostPort returns a host:port string, bracketing IPv6 addresses.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -885,7 +886,10 @@ func applyEnvironmentVariables(cfg *Config) {
 
 		// Multi-host connection support via environment variable
 		if hostsEnv := os.Getenv("PGEDGE_DB_HOSTS"); hostsEnv != "" {
-			if entries, err := ParseHostEntries(hostsEnv); err == nil {
+			entries, err := ParseHostEntries(hostsEnv)
+			if err != nil {
+				log.Printf("WARNING: ignoring invalid PGEDGE_DB_HOSTS value %q: %v", hostsEnv, err)
+			} else {
 				cfg.Databases[0].Hosts = entries
 				cfg.Databases[0].Host = "" // Clear single host to avoid conflict
 			}
@@ -1076,6 +1080,7 @@ func applyCLIFlags(cfg *Config, flags CLIFlags) error {
 				return fmt.Errorf("invalid --db-hosts value: %w", err)
 			}
 			cfg.Databases[0].Hosts = entries
+			cfg.Databases[0].Host = "" // Clear single host to avoid validation conflict
 		}
 		if flags.DBTargetSessionAttrsSet {
 			cfg.Databases[0].TargetSessionAttrs = flags.DBTargetSessionAttrs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,6 +296,20 @@ var validTargetSessionAttrs = map[string]bool{
 	"prefer-standby": true,
 }
 
+// validateHostname checks that a hostname does not contain characters
+// that would corrupt a libpq connection string (commas, whitespace,
+// at-signs, slashes, or question marks).
+func validateHostname(host string) error {
+	if strings.ContainsAny(host, ", \t\n\r@/?") {
+		return fmt.Errorf(
+			"invalid hostname %q: must not contain commas, "+
+				"whitespace, or URI-special characters",
+			host,
+		)
+	}
+	return nil
+}
+
 // Validate checks the NamedDatabaseConfig for invalid combinations.
 func (cfg *NamedDatabaseConfig) Validate() error {
 	// Cannot set both host/port and hosts list
@@ -307,6 +321,13 @@ func (cfg *NamedDatabaseConfig) Validate() error {
 		)
 	}
 
+	// Validate single-host hostname
+	if cfg.Host != "" {
+		if err := validateHostname(cfg.Host); err != nil {
+			return fmt.Errorf("database %q: %w", cfg.Name, err)
+		}
+	}
+
 	// Validate each host entry
 	for i, h := range cfg.Hosts {
 		if h.Host == "" {
@@ -314,6 +335,10 @@ func (cfg *NamedDatabaseConfig) Validate() error {
 				"database %q: hosts[%d] has empty host",
 				cfg.Name, i,
 			)
+		}
+		if err := validateHostname(h.Host); err != nil {
+			return fmt.Errorf("database %q: hosts[%d]: %w",
+				cfg.Name, i, err)
 		}
 		if h.Port != 0 && (h.Port < 1 || h.Port > 65535) {
 			return fmt.Errorf(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,16 +183,51 @@ func ParseHostEntries(s string) ([]HostEntry, error) {
 		if part == "" {
 			continue
 		}
-		host, portStr, hasPort := strings.Cut(part, ":")
+
+		var host string
 		port := 5432
-		if hasPort {
-			var err error
-			port, err = strconv.Atoi(portStr)
-			if err != nil {
+
+		if strings.HasPrefix(part, "[") {
+			// Bracketed IPv6: [2001:db8::1]:5432 or [2001:db8::1]
+			closeBracket := strings.Index(part, "]")
+			if closeBracket < 0 {
 				return nil, fmt.Errorf(
-					"invalid port in host entry %q: %w", part, err)
+					"missing closing bracket in host entry %q", part)
+			}
+			host = part[1:closeBracket]
+			rest := part[closeBracket+1:]
+			if strings.HasPrefix(rest, ":") {
+				var err error
+				port, err = strconv.Atoi(rest[1:])
+				if err != nil {
+					return nil, fmt.Errorf(
+						"invalid port in host entry %q: %w",
+						part, err)
+				}
+			} else if rest != "" {
+				return nil, fmt.Errorf(
+					"unexpected characters after bracket in "+
+						"host entry %q", part)
+			}
+		} else if strings.Count(part, ":") > 1 {
+			// Unbracketed IPv6: 2001:db8::1 (no port, use default)
+			host = part
+		} else {
+			// IPv4 or hostname with optional :port
+			if idx := strings.LastIndex(part, ":"); idx >= 0 {
+				var err error
+				port, err = strconv.Atoi(part[idx+1:])
+				if err != nil {
+					return nil, fmt.Errorf(
+						"invalid port in host entry %q: %w",
+						part, err)
+				}
+				host = part[:idx]
+			} else {
+				host = part
 			}
 		}
+
 		if port < 1 || port > 65535 {
 			return nil, fmt.Errorf(
 				"port %d out of range (1-65535) in host entry %q",
@@ -237,6 +272,14 @@ type NamedDatabaseConfig struct {
 	PoolMaxConnLifetime   string `yaml:"pool_max_conn_lifetime"`   // Max lifetime of a connection before it is closed and recreated (default: 0 = unlimited)
 }
 
+// formatHostPort returns a host:port string, bracketing IPv6 addresses.
+func formatHostPort(host string, port int) string {
+	if strings.Contains(host, ":") {
+		return fmt.Sprintf("[%s]:%d", host, port)
+	}
+	return fmt.Sprintf("%s:%d", host, port)
+}
+
 // BuildConnectionString creates a PostgreSQL connection string from NamedDatabaseConfig
 // If password is not set, pgx will automatically look it up from .pgpass file
 func (cfg *NamedDatabaseConfig) BuildConnectionString() string {
@@ -253,12 +296,12 @@ func (cfg *NamedDatabaseConfig) BuildConnectionString() string {
 			if port == 0 {
 				port = 5432
 			}
-			parts[i] = fmt.Sprintf("%s:%d", h.Host, port)
+			parts[i] = formatHostPort(h.Host, port)
 		}
 		u.Host = strings.Join(parts, ",")
 	} else {
 		// Single host (existing behavior)
-		u.Host = fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+		u.Host = formatHostPort(cfg.Host, cfg.Port)
 	}
 
 	u.Path = cfg.Database

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -183,6 +183,29 @@ func TestBuildConnectionString(t *testing.T) {
 			},
 			expected: "postgres://admin:p%40ss%3Aword@h1.example.com:5432,h2.example.com:5433/mydb?sslmode=verify-full",
 		},
+		{
+			name: "IPv6 single host is bracketed",
+			config: NamedDatabaseConfig{
+				User:     "postgres",
+				Host:     "2001:db8::1",
+				Port:     5432,
+				Database: "mydb",
+			},
+			expected: "postgres://postgres@[2001:db8::1]:5432/mydb",
+		},
+		{
+			name: "IPv6 multi-host entries are bracketed",
+			config: NamedDatabaseConfig{
+				User:     "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "2001:db8::1", Port: 5432},
+					{Host: "::1", Port: 5433},
+				},
+				TargetSessionAttrs: "read-write",
+			},
+			expected: "postgres://postgres@[2001:db8::1]:5432,[::1]:5433/mydb?target_session_attrs=read-write",
+		},
 	}
 
 	for _, tt := range tests {
@@ -813,6 +836,43 @@ func TestParseHostEntries(t *testing.T) {
 				{Host: "h1", Port: 5432},
 				{Host: "h2", Port: 5433},
 			},
+		},
+		{
+			name:  "bracketed IPv6 with port",
+			input: "[2001:db8::1]:5432,[2001:db8::2]:5433",
+			want: []HostEntry{
+				{Host: "2001:db8::1", Port: 5432},
+				{Host: "2001:db8::2", Port: 5433},
+			},
+		},
+		{
+			name:  "bracketed IPv6 without port",
+			input: "[2001:db8::1]",
+			want: []HostEntry{
+				{Host: "2001:db8::1", Port: 5432},
+			},
+		},
+		{
+			name:  "unbracketed IPv6 uses default port",
+			input: "2001:db8::1",
+			want: []HostEntry{
+				{Host: "2001:db8::1", Port: 5432},
+			},
+		},
+		{
+			name:  "mixed IPv4 and IPv6",
+			input: "h1:5432,[::1]:5433,2001:db8::1",
+			want: []HostEntry{
+				{Host: "h1", Port: 5432},
+				{Host: "::1", Port: 5433},
+				{Host: "2001:db8::1", Port: 5432},
+			},
+		},
+		{
+			name:    "missing closing bracket",
+			input:   "[2001:db8::1:5432",
+			wantErr: true,
+			errMsg:  "missing closing bracket",
 		},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,7 +13,9 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -129,6 +131,57 @@ func TestBuildConnectionString(t *testing.T) {
 				Database: "testdb",
 			},
 			expected: "postgres://user%3Aname:p%40ss%3Aword%2F123%23test@localhost:5432/testdb",
+		},
+		{
+			name: "multi-host with hosts list",
+			config: NamedDatabaseConfig{
+				User:     "postgres",
+				Database: "mydb",
+				SSLMode:  "require",
+				Hosts: []HostEntry{
+					{Host: "primary.example.com", Port: 5432},
+					{Host: "replica.example.com", Port: 5433},
+				},
+			},
+			expected: "postgres://postgres@primary.example.com:5432,replica.example.com:5433/mydb?sslmode=require",
+		},
+		{
+			name: "multi-host with target_session_attrs",
+			config: NamedDatabaseConfig{
+				User:     "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "node1.example.com", Port: 5432},
+					{Host: "node2.example.com", Port: 5432},
+				},
+				TargetSessionAttrs: "read-write",
+			},
+			expected: "postgres://postgres@node1.example.com:5432,node2.example.com:5432/mydb?target_session_attrs=read-write",
+		},
+		{
+			name: "hosts list with single entry behaves like host/port",
+			config: NamedDatabaseConfig{
+				User:     "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "single.example.com", Port: 5432},
+				},
+			},
+			expected: "postgres://postgres@single.example.com:5432/mydb",
+		},
+		{
+			name: "hosts list with password containing special chars",
+			config: NamedDatabaseConfig{
+				User:     "admin",
+				Password: "p@ss:word",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "h1.example.com", Port: 5432},
+					{Host: "h2.example.com", Port: 5433},
+				},
+				SSLMode: "verify-full",
+			},
+			expected: "postgres://admin:p%40ss%3Aword@h1.example.com:5432,h2.example.com:5433/mydb?sslmode=verify-full",
 		},
 	}
 
@@ -630,7 +683,9 @@ func TestApplyCLIFlags(t *testing.T) {
 		DBUser:         "cliuser",
 	}
 
-	applyCLIFlags(cfg, flags)
+	if err := applyCLIFlags(cfg, flags); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if !cfg.HTTP.Enabled {
 		t.Error("expected HTTP.Enabled to be set from CLI")
@@ -690,6 +745,106 @@ func TestSetBoolFromEnv(t *testing.T) {
 	os.Unsetenv("TEST_BOOL_VAR")
 }
 
+func TestParseHostEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []HostEntry
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "two hosts with ports",
+			input: "h1:5432,h2:5433",
+			want: []HostEntry{
+				{Host: "h1", Port: 5432},
+				{Host: "h2", Port: 5433},
+			},
+		},
+		{
+			name:  "hosts without ports default to 5432",
+			input: "h1,h2",
+			want: []HostEntry{
+				{Host: "h1", Port: 5432},
+				{Host: "h2", Port: 5432},
+			},
+		},
+		{
+			name:  "single host with port",
+			input: "myhost:5433",
+			want: []HostEntry{
+				{Host: "myhost", Port: 5433},
+			},
+		},
+		{
+			name:  "whitespace trimmed",
+			input: " h1:5432 , h2:5433 ",
+			want: []HostEntry{
+				{Host: "h1", Port: 5432},
+				{Host: "h2", Port: 5433},
+			},
+		},
+		{
+			name:    "invalid port",
+			input:   "h1:abc",
+			wantErr: true,
+		},
+		{
+			name:    "port out of range",
+			input:   "host1:99999",
+			wantErr: true,
+			errMsg:  "out of range",
+		},
+		{
+			name:    "port zero",
+			input:   "host1:0",
+			wantErr: true,
+			errMsg:  "out of range",
+		},
+		{
+			name:    "negative port",
+			input:   "host1:-1",
+			wantErr: true,
+		},
+		{
+			name:  "empty entries skipped",
+			input: "h1:5432,,h2:5433",
+			want: []HostEntry{
+				{Host: "h1", Port: 5432},
+				{Host: "h2", Port: 5433},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseHostEntries(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errMsg != "" &&
+					!strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q should contain %q",
+						err.Error(), tt.errMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %d entries, got %d", len(tt.want), len(got))
+			}
+			for i := range tt.want {
+				if got[i].Host != tt.want[i].Host || got[i].Port != tt.want[i].Port {
+					t.Errorf("entry %d: expected %+v, got %+v", i, tt.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
 func TestSetIntFromEnv(t *testing.T) {
 	os.Setenv("TEST_INT_VAR", "42")
 	defer os.Unsetenv("TEST_INT_VAR")
@@ -707,5 +862,159 @@ func TestSetIntFromEnv(t *testing.T) {
 	setIntFromEnv(&dest, "TEST_INT_VAR")
 	if dest != 0 {
 		t.Errorf("expected 0 for invalid int, got %d", dest)
+	}
+}
+
+func TestPoolHealthSettings(t *testing.T) {
+	cfg := NamedDatabaseConfig{
+		User:                  "postgres",
+		Host:                  "localhost",
+		Port:                  5432,
+		Database:              "testdb",
+		PoolHealthCheckPeriod: "15s",
+		PoolMaxConnLifetime:   "1h",
+	}
+
+	// Verify fields exist and are parseable as durations
+	hcp, err := time.ParseDuration(cfg.PoolHealthCheckPeriod)
+	if err != nil {
+		t.Fatalf("PoolHealthCheckPeriod not parseable: %v", err)
+	}
+	if hcp != 15*time.Second {
+		t.Errorf("expected 15s, got %v", hcp)
+	}
+
+	mcl, err := time.ParseDuration(cfg.PoolMaxConnLifetime)
+	if err != nil {
+		t.Fatalf("PoolMaxConnLifetime not parseable: %v", err)
+	}
+	if mcl != time.Hour {
+		t.Errorf("expected 1h, got %v", mcl)
+	}
+}
+
+func TestNamedDatabaseConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  NamedDatabaseConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid single host",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Host: "localhost", Port: 5432,
+				Database: "mydb",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid multi-host",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "h1", Port: 5432},
+					{Host: "h2", Port: 5432},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "host and hosts both set",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Host: "localhost", Port: 5432,
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "h1", Port: 5432},
+				},
+			},
+			wantErr: true,
+			errMsg:  "host",
+		},
+		{
+			name: "target_session_attrs without hosts",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Host: "localhost", Port: 5432,
+				Database:           "mydb",
+				TargetSessionAttrs: "read-write",
+			},
+			wantErr: true,
+			errMsg:  "target_session_attrs",
+		},
+		{
+			name: "invalid target_session_attrs value",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "h1", Port: 5432},
+				},
+				TargetSessionAttrs: "invalid-value",
+			},
+			wantErr: true,
+			errMsg:  "target_session_attrs",
+		},
+		{
+			name: "valid target_session_attrs prefer-standby",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "h1", Port: 5432},
+					{Host: "h2", Port: 5432},
+				},
+				TargetSessionAttrs: "prefer-standby",
+			},
+			wantErr: false,
+		},
+		{
+			name: "hosts entry missing host",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "", Port: 5432},
+				},
+			},
+			wantErr: true,
+			errMsg:  "host",
+		},
+		{
+			name: "port out of range in hosts",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "h1", Port: 99999},
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errMsg != "" &&
+					!strings.Contains(
+						strings.ToLower(err.Error()),
+						tt.errMsg,
+					) {
+					t.Errorf("error %q should contain %q",
+						err.Error(), tt.errMsg)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -991,6 +991,49 @@ func TestNamedDatabaseConfig_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "invalid port",
 		},
+		{
+			name: "hostname with comma in single host",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Host: "bad,host", Port: 5432,
+				Database: "mydb",
+			},
+			wantErr: true,
+			errMsg:  "invalid hostname",
+		},
+		{
+			name: "hostname with space in single host",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Host: "bad host", Port: 5432,
+				Database: "mydb",
+			},
+			wantErr: true,
+			errMsg:  "invalid hostname",
+		},
+		{
+			name: "hostname with comma in hosts entry",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Database: "mydb",
+				Hosts: []HostEntry{
+					{Host: "good", Port: 5432},
+					{Host: "bad,host", Port: 5432},
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid hostname",
+		},
+		{
+			name: "hostname with at-sign",
+			config: NamedDatabaseConfig{
+				Name: "db1", User: "postgres",
+				Host: "user@host", Port: 5432,
+				Database: "mydb",
+			},
+			wantErr: true,
+			errMsg:  "invalid hostname",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -867,10 +867,6 @@ func TestSetIntFromEnv(t *testing.T) {
 
 func TestPoolHealthSettings(t *testing.T) {
 	cfg := NamedDatabaseConfig{
-		User:                  "postgres",
-		Host:                  "localhost",
-		Port:                  5432,
-		Database:              "testdb",
 		PoolHealthCheckPeriod: "15s",
 		PoolMaxConnLifetime:   "1h",
 	}

--- a/internal/database/client_manager_test.go
+++ b/internal/database/client_manager_test.go
@@ -11,9 +11,58 @@
 package database
 
 import (
+	"net/url"
 	"os"
+	"strconv"
 	"testing"
+
+	"pgedge-postgres-mcp/internal/config"
 )
+
+// testDBConfig parses TEST_PGEDGE_POSTGRES_CONNECTION_STRING into a
+// NamedDatabaseConfig suitable for use with NewClientManagerWithConfig.
+// It returns nil if the connection string cannot be parsed.
+func testDBConfig(t *testing.T) *config.NamedDatabaseConfig {
+	t.Helper()
+	connStr := os.Getenv("TEST_PGEDGE_POSTGRES_CONNECTION_STRING")
+	u, err := url.Parse(connStr)
+	if err != nil {
+		t.Fatalf("Failed to parse TEST_PGEDGE_POSTGRES_CONNECTION_STRING: %v", err)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	port := 5432
+	if u.Port() != "" {
+		p, err := strconv.Atoi(u.Port())
+		if err == nil {
+			port = p
+		}
+	}
+	dbName := "postgres"
+	if len(u.Path) > 1 {
+		dbName = u.Path[1:]
+	}
+	user := ""
+	password := ""
+	if u.User != nil {
+		user = u.User.Username()
+		password, _ = u.User.Password()
+	}
+	sslMode := u.Query().Get("sslmode")
+
+	return &config.NamedDatabaseConfig{
+		Name:     "testdb",
+		Host:     host,
+		Port:     port,
+		Database: dbName,
+		User:     user,
+		Password: password,
+		SSLMode:  sslMode,
+	}
+}
 
 // TestClientManager_GetClient tests that different tokens get different clients
 func TestClientManager_GetClient(t *testing.T) {
@@ -22,7 +71,7 @@ func TestClientManager_GetClient(t *testing.T) {
 		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set, skipping database test")
 	}
 
-	cm := NewClientManagerWithConfig(nil)
+	cm := NewClientManagerWithConfig(testDBConfig(t))
 	defer cm.CloseAll()
 
 	t.Run("creates new client for new token", func(t *testing.T) {
@@ -97,7 +146,7 @@ func TestClientManager_RemoveClient(t *testing.T) {
 		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set, skipping database test")
 	}
 
-	cm := NewClientManagerWithConfig(nil)
+	cm := NewClientManagerWithConfig(testDBConfig(t))
 	defer cm.CloseAll()
 
 	// Create some clients
@@ -138,7 +187,7 @@ func TestClientManager_RemoveClients(t *testing.T) {
 		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set, skipping database test")
 	}
 
-	cm := NewClientManagerWithConfig(nil)
+	cm := NewClientManagerWithConfig(testDBConfig(t))
 	defer cm.CloseAll()
 
 	// Create several clients
@@ -173,7 +222,7 @@ func TestClientManager_CloseAll(t *testing.T) {
 		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set, skipping database test")
 	}
 
-	cm := NewClientManagerWithConfig(nil)
+	cm := NewClientManagerWithConfig(testDBConfig(t))
 
 	// Create several clients
 	for i := 1; i <= 3; i++ {

--- a/internal/database/client_manager_test.go
+++ b/internal/database/client_manager_test.go
@@ -37,9 +37,10 @@ func testDBConfig(t *testing.T) *config.NamedDatabaseConfig {
 	port := 5432
 	if u.Port() != "" {
 		p, err := strconv.Atoi(u.Port())
-		if err == nil {
-			port = p
+		if err != nil {
+			t.Fatalf("invalid port %q in TEST_PGEDGE_POSTGRES_CONNECTION_STRING: %v", u.Port(), err)
 		}
+		port = p
 	}
 	dbName := "postgres"
 	if len(u.Path) > 1 {

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -14,11 +14,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -112,17 +110,14 @@ func (c *Client) ConnectTo(connStr string) error {
 		return nil // Already connected
 	}
 
-	// Add application_name to connection string if not already present
-	enhancedConnStr, err := addApplicationName(connStr, "pgEdge Natural Language Agent")
-	if err != nil {
-		return fmt.Errorf("unable to enhance connection string: %w", err)
-	}
-
 	// Parse connection string into pgxpool.Config
-	poolConfig, err := pgxpool.ParseConfig(enhancedConnStr)
+	poolConfig, err := pgxpool.ParseConfig(connStr)
 	if err != nil {
 		return fmt.Errorf("unable to parse connection string: %w", err)
 	}
+
+	// Set application_name if not already present in the connection string
+	setApplicationName(poolConfig, "pgEdge Natural Language Agent")
 
 	// Log connection details if debug logging is enabled
 	if GetLogLevel() >= LogLevelDebug {
@@ -223,30 +218,16 @@ func (c *Client) ConnectTo(connStr string) error {
 	return nil
 }
 
-// addApplicationName adds application_name parameter to a PostgreSQL connection string.
-// It handles both single-host and multi-host connection strings (comma-separated hosts)
-// by using pgx's parser to check for existing application_name, then appending to
-// the original string to avoid mangling multi-host URLs.
-func addApplicationName(connStr, appName string) (string, error) {
-	// Use pgx's parser to check if application_name is already set.
-	// This handles both single-host and multi-host connection strings.
-	cfg, err := pgxpool.ParseConfig(connStr)
-	if err != nil {
-		return "", fmt.Errorf("invalid connection string: %w", err)
+// setApplicationName sets application_name on a pgxpool.Config if not
+// already present. This avoids string manipulation on the DSN and works
+// correctly with multi-host connection strings.
+func setApplicationName(cfg *pgxpool.Config, appName string) {
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = make(map[string]string)
 	}
-
-	// If application_name is already set in runtime params, keep it
-	if _, ok := cfg.ConnConfig.RuntimeParams["application_name"]; ok {
-		return connStr, nil
+	if _, ok := cfg.ConnConfig.RuntimeParams["application_name"]; !ok {
+		cfg.ConnConfig.RuntimeParams["application_name"] = appName
 	}
-
-	// Append application_name to the connection string
-	separator := "?"
-	if strings.Contains(connStr, "?") {
-		separator = "&"
-	}
-	return connStr + separator + "application_name=" +
-		url.QueryEscape(appName), nil
 }
 
 // SetDefaultConnection sets the default connection string to use for queries

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -130,6 +131,7 @@ func (c *Client) ConnectTo(connStr string) error {
 		poolConfigMap["min_conns"] = poolConfig.MinConns
 		poolConfigMap["max_conn_lifetime"] = poolConfig.MaxConnLifetime
 		poolConfigMap["max_conn_idle_time"] = poolConfig.MaxConnIdleTime
+		poolConfigMap["health_check_period"] = poolConfig.HealthCheckPeriod
 		LogConnectionDetails(connStr, poolConfigMap)
 	}
 
@@ -150,6 +152,35 @@ func (c *Client) ConnectTo(connStr string) error {
 				return fmt.Errorf("invalid pool_max_conn_idle_time: %w", err)
 			}
 			poolConfig.MaxConnIdleTime = idleTime
+		}
+
+		// Set health check period
+		if c.dbConfig.PoolHealthCheckPeriod != "" {
+			hcp, err := time.ParseDuration(c.dbConfig.PoolHealthCheckPeriod)
+			if err != nil {
+				return fmt.Errorf("invalid pool_health_check_period: %w", err)
+			}
+			poolConfig.HealthCheckPeriod = hcp
+		}
+
+		// Set max connection lifetime
+		if c.dbConfig.PoolMaxConnLifetime != "" {
+			mcl, err := time.ParseDuration(c.dbConfig.PoolMaxConnLifetime)
+			if err != nil {
+				return fmt.Errorf("invalid pool_max_conn_lifetime: %w", err)
+			}
+			poolConfig.MaxConnLifetime = mcl
+		}
+	}
+
+	// For multi-host connections, enable health checking by default
+	// so broken connections to failed hosts are cleaned up quickly.
+	if c.dbConfig != nil && len(c.dbConfig.Hosts) > 0 {
+		if c.dbConfig.PoolHealthCheckPeriod == "" {
+			poolConfig.HealthCheckPeriod = 30 * time.Second
+		}
+		if c.dbConfig.PoolMaxConnLifetime == "" {
+			poolConfig.MaxConnLifetime = 5 * time.Minute
 		}
 	}
 
@@ -192,24 +223,30 @@ func (c *Client) ConnectTo(connStr string) error {
 	return nil
 }
 
-// addApplicationName adds application_name parameter to a PostgreSQL connection string
+// addApplicationName adds application_name parameter to a PostgreSQL connection string.
+// It handles both single-host and multi-host connection strings (comma-separated hosts)
+// by using pgx's parser to check for existing application_name, then appending to
+// the original string to avoid mangling multi-host URLs.
 func addApplicationName(connStr, appName string) (string, error) {
-	// Parse the connection string
-	u, err := url.Parse(connStr)
+	// Use pgx's parser to check if application_name is already set.
+	// This handles both single-host and multi-host connection strings.
+	cfg, err := pgxpool.ParseConfig(connStr)
 	if err != nil {
 		return "", fmt.Errorf("invalid connection string: %w", err)
 	}
 
-	// Get existing query parameters
-	query := u.Query()
-
-	// Add application_name if not already present
-	if !query.Has("application_name") {
-		query.Set("application_name", appName)
-		u.RawQuery = query.Encode()
+	// If application_name is already set in runtime params, keep it
+	if _, ok := cfg.ConnConfig.RuntimeParams["application_name"]; ok {
+		return connStr, nil
 	}
 
-	return u.String(), nil
+	// Append application_name to the connection string
+	separator := "?"
+	if strings.Contains(connStr, "?") {
+		separator = "&"
+	}
+	return connStr + separator + "application_name=" +
+		url.QueryEscape(appName), nil
 }
 
 // SetDefaultConnection sets the default connection string to use for queries

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -11,7 +11,10 @@
 package database
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestNewClient(t *testing.T) {
@@ -243,6 +246,73 @@ func TestGetPoolFor(t *testing.T) {
 	pool = client.GetPoolFor("postgres://localhost/test")
 	if pool != nil {
 		t.Error("GetPoolFor() returned non-nil pool when Pool is nil")
+	}
+}
+
+func TestAddApplicationName(t *testing.T) {
+	tests := []struct {
+		name    string
+		connStr string
+		appName string
+		wantErr bool
+	}{
+		{
+			name:    "single host",
+			connStr: "postgres://user@localhost:5432/db",
+			appName: "test-app",
+		},
+		{
+			name:    "multi-host",
+			connStr: "postgres://user@host1:5432,host2:5433/db",
+			appName: "test-app",
+		},
+		{
+			name:    "multi-host with existing params",
+			connStr: "postgres://user@host1:5432,host2:5433/db?sslmode=require",
+			appName: "test-app",
+		},
+		{
+			name:    "already has application_name",
+			connStr: "postgres://user@host1:5432/db?application_name=existing",
+			appName: "test-app",
+		},
+		{
+			name:    "multi-host with target_session_attrs",
+			connStr: "postgres://user@h1:5432,h2:5432/db?target_session_attrs=read-write",
+			appName: "test-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := addApplicationName(tt.connStr, tt.appName)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Parse result with pgx to verify it's valid
+			_, parseErr := pgxpool.ParseConfig(result)
+			if parseErr != nil {
+				t.Fatalf("result not parseable by pgx: %v\nresult: %s", parseErr, result)
+			}
+
+			// Verify application_name behavior
+			if tt.name == "already has application_name" {
+				if !strings.Contains(result, "application_name=existing") {
+					t.Errorf("should preserve existing application_name, got: %s", result)
+				}
+			} else {
+				if !strings.Contains(result, "application_name=") {
+					t.Errorf("should contain application_name, got: %s", result)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -11,7 +11,6 @@
 package database
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -249,68 +248,51 @@ func TestGetPoolFor(t *testing.T) {
 	}
 }
 
-func TestAddApplicationName(t *testing.T) {
+func TestSetApplicationName(t *testing.T) {
 	tests := []struct {
-		name    string
-		connStr string
-		appName string
-		wantErr bool
+		name     string
+		connStr  string
+		appName  string
+		wantName string
 	}{
 		{
-			name:    "single host",
-			connStr: "postgres://user@localhost:5432/db",
-			appName: "test-app",
+			name:     "single host",
+			connStr:  "postgres://user@localhost:5432/db",
+			appName:  "test-app",
+			wantName: "test-app",
 		},
 		{
-			name:    "multi-host",
-			connStr: "postgres://user@host1:5432,host2:5433/db",
-			appName: "test-app",
+			name:     "multi-host",
+			connStr:  "postgres://user@host1:5432,host2:5433/db",
+			appName:  "test-app",
+			wantName: "test-app",
 		},
 		{
-			name:    "multi-host with existing params",
-			connStr: "postgres://user@host1:5432,host2:5433/db?sslmode=require",
-			appName: "test-app",
+			name:     "already has application_name",
+			connStr:  "postgres://user@host1:5432/db?application_name=existing",
+			appName:  "test-app",
+			wantName: "existing",
 		},
 		{
-			name:    "already has application_name",
-			connStr: "postgres://user@host1:5432/db?application_name=existing",
-			appName: "test-app",
-		},
-		{
-			name:    "multi-host with target_session_attrs",
-			connStr: "postgres://user@h1:5432,h2:5432/db?target_session_attrs=read-write",
-			appName: "test-app",
+			name:     "multi-host with target_session_attrs",
+			connStr:  "postgres://user@h1:5432,h2:5432/db?target_session_attrs=read-write",
+			appName:  "test-app",
+			wantName: "test-app",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := addApplicationName(tt.connStr, tt.appName)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				return
-			}
+			cfg, err := pgxpool.ParseConfig(tt.connStr)
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("failed to parse connection string: %v", err)
 			}
 
-			// Parse result with pgx to verify it's valid
-			_, parseErr := pgxpool.ParseConfig(result)
-			if parseErr != nil {
-				t.Fatalf("result not parseable by pgx: %v\nresult: %s", parseErr, result)
-			}
+			setApplicationName(cfg, tt.appName)
 
-			// Verify application_name behavior
-			if tt.name == "already has application_name" {
-				if !strings.Contains(result, "application_name=existing") {
-					t.Errorf("should preserve existing application_name, got: %s", result)
-				}
-			} else {
-				if !strings.Contains(result, "application_name=") {
-					t.Errorf("should contain application_name, got: %s", result)
-				}
+			got := cfg.ConnConfig.RuntimeParams["application_name"]
+			if got != tt.wantName {
+				t.Errorf("application_name = %q, want %q", got, tt.wantName)
 			}
 		})
 	}

--- a/internal/tools/database_switching.go
+++ b/internal/tools/database_switching.go
@@ -63,6 +63,30 @@ func getEffectiveCurrentDB(tokenHash string, clientManager *database.ClientManag
 	return ""
 }
 
+// populateHostFields adds host connection fields to the response map.
+// For multi-host configs, it sets host/port from the first configured entry
+// and includes the full hosts array. For single-host, it uses Host and Port directly.
+func populateHostFields(entry map[string]interface{}, cfg *config.NamedDatabaseConfig) {
+	if len(cfg.Hosts) > 0 {
+		entry["host"] = cfg.Hosts[0].Host
+		entry["port"] = cfg.Hosts[0].Port
+		hostsList := make([]map[string]interface{}, len(cfg.Hosts))
+		for j, h := range cfg.Hosts {
+			hostsList[j] = map[string]interface{}{
+				"host": h.Host,
+				"port": h.Port,
+			}
+		}
+		entry["hosts"] = hostsList
+		if cfg.TargetSessionAttrs != "" {
+			entry["target_session_attrs"] = cfg.TargetSessionAttrs
+		}
+	} else {
+		entry["host"] = cfg.Host
+		entry["port"] = cfg.Port
+	}
+}
+
 // buildDatabaseListResponse builds the JSON response for list_database_connections.
 // The statusFunc, when non-nil, is called with each database name to determine
 // its connection status ("connected" or "unavailable").
@@ -74,9 +98,13 @@ func buildDatabaseListResponse(
 	dbList := make([]map[string]interface{}, 0, len(databases))
 	for i := range databases {
 		entry := map[string]interface{}{
-			"name": databases[i].Name, "database": databases[i].Database,
-			"host": databases[i].Host, "port": databases[i].Port, "allow_writes": databases[i].AllowWrites,
+			"name":         databases[i].Name,
+			"database":     databases[i].Database,
+			"allow_writes": databases[i].AllowWrites,
 		}
+
+		populateHostFields(entry, &databases[i])
+
 		if statusFunc != nil {
 			entry["status"] = statusFunc(databases[i].Name)
 		}
@@ -110,8 +138,10 @@ before using select_database_connection to switch.
 Each database entry includes:
 - name: The connection name (use this with select_database_connection)
 - database: The PostgreSQL database name
-- host: Database server hostname
-- port: Database server port number
+- host: Database server hostname (first configured host for multi-host configs)
+- port: Database server port number (first configured port for multi-host configs)
+- hosts: (optional) Array of host/port pairs for multi-host configs
+- target_session_attrs: (optional) Session routing for multi-host
 - allow_writes: Whether write operations are permitted
 - status: Connection status ("connected" or "unavailable")
 
@@ -229,9 +259,10 @@ permissions. Consider re-examining the schema after switching.`,
 				"message":      fmt.Sprintf("Switched to database: %s", name),
 				"current":      name,
 				"database":     dbConfig.Database,
-				"host":         dbConfig.Host,
 				"allow_writes": dbConfig.AllowWrites,
 			}
+
+			populateHostFields(result, dbConfig)
 
 			jsonBytes, err := json.MarshalIndent(result, "", "  ")
 			if err != nil {

--- a/internal/tools/database_switching.go
+++ b/internal/tools/database_switching.go
@@ -66,15 +66,24 @@ func getEffectiveCurrentDB(tokenHash string, clientManager *database.ClientManag
 // populateHostFields adds host connection fields to the response map.
 // For multi-host configs, it sets host/port from the first configured entry
 // and includes the full hosts array. For single-host, it uses Host and Port directly.
+// effectivePort returns the port or 5432 if zero, matching
+// BuildConnectionString behavior when YAML omits the port.
+func effectivePort(port int) int {
+	if port == 0 {
+		return 5432
+	}
+	return port
+}
+
 func populateHostFields(entry map[string]interface{}, cfg *config.NamedDatabaseConfig) {
 	if len(cfg.Hosts) > 0 {
 		entry["host"] = cfg.Hosts[0].Host
-		entry["port"] = cfg.Hosts[0].Port
+		entry["port"] = effectivePort(cfg.Hosts[0].Port)
 		hostsList := make([]map[string]interface{}, len(cfg.Hosts))
 		for j, h := range cfg.Hosts {
 			hostsList[j] = map[string]interface{}{
 				"host": h.Host,
-				"port": h.Port,
+				"port": effectivePort(h.Port),
 			}
 		}
 		entry["hosts"] = hostsList
@@ -83,7 +92,7 @@ func populateHostFields(entry map[string]interface{}, cfg *config.NamedDatabaseC
 		}
 	} else {
 		entry["host"] = cfg.Host
-		entry["port"] = cfg.Port
+		entry["port"] = effectivePort(cfg.Port)
 	}
 }
 

--- a/internal/tools/database_switching_test.go
+++ b/internal/tools/database_switching_test.go
@@ -593,6 +593,192 @@ func TestSelectDatabaseConnectionTool_EmptyNameString(t *testing.T) {
 	}
 }
 
+// TestBuildDatabaseListResponse_MultiHost tests multi-host config in list response
+func TestBuildDatabaseListResponse_MultiHost(t *testing.T) {
+	databases := []config.NamedDatabaseConfig{
+		{
+			Name:     "single",
+			Database: "mydb",
+			Host:     "db.example.com",
+			Port:     5432,
+		},
+		{
+			Name:     "cluster",
+			Database: "mydb",
+			Hosts: []config.HostEntry{
+				{Host: "primary.example.com", Port: 5432},
+				{Host: "replica.example.com", Port: 5433},
+			},
+			TargetSessionAttrs: "read-write",
+		},
+	}
+
+	resp, err := buildDatabaseListResponse(databases, "single", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Parse the response JSON
+	var result map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(resp.Content[0].Text), &result); jsonErr != nil {
+		t.Fatalf("failed to parse response: %v", jsonErr)
+	}
+
+	dbList := result["databases"].([]interface{})
+	if len(dbList) != 2 {
+		t.Fatalf("expected 2 databases, got %d", len(dbList))
+	}
+
+	// Single-host entry
+	single := dbList[0].(map[string]interface{})
+	if single["host"] != "db.example.com" {
+		t.Errorf("single-host: expected host db.example.com, got %v", single["host"])
+	}
+	if _, hasHosts := single["hosts"]; hasHosts {
+		t.Error("single-host: should not have hosts array")
+	}
+
+	// Multi-host entry
+	cluster := dbList[1].(map[string]interface{})
+	if cluster["host"] != "primary.example.com" {
+		t.Errorf("multi-host: expected primary host, got %v", cluster["host"])
+	}
+	hosts, ok := cluster["hosts"]
+	if !ok {
+		t.Fatal("multi-host: expected hosts array in response")
+	}
+	hostList := hosts.([]interface{})
+	if len(hostList) != 2 {
+		t.Errorf("multi-host: expected 2 hosts, got %d", len(hostList))
+	}
+	if cluster["target_session_attrs"] != "read-write" {
+		t.Errorf("expected target_session_attrs read-write, got %v", cluster["target_session_attrs"])
+	}
+}
+
+// TestPopulateHostFields tests the shared host field population helper
+func TestPopulateHostFields(t *testing.T) {
+	t.Run("single host", func(t *testing.T) {
+		entry := map[string]interface{}{}
+		cfg := &config.NamedDatabaseConfig{
+			Host: "db.example.com",
+			Port: 5432,
+		}
+		populateHostFields(entry, cfg)
+
+		if entry["host"] != "db.example.com" {
+			t.Errorf("expected host db.example.com, got %v", entry["host"])
+		}
+		if entry["port"] != 5432 {
+			t.Errorf("expected port 5432, got %v", entry["port"])
+		}
+		if _, ok := entry["hosts"]; ok {
+			t.Error("single-host should not have hosts array")
+		}
+		if _, ok := entry["target_session_attrs"]; ok {
+			t.Error("single-host should not have target_session_attrs")
+		}
+	})
+
+	t.Run("multi host without target_session_attrs", func(t *testing.T) {
+		entry := map[string]interface{}{}
+		cfg := &config.NamedDatabaseConfig{
+			Hosts: []config.HostEntry{
+				{Host: "primary.example.com", Port: 5432},
+				{Host: "replica.example.com", Port: 5433},
+			},
+		}
+		populateHostFields(entry, cfg)
+
+		if entry["host"] != "primary.example.com" {
+			t.Errorf("expected first host, got %v", entry["host"])
+		}
+		if entry["port"] != 5432 {
+			t.Errorf("expected first port, got %v", entry["port"])
+		}
+		hostsList := entry["hosts"].([]map[string]interface{})
+		if len(hostsList) != 2 {
+			t.Fatalf("expected 2 hosts, got %d", len(hostsList))
+		}
+		if hostsList[1]["host"] != "replica.example.com" {
+			t.Errorf("expected second host replica.example.com, got %v", hostsList[1]["host"])
+		}
+		if _, ok := entry["target_session_attrs"]; ok {
+			t.Error("should not have target_session_attrs when empty")
+		}
+	})
+
+	t.Run("multi host with target_session_attrs", func(t *testing.T) {
+		entry := map[string]interface{}{}
+		cfg := &config.NamedDatabaseConfig{
+			Hosts: []config.HostEntry{
+				{Host: "primary.example.com", Port: 5432},
+			},
+			TargetSessionAttrs: "read-write",
+		}
+		populateHostFields(entry, cfg)
+
+		if entry["target_session_attrs"] != "read-write" {
+			t.Errorf("expected target_session_attrs read-write, got %v", entry["target_session_attrs"])
+		}
+	})
+}
+
+// TestSelectDatabaseConnectionTool_MultiHost tests multi-host fields in select response
+func TestSelectDatabaseConnectionTool_MultiHost(t *testing.T) {
+	trueVal := true
+	databases := []config.NamedDatabaseConfig{
+		{
+			Name:     "cluster",
+			Database: "mydb",
+			User:     "user1",
+			Hosts: []config.HostEntry{
+				{Host: "primary.example.com", Port: 5432},
+				{Host: "replica.example.com", Port: 5433},
+			},
+			TargetSessionAttrs: "read-write",
+			AllowLLMSwitching:  &trueVal,
+		},
+	}
+	cfg := &config.Config{Databases: databases}
+	clientManager := database.NewClientManager(databases)
+	defer clientManager.CloseAll()
+
+	tool := SelectDatabaseConnectionTool(clientManager, nil, cfg)
+
+	args := map[string]interface{}{
+		"__context": context.Background(),
+		"name":      "cluster",
+	}
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+	if response.IsError {
+		t.Fatalf("Expected success, got error: %v", response.Content)
+	}
+
+	var result map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(response.Content[0].Text), &result); jsonErr != nil {
+		t.Fatalf("failed to parse response: %v", jsonErr)
+	}
+
+	if result["host"] != "primary.example.com" {
+		t.Errorf("expected host primary.example.com, got %v", result["host"])
+	}
+	hosts, ok := result["hosts"]
+	if !ok {
+		t.Fatal("expected hosts array in select response")
+	}
+	hostList := hosts.([]interface{})
+	if len(hostList) != 2 {
+		t.Errorf("expected 2 hosts, got %d", len(hostList))
+	}
+	if result["target_session_attrs"] != "read-write" {
+		t.Errorf("expected target_session_attrs read-write, got %v", result["target_session_attrs"])
+	}
+}
+
 // TestListDatabaseConnectionsTool_DefaultsToNil tests allow_llm_switching defaulting to true when nil
 func TestListDatabaseConnectionsTool_DefaultsToNil(t *testing.T) {
 	// Create database without explicit allow_llm_switching (should default to true)

--- a/web/src/components/DatabaseSelectorPopover.jsx
+++ b/web/src/components/DatabaseSelectorPopover.jsx
@@ -154,7 +154,7 @@ const DatabaseSelectorPopover = ({
                                                 color="text.secondary"
                                                 sx={{ fontFamily: 'monospace' }}
                                             >
-                                                {db.user}@{db.host}:{db.port}/{db.database}
+                                                {db.user}@{db.host}:{db.port}/{db.database}{db.hosts && db.hosts.length > 1 ? ` (+${db.hosts.length - 1} more hosts)` : ''}
                                             </Typography>
                                         }
                                     />
@@ -191,6 +191,11 @@ DatabaseSelectorPopover.propTypes = {
         user: PropTypes.string,
         sslmode: PropTypes.string,
         allow_writes: PropTypes.bool,
+        hosts: PropTypes.arrayOf(PropTypes.shape({
+            host: PropTypes.string,
+            port: PropTypes.number,
+        })),
+        target_session_attrs: PropTypes.string,
     })),
     currentDatabase: PropTypes.string,
     onSelect: PropTypes.func.isRequired,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                             
                                                                                                                                                                                                                                       
  - Add multi-host connection support for PostgreSQL high availability and failover, using libpq-compatible multi-host DSN strings (#96)                                                                                                                                                                    
  - New `hosts` array and `target_session_attrs` config fields enable automatic failover across multiple PostgreSQL servers via pgx                                                                                                                                                                      
  - Pool health check and connection lifetime settings improve resilience for multi-host deployments
  - CLI flags, environment variables, config validation, API responses, MCP tool responses, and web client all updated for multi-host
  - Fully backward compatible; existing single-host configs unchanged

  ## Changed Files

  | Area | Files |
  |------|-------|
  | Config | `internal/config/config.go`, `config_test.go` |
  | Connection | `internal/database/connection.go`, `connection_test.go` |
  | MCP Tools | `internal/tools/database_switching.go`, `database_switching_test.go` |
  | HTTP API | `internal/api/databases.go`, `databases_test.go` |
  | CLI | `cmd/pgedge-pg-mcp-svr/main.go` |
  | Web Client | `web/src/components/DatabaseSelectorPopover.jsx` |
  | Docs | `docs/changelog.md`, `docs/guide/configuration.md` |
  | Examples | `examples/pgedge-postgres-mcp-http.yaml.example`, `stdio.yaml.example` |

  ## Test Plan

  - [ ] Unit tests pass: `go test -count=1 ./internal/config/ ./internal/tools/ ./internal/api/ ./internal/database/`
  - [ ] Integration tests pass with a running Postgres instance
  - [ ] Single-host config produces identical behavior to before
  - [ ] Multi-host config generates correct libpq connection string
  - [ ] Invalid configs (both host and hosts, bad port, bad target_session_attrs) are rejected
  - [ ] Web client shows "(+N more hosts)" for multi-host connections
  - [ ] SIGHUP reload preserves CLI multi-host overrides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-host database connections for high availability and automatic failover
  * Target session attributes for read/write routing in multi-host setups
  * CLI flags and env var to configure multi-hosts and session attributes
  * Pool health check and connection lifetime settings
  * Database selector UI shows host counts and connection details

* **Documentation**
  * Updated configuration guide, examples, and changelog for multi-host and pool settings

* **Tests**
  * Expanded test coverage for multi-host parsing, validation, and API responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->