### PR TITLE
docs: add connect_timeout to config examples, update kb sources

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -39,13 +39,13 @@ sources:
       project_version: "14"
 
     - git_url: "https://github.com/pgadmin-org/pgadmin4.git"
-      tag: "REL-9_11"
+      tag: "REL-9_13"
       doc_path: "docs/en_US"
       project_name: "pgAdmin 4"
       project_version: "9.13"
 
     - git_url: "https://github.com/pgadmin-org/pgadmin4.git"
-      tag: "REL-9_11"
+      tag: "REL-9_12"
       doc_path: "docs/en_US"
       project_name: "pgAdmin 4"
       project_version: "9.12"

--- a/examples/pgedge-postgres-mcp-http.yaml.example
+++ b/examples/pgedge-postgres-mcp-http.yaml.example
@@ -39,6 +39,7 @@ databases:
       pool_max_conns: 10
       pool_min_conns: 2
       pool_max_conn_idle_time: "5m"
+      connect_timeout: "10s"
       available_to_users: []  # Empty = available to all users
       # WARNING: allow_writes enables the AI to execute INSERT, UPDATE, DELETE, etc.
       # Only enable on non-production databases where data loss is acceptable.
@@ -82,6 +83,7 @@ databases:
     #   user: "postgres"
     #   password: ""
     #   sslmode: "prefer"
+    #   connect_timeout: "10s"
     #   pool_max_conns: 10
     #   pool_min_conns: 2
     #   pool_health_check_period: "30s"

--- a/examples/pgedge-postgres-mcp-stdio.yaml.example
+++ b/examples/pgedge-postgres-mcp-stdio.yaml.example
@@ -20,6 +20,7 @@ databases:
       user: "postgres"
       password: ""  # Leave empty to use .pgpass file
       sslmode: "prefer"
+      connect_timeout: "10s"
       pool_max_conns: 10
       pool_min_conns: 2
       pool_max_conn_idle_time: "5m"
@@ -52,6 +53,7 @@ databases:
     #   user: "postgres"
     #   password: ""
     #   sslmode: "prefer"
+    #   connect_timeout: "10s"
     #   pool_max_conns: 10
     #   pool_min_conns: 2
     #   pool_health_check_period: "30s"


### PR DESCRIPTION
Example config updates:
- Add connect_timeout: "10s" to single-host and multi-host database configurations in HTTP and STDIO example files

KB builder source updates:
- Update pgAdmin 4 tags (REL-9_11 → REL-9_13, REL-9_11 → REL-9_12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pgAdmin 4 example versions to latest releases (9.12 and 9.13).
  * Added connection timeout configuration examples for database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->