### PR TITLE
Update kb builder sources with latest releases

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -157,10 +157,10 @@ sources:
       project_version: "1.0.0-beta1"
 
     - git_url: "https://github.com/pgEdge/pgedge-docloader.git"
-      tag: "v1.0.0-beta1"
+      tag: "v1.0.0"
       doc_path: "docs"
       project_name: "pgEdge Docloader"
-      project_version: "1.0.0-beta1"
+      project_version: "1.0.0"
 
     - git_url: "https://github.com/pgEdge/pgedge-rag-server.git"
       tag: "v1.0.0-beta2"
@@ -174,6 +174,12 @@ sources:
       project_name: "pgEdge RAG Server"
       project_version: "1.0.0-beta1"
 
+    - git_url: "https://github.com/pgEdge/spock.git"
+      tag: "v5.0.6"
+      doc_path: "docs"
+      project_name: "Spock"
+      project_version: "5.0.6"
+      
     - git_url: "https://github.com/pgEdge/spock.git"
       tag: "v5.0.5"
       doc_path: "docs"
@@ -271,16 +277,10 @@ sources:
       project_version: "1.3.5"
 
     - git_url: "https://github.com/pgEdge/pgedge-vectorizer.git"
-      tag: "v1.0-beta2"
+      tag: "v1.0"
       doc_path: "docs"
       project_name: "pgEdge Vectorizer"
-      project_version: "1.0-beta2"
-
-    - git_url: "https://github.com/pgEdge/pgedge-vectorizer.git"
-      tag: "v1.0-beta1"
-      doc_path: "docs"
-      project_name: "pgEdge Vectorizer"
-      project_version: "1.0-beta1"
+      project_version: "1.0"
 
     - git_url: "https://github.com/pgbouncer/pgbouncer.git"
       tag: "pgbouncer_1_25_1"


### PR DESCRIPTION
Currently, DocLoader v1.0.0 and Vectorizer v1.0 are under testing. The main purpose of sharing these changes in advance is to ensure they are available at the time of MCP tag creation. You can apply this PR later on as needed.

This PR include the following updates 

Version updates:
- pgEdge Docloader: v1.0.0-beta1 → v1.0.0
- pgEdge Vectorizer: v1.0-beta2 → v1.0 (consolidated from beta versions)

New additions:
- Spock v5.0.6

Removed:
- pgEdge Vectorizer v1.0-beta1 (superseded by v1.0)
- pgEdge Vectorizer v1.0-beta2 (superseded by v1.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Promoted key project dependencies to stable production releases: pgedge-docloader upgraded to v1.0.0 and pgedge-vectorizer to v1.0 (from beta versions)
  * Streamlined version management by consolidating multiple pgedge-vectorizer beta releases into a unified stable version
  * Expanded framework compatibility by adding Spock v5.0.6 alongside previously supported versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->