### PR TITLE
Only create a GitHub release when triggered by a tag push, not when

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,7 @@ jobs:
                   cat checksums.txt
 
             - name: Create GitHub Release
+              if: github.event_name != 'workflow_dispatch'
               uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
               with:
                   files: |


### PR DESCRIPTION
  Only create a GitHub release when triggered by a tag push, not when run manually via workflow_dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to skip automatic release creation for manual workflow triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->