### PR TITLE
fix: make quickstart demo self-contained

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,11 @@ and this project adheres to
   now only runs when HTTP mode is enabled. Stdio mode does not
   use HTTP authentication.
 
+- Quickstart demo files (`docker-compose.yml`, `.env.example`,
+  `pgedge-ait-demo.sh`) are now served from the GitHub
+  repository instead of `downloads.pgedge.com`. The Northwind
+  example database download is unchanged.
+
 ### Fixed
 
 - MCP tools (`query_database`, `count_rows`, `get_schema_info`) now

--- a/docs/guide/quickstart_demo.md
+++ b/docs/guide/quickstart_demo.md
@@ -41,11 +41,11 @@ There are two installation options:
 The single command option is the fastest way to get started.  Execute the 
 following command:
 
-`/bin/sh -c "$(curl -fsSL https://downloads.pgedge.com/quickstart/mcp/pgedge-ait-demo.sh)"`
+`/bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/quickstart-demo/pgedge-ait-demo.sh)"`
 
 This command will:
 
-- Download `docker-compose.yml` and `.env.example` from the same location.
+- Download `docker-compose.yml` and `.env.example` from the GitHub repository.
 - Prompt you for your API key(s) securely.
 - Start all services automatically.
 - Display connection details when ready.
@@ -57,7 +57,7 @@ This command will:
 Sample output from running the `demo` script:
 
 ```bash
-$ /bin/sh -c "$(curl -fsSL https://downloads.pgedge.com/quickstart/mcp/pgedge-ait-demo.sh)"
+$ /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/quickstart-demo/pgedge-ait-demo.sh)"
 ℹ  Creating workspace: /tmp/pgedge-download.28085
 ℹ  Downloading files
 ℹ  → docker-compose.yml
@@ -137,8 +137,8 @@ cd ~/pgedge-ait-demo
 Download the demo artifacts:
 
 ```bash
-curl -fsSLO https://downloads.pgedge.com/quickstart/mcp/docker-compose.yml
-curl -fsSLO https://downloads.pgedge.com/quickstart/mcp/.env.example
+curl -fsSLO https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/quickstart-demo/docker-compose.yml
+curl -fsSLO https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/quickstart-demo/.env.example
 ```
 
 Configure your API key

--- a/examples/quickstart-demo/README.md
+++ b/examples/quickstart-demo/README.md
@@ -1,10 +1,15 @@
 # pgEdge MCP Server and AI Toolkit Quickstart
 
-This directory contains the AI Toolkit MCP Quickstart demo.  These files are hosted on https://downloads.pgedge.com 
-to support the live demo linked here: https://www.pgedge.com/ai-toolkit  
+This directory contains the AI Toolkit MCP Quickstart demo.
+These files are served directly from the GitHub repository
+to support the live demo linked here:
+https://www.pgedge.com/ai-toolkit
 
-The purpose of this demo is to provide end-users a working interactive example of the MCP server in action with the 
-fewest configuration steps.  Therefore, rather than building containers from the repo, it pulls the latest public 
-container images from our repository.
+The purpose of this demo is to provide end-users a working
+interactive example of the MCP server in action with the
+fewest configuration steps. Rather than building containers
+from the repo, the demo pulls the latest public container
+images from our repository.
 
-For more detail, please refer to: [Quick Start Demo Guide](../../docs/guide/quickstart_demo.md)
+For more detail, please refer to:
+[Quick Start Demo Guide](../../docs/guide/quickstart_demo.md)

--- a/examples/quickstart-demo/pgedge-ait-demo.sh
+++ b/examples/quickstart-demo/pgedge-ait-demo.sh
@@ -4,7 +4,7 @@ set -eu
 # ----------------------------
 # Config
 # ----------------------------
-BASE_URL="https://downloads.pgedge.com/quickstart/mcp"
+BASE_URL="https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/quickstart-demo"
 FILES="docker-compose.yml .env.example"
 WORKDIR="/tmp/pgedge-download.$$"
 


### PR DESCRIPTION
## Summary

- Repoint quickstart demo script (`pgedge-ait-demo.sh`) from
  `downloads.pgedge.com` to GitHub raw URLs so the demo files
  are served directly from the repository.
- Update `docs/guide/quickstart_demo.md` to use GitHub raw URLs
  for both the one-step and three-step quickstart instructions.
- Update `examples/quickstart-demo/README.md` to reflect GitHub
  hosting and wrap lines to 79 characters.
- Add changelog entry under `[Unreleased] > Changed`.

The Northwind example database SQL download intentionally remains
on `downloads.pgedge.com`.

## Test Plan

- [x] Verify `curl -fsSI` returns HTTP 200 for the GitHub raw
      URLs of `docker-compose.yml`, `.env.example`, and
      `pgedge-ait-demo.sh`
- [x] Run the one-step quickstart command and confirm it
      downloads files and starts services
- [x] Confirm no unintended `downloads.pgedge.com` references
      remain in the quickstart-demo directory (except
      `northwind.sql` in `docker-compose.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated quickstart demo guides and changelog to reflect changes in file hosting.

* **Chores**
  * Updated quickstart demo installation scripts and artifact download sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->