### PR TITLE
Strip semicolons from queries before appending LIMIT/OFFSET. #110

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to
 
 ### Fixed
 
+- Queries with trailing semicolons no longer produce a SQL syntax
+  error when the server auto-appends a `LIMIT` clause. The server
+  now strips trailing semicolons before appending `LIMIT`/`OFFSET`.
+
 - MCP tools (`query_database`, `count_rows`, `get_schema_info`) now
   load metadata synchronously on the first call instead of returning
   a "database is still initializing" error. This eliminates the

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"pgedge-postgres-mcp/internal/database"
 	"pgedge-postgres-mcp/internal/logging"
@@ -35,6 +36,14 @@ func validateReadOnlyQuery(query string) error {
 				"connection is in read-only mode")
 	}
 	return nil
+}
+
+// stripTrailingSemicolons removes trailing semicolons and whitespace from
+// a SQL query so that LIMIT/OFFSET clauses can be safely appended.
+func stripTrailingSemicolons(query string) string {
+	return strings.TrimRightFunc(strings.TrimLeftFunc(query, unicode.IsSpace), func(r rune) bool {
+		return r == ';' || unicode.IsSpace(r)
+	})
 }
 
 // QueryDatabaseTool creates the query_database tool
@@ -225,9 +234,12 @@ To avoid rate limits (30,000 input tokens/minute):
 				}
 			}
 
-			// Strip trailing semicolons to avoid syntax errors when appending LIMIT/OFFSET
-			sqlQuery = strings.TrimRight(strings.TrimSpace(sqlQuery), ";")
-			sqlQuery = strings.TrimSpace(sqlQuery)
+			// Strip trailing semicolons and whitespace to avoid syntax
+			// errors when appending LIMIT/OFFSET.
+			sqlQuery = stripTrailingSemicolons(sqlQuery)
+			if sqlQuery == "" {
+				return mcp.NewToolError("Query is empty")
+			}
 
 			// Track if query already had LIMIT/OFFSET clauses
 			upperQuery := strings.ToUpper(strings.TrimSpace(sqlQuery))

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -225,6 +225,10 @@ To avoid rate limits (30,000 input tokens/minute):
 				}
 			}
 
+			// Strip trailing semicolons to avoid syntax errors when appending LIMIT/OFFSET
+			sqlQuery = strings.TrimRight(strings.TrimSpace(sqlQuery), ";")
+			sqlQuery = strings.TrimSpace(sqlQuery)
+
 			// Track if query already had LIMIT/OFFSET clauses
 			upperQuery := strings.ToUpper(strings.TrimSpace(sqlQuery))
 			hasExistingLimit := strings.Contains(upperQuery, "LIMIT")

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -41,7 +41,7 @@ func validateReadOnlyQuery(query string) error {
 // stripTrailingSemicolons removes trailing semicolons and whitespace from
 // a SQL query so that LIMIT/OFFSET clauses can be safely appended.
 func stripTrailingSemicolons(query string) string {
-	return strings.TrimRightFunc(strings.TrimLeftFunc(query, unicode.IsSpace), func(r rune) bool {
+	return strings.TrimRightFunc(query, func(r rune) bool {
 		return r == ';' || unicode.IsSpace(r)
 	})
 }

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -288,10 +288,10 @@ func TestQueryTypeDetection(t *testing.T) {
 	}
 }
 
-// TestTrailingSemicolonStripping verifies that trailing semicolons are
+// TestStripTrailingSemicolons verifies that trailing semicolons are
 // stripped before LIMIT/OFFSET are appended, preventing syntax errors
 // like "SELECT 1; LIMIT 101". See GitHub issue #110.
-func TestTrailingSemicolonStripping(t *testing.T) {
+func TestStripTrailingSemicolons(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -323,6 +323,16 @@ func TestTrailingSemicolonStripping(t *testing.T) {
 			expected: "SELECT 1",
 		},
 		{
+			name:     "interleaved trailing semicolons and spaces",
+			input:    "SELECT 1; ;",
+			expected: "SELECT 1",
+		},
+		{
+			name:     "semicolons and spaces only",
+			input:    " ; ;;  ",
+			expected: "",
+		},
+		{
 			name:     "semicolon in middle preserved",
 			input:    "SELECT '1;2'",
 			expected: "SELECT '1;2'",
@@ -331,8 +341,7 @@ func TestTrailingSemicolonStripping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := strings.TrimRight(strings.TrimSpace(tt.input), ";")
-			result = strings.TrimSpace(result)
+			result := stripTrailingSemicolons(tt.input)
 			if result != tt.expected {
 				t.Errorf("got %q, want %q", result, tt.expected)
 			}

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -320,7 +320,7 @@ func TestStripTrailingSemicolons(t *testing.T) {
 		{
 			name:     "leading and trailing whitespace",
 			input:    "  SELECT 1;  ",
-			expected: "SELECT 1",
+			expected: "  SELECT 1",
 		},
 		{
 			name:     "interleaved trailing semicolons and spaces",
@@ -331,6 +331,26 @@ func TestStripTrailingSemicolons(t *testing.T) {
 			name:     "semicolons and spaces only",
 			input:    " ; ;;  ",
 			expected: "",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace only",
+			input:    "   ",
+			expected: "",
+		},
+		{
+			name:     "trailing semicolon after string literal",
+			input:    "SELECT '1;2';",
+			expected: "SELECT '1;2'",
+		},
+		{
+			name:     "tabs and newlines",
+			input:    "SELECT 1;\n\t",
+			expected: "SELECT 1",
 		},
 		{
 			name:     "semicolon in middle preserved",

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -288,6 +288,58 @@ func TestQueryTypeDetection(t *testing.T) {
 	}
 }
 
+// TestTrailingSemicolonStripping verifies that trailing semicolons are
+// stripped before LIMIT/OFFSET are appended, preventing syntax errors
+// like "SELECT 1; LIMIT 101". See GitHub issue #110.
+func TestTrailingSemicolonStripping(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no semicolon",
+			input:    "SELECT 1",
+			expected: "SELECT 1",
+		},
+		{
+			name:     "single trailing semicolon",
+			input:    "SELECT 1;",
+			expected: "SELECT 1",
+		},
+		{
+			name:     "semicolon with trailing space",
+			input:    "SELECT 1; ",
+			expected: "SELECT 1",
+		},
+		{
+			name:     "multiple trailing semicolons",
+			input:    "SELECT 1;;;",
+			expected: "SELECT 1",
+		},
+		{
+			name:     "leading and trailing whitespace",
+			input:    "  SELECT 1;  ",
+			expected: "SELECT 1",
+		},
+		{
+			name:     "semicolon in middle preserved",
+			input:    "SELECT '1;2'",
+			expected: "SELECT '1;2'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := strings.TrimRight(strings.TrimSpace(tt.input), ";")
+			result = strings.TrimSpace(result)
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestFormatResultsAsTSV(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
#110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where SQL queries ending with trailing semicolons could cause syntax errors when LIMIT/OFFSET were appended; such queries are now normalized so appended clauses work correctly.

* **Documentation**
  * Updated the changelog to note the trailing-semicolon handling improvement.

* **Tests**
  * Added unit tests covering many trailing-semicolon scenarios to ensure correct normalization and preservation of semicolons inside string literals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->