### PR TITLE
Fix SIGHUP config reload not invalidating stale DB connections

### DIFF
--- a/internal/database/client_manager.go
+++ b/internal/database/client_manager.go
@@ -312,25 +312,25 @@ func (cm *ClientManager) UpdateDatabaseConfigs(databases []config.NamedDatabaseC
 
 // databaseConfigChanged returns true when connection-relevant fields differ
 // between two NamedDatabaseConfig values. These are the fields that affect
-// the DSN, pool behaviour, or transaction mode.
-func databaseConfigChanged(old, new *config.NamedDatabaseConfig) bool {
-	if old.Host != new.Host ||
-		old.Port != new.Port ||
-		old.Database != new.Database ||
-		old.User != new.User ||
-		old.Password != new.Password ||
-		old.SSLMode != new.SSLMode ||
-		old.TargetSessionAttrs != new.TargetSessionAttrs ||
-		old.AllowWrites != new.AllowWrites ||
-		old.PoolMaxConns != new.PoolMaxConns ||
-		old.PoolMinConns != new.PoolMinConns ||
-		old.PoolMaxConnIdleTime != new.PoolMaxConnIdleTime ||
-		old.PoolHealthCheckPeriod != new.PoolHealthCheckPeriod ||
-		old.PoolMaxConnLifetime != new.PoolMaxConnLifetime ||
-		old.ConnectTimeout != new.ConnectTimeout {
+// the DSN, pool behavior, or transaction mode.
+func databaseConfigChanged(oldCfg, newCfg *config.NamedDatabaseConfig) bool {
+	if oldCfg.Host != newCfg.Host ||
+		oldCfg.Port != newCfg.Port ||
+		oldCfg.Database != newCfg.Database ||
+		oldCfg.User != newCfg.User ||
+		oldCfg.Password != newCfg.Password ||
+		oldCfg.SSLMode != newCfg.SSLMode ||
+		oldCfg.TargetSessionAttrs != newCfg.TargetSessionAttrs ||
+		oldCfg.AllowWrites != newCfg.AllowWrites ||
+		oldCfg.PoolMaxConns != newCfg.PoolMaxConns ||
+		oldCfg.PoolMinConns != newCfg.PoolMinConns ||
+		oldCfg.PoolMaxConnIdleTime != newCfg.PoolMaxConnIdleTime ||
+		oldCfg.PoolHealthCheckPeriod != newCfg.PoolHealthCheckPeriod ||
+		oldCfg.PoolMaxConnLifetime != newCfg.PoolMaxConnLifetime ||
+		oldCfg.ConnectTimeout != newCfg.ConnectTimeout {
 		return true
 	}
-	if !reflect.DeepEqual(old.Hosts, new.Hosts) {
+	if !reflect.DeepEqual(oldCfg.Hosts, newCfg.Hosts) {
 		return true
 	}
 	return false

--- a/internal/database/client_manager.go
+++ b/internal/database/client_manager.go
@@ -13,6 +13,7 @@ package database
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"sync"
 
 	"pgedge-postgres-mcp/internal/config"
@@ -247,9 +248,10 @@ func (cm *ClientManager) GetDatabaseConfigs() []config.NamedDatabaseConfig {
 	return configs
 }
 
-// UpdateDatabaseConfigs updates the database configurations
-// Used for SIGHUP config reload
-// Note: Existing connections are NOT closed - they will be reused if config matches
+// UpdateDatabaseConfigs updates the database configurations.
+// Used for SIGHUP config reload. Existing connections are closed when the
+// database is removed or when connection-relevant settings have changed;
+// they will be lazily recreated with the new config on the next request.
 func (cm *ClientManager) UpdateDatabaseConfigs(databases []config.NamedDatabaseConfig) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
@@ -283,10 +285,55 @@ func (cm *ClientManager) UpdateDatabaseConfigs(databases []config.NamedDatabaseC
 		}
 	}
 
+	// Find databases that exist in both old and new configs but have
+	// connection-relevant settings that changed. Close all pooled
+	// connections so they get recreated with the new configuration.
+	for name, oldCfg := range cm.dbConfigs {
+		newCfg, exists := newConfigs[name]
+		if !exists {
+			continue // already handled above as a removal
+		}
+		if databaseConfigChanged(oldCfg, newCfg) {
+			for _, tokenClients := range cm.clients {
+				if client, exists := tokenClients[name]; exists {
+					client.Close()
+					delete(tokenClients, name)
+				}
+			}
+			fmt.Fprintf(os.Stderr, "Closed connections to database '%s' (configuration changed)\n", name)
+		}
+	}
+
 	cm.dbConfigs = newConfigs
 	cm.defaultDBName = newDefaultName
 
 	fmt.Fprintf(os.Stderr, "Updated database configurations: %d database(s)\n", len(databases))
+}
+
+// databaseConfigChanged returns true when connection-relevant fields differ
+// between two NamedDatabaseConfig values. These are the fields that affect
+// the DSN, pool behaviour, or transaction mode.
+func databaseConfigChanged(old, new *config.NamedDatabaseConfig) bool {
+	if old.Host != new.Host ||
+		old.Port != new.Port ||
+		old.Database != new.Database ||
+		old.User != new.User ||
+		old.Password != new.Password ||
+		old.SSLMode != new.SSLMode ||
+		old.TargetSessionAttrs != new.TargetSessionAttrs ||
+		old.AllowWrites != new.AllowWrites ||
+		old.PoolMaxConns != new.PoolMaxConns ||
+		old.PoolMinConns != new.PoolMinConns ||
+		old.PoolMaxConnIdleTime != new.PoolMaxConnIdleTime ||
+		old.PoolHealthCheckPeriod != new.PoolHealthCheckPeriod ||
+		old.PoolMaxConnLifetime != new.PoolMaxConnLifetime ||
+		old.ConnectTimeout != new.ConnectTimeout {
+		return true
+	}
+	if !reflect.DeepEqual(old.Hosts, new.Hosts) {
+		return true
+	}
+	return false
 }
 
 // RemoveClient removes and closes all database clients for a given token hash

--- a/internal/database/client_manager_unit_test.go
+++ b/internal/database/client_manager_unit_test.go
@@ -335,6 +335,141 @@ func TestClientManager_UpdateDatabaseConfigs(t *testing.T) {
 	}
 }
 
+func TestClientManager_UpdateDatabaseConfigs_ChangedConfig(t *testing.T) {
+	cm := NewClientManager([]config.NamedDatabaseConfig{
+		{Name: "db1", Host: "host1", Port: 5432, Database: "test1", AllowWrites: false},
+	})
+
+	// Inject a mock client for a token
+	err := cm.SetClient("token1", NewClient(nil))
+	if err != nil {
+		t.Fatalf("unexpected error setting client: %v", err)
+	}
+	if count := cm.GetClientCount(); count != 1 {
+		t.Fatalf("expected 1 client, got %d", count)
+	}
+
+	// Update with changed config (Host and AllowWrites differ)
+	cm.UpdateDatabaseConfigs([]config.NamedDatabaseConfig{
+		{Name: "db1", Host: "host2", Port: 5432, Database: "test1", AllowWrites: true},
+	})
+
+	// Stale connection should have been closed
+	if count := cm.GetClientCount(); count != 0 {
+		t.Errorf("expected 0 clients after config change, got %d", count)
+	}
+
+	// New config should be stored
+	cfg := cm.GetDatabaseConfig("db1")
+	if cfg == nil {
+		t.Fatal("expected db1 config to exist")
+	}
+	if cfg.Host != "host2" {
+		t.Errorf("expected host 'host2', got %q", cfg.Host)
+	}
+	if !cfg.AllowWrites {
+		t.Error("expected AllowWrites to be true")
+	}
+}
+
+func TestClientManager_UpdateDatabaseConfigs_UnchangedConfig(t *testing.T) {
+	cm := NewClientManager([]config.NamedDatabaseConfig{
+		{Name: "db1", Host: "host1", Port: 5432, Database: "test1"},
+	})
+
+	// Inject a mock client for a token
+	err := cm.SetClient("token1", NewClient(nil))
+	if err != nil {
+		t.Fatalf("unexpected error setting client: %v", err)
+	}
+	if count := cm.GetClientCount(); count != 1 {
+		t.Fatalf("expected 1 client, got %d", count)
+	}
+
+	// Update with identical config
+	cm.UpdateDatabaseConfigs([]config.NamedDatabaseConfig{
+		{Name: "db1", Host: "host1", Port: 5432, Database: "test1"},
+	})
+
+	// Connection should still be there
+	if count := cm.GetClientCount(); count != 1 {
+		t.Errorf("expected 1 client for unchanged config, got %d", count)
+	}
+}
+
+func TestDatabaseConfigChanged(t *testing.T) {
+	base := &config.NamedDatabaseConfig{
+		Host:        "localhost",
+		Port:        5432,
+		Database:    "mydb",
+		User:        "user",
+		Password:    "pass",
+		SSLMode:     "prefer",
+		AllowWrites: false,
+	}
+
+	tests := []struct {
+		name    string
+		modify  func(c *config.NamedDatabaseConfig)
+		changed bool
+	}{
+		{
+			name:    "identical configs",
+			modify:  func(c *config.NamedDatabaseConfig) {},
+			changed: false,
+		},
+		{
+			name:    "changed Host",
+			modify:  func(c *config.NamedDatabaseConfig) { c.Host = "remotehost" },
+			changed: true,
+		},
+		{
+			name:    "changed AllowWrites",
+			modify:  func(c *config.NamedDatabaseConfig) { c.AllowWrites = true },
+			changed: true,
+		},
+		{
+			name:    "changed Password",
+			modify:  func(c *config.NamedDatabaseConfig) { c.Password = "newpass" },
+			changed: true,
+		},
+		{
+			name:    "changed Port",
+			modify:  func(c *config.NamedDatabaseConfig) { c.Port = 5433 },
+			changed: true,
+		},
+		{
+			name:    "changed PoolMaxConns",
+			modify:  func(c *config.NamedDatabaseConfig) { c.PoolMaxConns = 10 },
+			changed: true,
+		},
+		{
+			name:    "changed Hosts slice",
+			modify:  func(c *config.NamedDatabaseConfig) { c.Hosts = []config.HostEntry{{Host: "h1", Port: 5432}} },
+			changed: true,
+		},
+		{
+			name: "changed non-connection field only",
+			modify: func(c *config.NamedDatabaseConfig) {
+				c.AvailableToUsers = []string{"alice"}
+			},
+			changed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of base for the "new" config
+			modified := *base
+			tt.modify(&modified)
+			got := databaseConfigChanged(base, &modified)
+			if got != tt.changed {
+				t.Errorf("databaseConfigChanged() = %v, want %v", got, tt.changed)
+			}
+		})
+	}
+}
+
 func TestClientManager_SetClient_Validation(t *testing.T) {
 	cm := NewClientManager([]config.NamedDatabaseConfig{
 		{Name: "db1", Host: "localhost", Port: 5432, Database: "test1"},


### PR DESCRIPTION
## Summary

- When SIGHUP triggers a config reload, `UpdateDatabaseConfigs` now
  detects databases whose connection-relevant settings have changed
  and closes their existing pooled connections so they get lazily
  recreated with the new configuration on the next request.
- Previously only *removed* databases had connections closed; changes
  to credentials, `allow_writes`, host, pool settings, etc. for an
  existing database name had no effect until a full container restart.
- Adds a `databaseConfigChanged` helper that compares all DSN, pool,
  and transaction-mode fields between old and new configs.

## Test plan

- [x] New unit tests for changed-config, unchanged-config, and
  `databaseConfigChanged` field comparisons
- [x] `make test` passes
- [ ] Manual: launch container with `allow_writes: false`, update config
  to `allow_writes: true` with new credentials, send SIGHUP, verify
  write queries succeed without container restart

PLAT-527 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling on configuration reloads: connections are closed and recreated when connection-relevant settings change, ensuring clients use current connection details.

* **Tests**
  * Added unit tests covering detection of configuration changes and verifying connection refresh vs. retention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->