### PR TITLE
Fix workflow_dispatch builds by using GoReleaser snapshot mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
               with:
                   distribution: goreleaser
                   version: latest
-                  args: release --clean --config .goreleaser-amd64.yaml ${{ github.event_name == 'workflow_dispatch' && '--snapshot' || '' }}
+                  args: release --clean --config .goreleaser-amd64.yaml ${{ github.event_name == 'workflow_dispatch' && github.ref_type != 'tag' && '--snapshot' || '' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -214,7 +214,7 @@ jobs:
               with:
                   distribution: goreleaser
                   version: latest
-                  args: release --clean --config .goreleaser-arm64.yaml ${{ github.event_name == 'workflow_dispatch' && '--snapshot' || '' }}
+                  args: release --clean --config .goreleaser-arm64.yaml ${{ github.event_name == 'workflow_dispatch' && github.ref_type != 'tag' && '--snapshot' || '' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -235,7 +235,7 @@ jobs:
         name: Create Release
         runs-on: ubuntu-latest
         needs: [build-amd64, build-arm64]
-        if: github.event_name != 'workflow_dispatch'
+        if: github.ref_type == 'tag'
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,7 @@ jobs:
         name: Create Release
         runs-on: ubuntu-latest
         needs: [build-amd64, build-arm64]
+        if: github.event_name != 'workflow_dispatch'
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -283,7 +284,6 @@ jobs:
                   cat checksums.txt
 
             - name: Create GitHub Release
-              if: github.event_name != 'workflow_dispatch'
               uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
               with:
                   files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
               with:
                   distribution: goreleaser
                   version: latest
-                  args: release --clean --config .goreleaser-amd64.yaml
+                  args: release --clean --config .goreleaser-amd64.yaml ${{ github.event_name == 'workflow_dispatch' && '--snapshot' || '' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -214,7 +214,7 @@ jobs:
               with:
                   distribution: goreleaser
                   version: latest
-                  args: release --clean --config .goreleaser-arm64.yaml
+                  args: release --clean --config .goreleaser-arm64.yaml ${{ github.event_name == 'workflow_dispatch' && '--snapshot' || '' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
  Skip GitHub release creation and use --snapshot flag when triggered
  manually, so builds succeed without a tagged commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enable on-demand snapshot builds when the release workflow is manually triggered, producing snapshot artifacts for testing.
  * Ensure the main release job runs only for tagged pushes, so official releases are created from tags.
  * Allow the release creation step to execute for manual triggers and pushes, so release artifacts and notes can be generated outside tag-only flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->