### PR TITLE
Docs/quickstart updates

### DIFF
--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -466,7 +466,7 @@ create a user account before starting the server.
         -username admin -password secret123
 
     # Set permissions for the user file
-    chmod 644 ./bin/postgres-mcp-users.yaml
+    chmod 644 ./postgres-mcp-users.yaml
 
     # Start the server in HTTP mode
     ./bin/pgedge-postgres-mcp \
@@ -620,7 +620,7 @@ Install the Web client from the pgEdge repository
         -username admin -password secret123
 
     # Set permissions for the user file
-    chmod 644 ./bin/postgres-mcp-users.yaml
+    chmod 644 ./postgres-mcp-users.yaml
 
     # Start the server in HTTP mode
     ./bin/pgedge-postgres-mcp \
@@ -628,11 +628,18 @@ Install the Web client from the pgEdge repository
         -http -addr :8080
     ```
 
-    Open `http://localhost:8080` in your browser and log
-    in with the credentials you created.
+    Verify the server is running:
+
+    ```bash
+    curl http://localhost:8080/health
+    ```
+
+    The standalone binary provides only the MCP API; there
+    is no built-in web interface. Use the CLI client or
+    Docker for the Web GUI.
 
 **Verify the setup** by asking "What tables are in my
-database?" in the chat interface.
+database?" using the CLI client or Docker web interface.
 
 For full Web UI documentation, see the
 [Web Client Guide](web-client.md).

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -110,6 +110,13 @@ default location is `/etc/pgedge/postgres-mcp.yaml`. For
 builds from source, place the file at
 `bin/postgres-mcp.yaml` alongside the compiled binary.
 
+> **Note:** For pgEdge package installations, edit the
+> existing `/etc/pgedge/postgres-mcp.yaml` file. Comment
+> out or remove unused options for a clean setup. Set the
+> `user_file` path to `/etc/pgedge/postgres-mcp-users.yaml`
+> so user credentials are stored in the same directory as
+> the configuration.
+
 The following example shows a minimal configuration with
 all available sections. Uncomment and edit the sections you
 need. For a full reference with detailed comments, see

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -112,7 +112,7 @@ builds from source, place the file at
 
 > **Note:** For pgEdge package installations, edit the
 > existing `/etc/pgedge/postgres-mcp.yaml` file. Comment
-> out or remove unused options for a clean setup. Set the
+> out or remove unused options for a quick setup. Set the
 > `user_file` path to `/etc/pgedge/postgres-mcp-users.yaml`
 > so user credentials are stored in the same directory as
 > the configuration.
@@ -534,20 +534,24 @@ Install the Web client from the pgEdge repository
     # Set ownership for the user file
     sudo chown pgedge:pgedge /etc/pgedge/postgres-mcp-users.yaml
 
-    # Start the server in HTTP mode
-    pgedge-postgres-mcp \
-        -config /etc/pgedge/postgres-mcp.yaml \
-        -http -addr :8080
+    # Start the MCP server (choose one method)
+    # Option 1: Using systemctl (recommended)
+    sudo systemctl start pgedge-postgres-mcp.service
+
+    # Option 2: Manual start
+    # pgedge-postgres-mcp \
+    #     -config /etc/pgedge/postgres-mcp.yaml \
+    #     -http -addr :8080 &
+
+    # Start nginx
+    sudo systemctl start nginx.service
     ```
+
+    > **Note:** On RHEL/Rocky with SELinux enabled, run
+    > `sudo setenforce 0` before starting nginx.
 
     Open `http://localhost:8081` in your browser and log
     in with the credentials you created.
-    > **Note:** Start nginx using the following commands:
-    >
-    > ```bash
-    > setenforce 0
-    > systemctl start nginx.service
-    > ```
     
     
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -146,8 +146,7 @@ http:
 #         chain_file: ""
       auth:
           enabled: true
-          token_file: "/etc/pgedge/postgres-mcp-tokens.yaml"
-          user_file: "/etc/pgedge/postgres-mcp-users.yaml"
+          user_file: "./postgres-mcp-users.yaml"
 #         max_failed_attempts_before_lockout: 0
 #         rate_limit_window_minutes: 15
 #         rate_limit_max_attempts: 10

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -52,7 +52,7 @@ Every setup requires the following:
     The binary is installed at
     `/usr/bin/pgedge-postgres-mcp`. The default
     configuration file is at
-    `/etc/pgedge/mcp-server.yaml`.
+    `/etc/pgedge/postgres-mcp.yaml`.
 
 === "GitHub Release"
 
@@ -106,7 +106,7 @@ The MCP server reads settings from a YAML configuration
 file. Create a file named `postgres-mcp.yaml` and place it
 in the same directory as the binary, or specify its
 location with the `-config` flag. For pgEdge packages, the
-default location is `/etc/pgedge/mcp-server.yaml`. For
+default location is `/etc/pgedge/postgres-mcp.yaml`. For
 builds from source, place the file at
 `bin/postgres-mcp.yaml` alongside the compiled binary.
 
@@ -136,7 +136,7 @@ databases:
 
 # HTTP server (enable for Web UI, CLI HTTP mode,
 # or API access)
-# http:
+http:
 #     enabled: true
 #     address: ":8080"
 #     tls:
@@ -144,10 +144,10 @@ databases:
 #         cert_file: ""
 #         key_file: ""
 #         chain_file: ""
-#     auth:
-#         enabled: true
-#         token_file: ""
-#         user_file: ""
+      auth:
+          enabled: true
+          token_file: "/etc/pgedge/postgres-mcp-tokens.yaml"
+          user_file: "/etc/pgedge/postgres-mcp-users.yaml"
 #         max_failed_attempts_before_lockout: 0
 #         rate_limit_window_minutes: 15
 #         rate_limit_max_attempts: 10
@@ -255,10 +255,21 @@ subprocess. This mode is ideal for single-user development.
     pgedge-nla-cli \
         -mcp-mode stdio \
         -mcp-server-path /usr/bin/pgedge-postgres-mcp \
-        -mcp-server-config /etc/pgedge/mcp-server.yaml
+        -mcp-server-config /etc/pgedge/postgres-mcp.yaml
     ```
 
 === "GitHub Release"
+
+    Download the latest CLI release for your platform from the
+    [GitHub Releases](https://github.com/pgEdge/pgedge-postgres-mcp/releases)
+    page. Extract the archive and add the `pgedge-nla-cli` binary
+    to your path.
+
+    ```bash
+    # Example for Linux amd64
+    tar xzf pgedge-postgres-mcp-cli_linux_amd64.tar.gz
+    chmod +x pgedge-nla-cli
+    ```
 
     Set your LLM API key and start the CLI, pointing it at
     the server binary and your configuration file:
@@ -330,14 +341,17 @@ create a user account before starting the server.
 
     ```bash
     # Create a user account (runs and exits)
-    pgedge-postgres-mcp \
-        -config /etc/pgedge/mcp-server.yaml \
+    sudo pgedge-postgres-mcp \
+        -config /etc/pgedge/postgres-mcp.yaml \
         -add-user \
         -username admin -password secret123
 
+    # Set ownership for the user file
+    sudo chown pgedge:pgedge /etc/pgedge/postgres-mcp-users.yaml
+
     # Start the server in HTTP mode
     pgedge-postgres-mcp \
-        -config /etc/pgedge/mcp-server.yaml \
+        -config /etc/pgedge/postgres-mcp.yaml \
         -http -addr :8080 &
 
     # Connect the CLI
@@ -353,6 +367,17 @@ create a user account before starting the server.
 
 === "GitHub Release"
 
+    Download the latest CLI release for your platform from the
+    [GitHub Releases](https://github.com/pgEdge/pgedge-postgres-mcp/releases)
+    page. Extract the archive and add the `pgedge-nla-cli` binary
+    to your path.
+
+    ```bash
+    # Example for Linux amd64
+    tar xzf pgedge-postgres-mcp-cli_linux_amd64.tar.gz
+    chmod +x pgedge-nla-cli
+    ```
+
     Create a user account, start the server, then connect
     the CLI:
 
@@ -362,6 +387,9 @@ create a user account before starting the server.
         -config ./postgres-mcp.yaml \
         -add-user \
         -username admin -password secret123
+
+    # Set permissions for the user file
+    chmod 644 ./postgres-mcp-users.yaml
 
     # Start the server in HTTP mode
     ./pgedge-postgres-mcp \
@@ -438,6 +466,9 @@ create a user account before starting the server.
         -add-user \
         -username admin -password secret123
 
+    # Set permissions for the user file
+    chmod 644 ./bin/postgres-mcp-users.yaml
+
     # Start the server in HTTP mode
     ./bin/pgedge-postgres-mcp \
         -config ./bin/postgres-mcp.yaml \
@@ -476,27 +507,43 @@ default, so you must also create a user account.
 
 === "pgEdge Packages"
 
+Install the Web client from the pgEdge repository
+(configured in [Prerequisites](#obtaining-the-mcp-server)):
+
+```bash
+# Debian/Ubuntu: sudo apt-get install -y pgedge-nla-web
+# RHEL/Rocky:    sudo dnf install -y pgedge-nla-web
+```
+
     Create a user account, then start the server in HTTP
     mode:
 
     ```bash
     # Create a user account (runs and exits)
-    pgedge-postgres-mcp \
-        -config /etc/pgedge/mcp-server.yaml \
+    sudo pgedge-postgres-mcp \
+        -config /etc/pgedge/postgres-mcp.yaml \
         -add-user \
         -username admin -password secret123
 
+    # Set ownership for the user file
+    sudo chown pgedge:pgedge /etc/pgedge/postgres-mcp-users.yaml
+
     # Start the server in HTTP mode
     pgedge-postgres-mcp \
-        -config /etc/pgedge/mcp-server.yaml \
+        -config /etc/pgedge/postgres-mcp.yaml \
         -http -addr :8080
     ```
 
-    Open `http://localhost:8080` in your browser and log
+    Open `http://localhost:8081` in your browser and log
     in with the credentials you created.
-
-    You can also install the `pgedge-nla-web` package for
-    a standalone web UI served by Nginx.
+    > **Note:** Start nginx using the following commands:
+    >
+    > ```bash
+    > setenforce 0
+    > systemctl start nginx.service
+    > ```
+    
+    
 
 === "GitHub Release"
 
@@ -510,14 +557,24 @@ default, so you must also create a user account.
         -add-user \
         -username admin -password secret123
 
+    # Set permissions for the user file
+    chmod 644 ./postgres-mcp-users.yaml
+
     # Start the server in HTTP mode
     ./pgedge-postgres-mcp \
         -config ./postgres-mcp.yaml \
         -http -addr :8080
     ```
 
-    Open `http://localhost:8080` in your browser and log
-    in with the credentials you created.
+    Verify the server is running:
+
+    ```bash
+    curl http://localhost:8080/health
+    ```
+
+    The standalone binary provides only the MCP API; there
+    is no built-in web interface. Use the CLI client or
+    Docker for the Web GUI.
 
 === "Docker"
 
@@ -563,6 +620,9 @@ default, so you must also create a user account.
         -add-user \
         -username admin -password secret123
 
+    # Set permissions for the user file
+    chmod 644 ./bin/postgres-mcp-users.yaml
+
     # Start the server in HTTP mode
     ./bin/pgedge-postgres-mcp \
         -config ./bin/postgres-mcp.yaml \
@@ -597,7 +657,7 @@ transport. Create a `.mcp.json` file in your project root.
           "command": "/usr/bin/pgedge-postgres-mcp",
           "args": [
             "-config",
-            "/etc/pgedge/mcp-server.yaml"
+            "/etc/pgedge/postgres-mcp.yaml"
           ]
         }
       }
@@ -717,7 +777,7 @@ system:
           "command": "/usr/bin/pgedge-postgres-mcp",
           "args": [
             "-config",
-            "/etc/pgedge/mcp-server.yaml"
+            "/etc/pgedge/postgres-mcp.yaml"
           ]
         }
       }
@@ -831,7 +891,7 @@ The configuration file is located at `~/.cursor/mcp.json`.
           "command": "/usr/bin/pgedge-postgres-mcp",
           "args": [
             "-config",
-            "/etc/pgedge/mcp-server.yaml"
+            "/etc/pgedge/postgres-mcp.yaml"
           ]
         }
       }
@@ -942,7 +1002,7 @@ The configuration file is located at
           "command": "/usr/bin/pgedge-postgres-mcp",
           "args": [
             "-config",
-            "/etc/pgedge/mcp-server.yaml"
+            "/etc/pgedge/postgres-mcp.yaml"
           ]
         }
       }
@@ -1054,7 +1114,7 @@ file in your project root.
           "command": "/usr/bin/pgedge-postgres-mcp",
           "args": [
             "-config",
-            "/etc/pgedge/mcp-server.yaml"
+            "/etc/pgedge/postgres-mcp.yaml"
           ]
         }
       }

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -143,7 +143,7 @@ databases:
 
 # HTTP server (enable for Web UI, CLI HTTP mode,
 # or API access)
-http:
+# http:
 #     enabled: true
 #     address: ":8080"
 #     tls:
@@ -151,9 +151,9 @@ http:
 #         cert_file: ""
 #         key_file: ""
 #         chain_file: ""
-      auth:
-          enabled: true
-          user_file: "./postgres-mcp-users.yaml"
+#     auth:
+#         enabled: true
+#         user_file: "./postgres-mcp-users.yaml"
 #         max_failed_attempts_before_lockout: 0
 #         rate_limit_window_minutes: 15
 #         rate_limit_max_attempts: 10
@@ -395,7 +395,7 @@ create a user account before starting the server.
         -username admin -password secret123
 
     # Set permissions for the user file
-    chmod 644 ./postgres-mcp-users.yaml
+    chmod 640 ./postgres-mcp-users.yaml
 
     # Start the server in HTTP mode
     ./pgedge-postgres-mcp \
@@ -473,7 +473,7 @@ create a user account before starting the server.
         -username admin -password secret123
 
     # Set permissions for the user file
-    chmod 644 ./postgres-mcp-users.yaml
+    chmod 640 ./postgres-mcp-users.yaml
 
     # Start the server in HTTP mode
     ./bin/pgedge-postgres-mcp \
@@ -513,13 +513,14 @@ default, so you must also create a user account.
 
 === "pgEdge Packages"
 
-Install the Web client from the pgEdge repository
-(configured in [Prerequisites](#obtaining-the-mcp-server)):
+    Install the Web client from the pgEdge repository
+    (configured in
+    [Prerequisites](#obtaining-the-mcp-server)):
 
-```bash
-# Debian/Ubuntu: sudo apt-get install -y pgedge-nla-web
-# RHEL/Rocky:    sudo dnf install -y pgedge-nla-web
-```
+    ```bash
+    # Debian/Ubuntu: sudo apt-get install -y pgedge-nla-web
+    # RHEL/Rocky:    sudo dnf install -y pgedge-nla-web
+    ```
 
     Create a user account, then start the server in HTTP
     mode:
@@ -548,12 +549,12 @@ Install the Web client from the pgEdge repository
     ```
 
     > **Note:** On RHEL/Rocky with SELinux enabled, run
-    > `sudo setenforce 0` before starting nginx.
+    > `sudo setsebool -P httpd_can_network_connect 1`
+    > before starting nginx to allow the proxy connection.
 
     Open `http://localhost:8081` in your browser and log
     in with the credentials you created.
-    
-    
+
 
 === "GitHub Release"
 
@@ -568,7 +569,7 @@ Install the Web client from the pgEdge repository
         -username admin -password secret123
 
     # Set permissions for the user file
-    chmod 644 ./postgres-mcp-users.yaml
+    chmod 640 ./postgres-mcp-users.yaml
 
     # Start the server in HTTP mode
     ./pgedge-postgres-mcp \
@@ -631,7 +632,7 @@ Install the Web client from the pgEdge repository
         -username admin -password secret123
 
     # Set permissions for the user file
-    chmod 644 ./postgres-mcp-users.yaml
+    chmod 640 ./postgres-mcp-users.yaml
 
     # Start the server in HTTP mode
     ./bin/pgedge-postgres-mcp \


### PR DESCRIPTION
Key Changes
1. Configuration Filename Standardization

Fixed incorrect config filename from mcp-server.yaml → postgres-mcp.yaml throughout the guide


2. Package Installation Improvements

- Added guidance for editing /etc/pgedge/postgres-mcp.yaml
- Recommend setting user_file to /etc/pgedge/postgres-mcp-users.yaml
- Added systemctl commands for starting MCP server (with manual option)
- Added proper file ownership (chown pgedge:pgedge) instructions
- Improved SELinux/nginx note formatting

3. User File Handling

- Added chmod 644 for user file permissions (source/release builds)
- Fixed user file path references to match actual creation location

4. Web UI Clarifications

- Clarified standalone binaries provide MCP API only (no web interface)
- Added curl http://localhost:8080/health verification step
- Updated Web UI port to 8081 (nginx) vs 8080 (MCP server)


5. GitHub Release Tab Improvements

- Added download/extract instructions for CLI binary
- Consistent formatting across all installation methods

Impact


These changes improve the onboarding experience for new users, particularly those using pgEdge packages by ensuring documentation matches actual software behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated default configuration path and guidance for storing credentials and setting auth user_file
  * Expanded installation/startup steps (use of sudo, file ownership and permission recommendations)
  * Updated Web UI access port and clarified that the standalone binary exposes only the API (use CLI or Docker for GUI)
  * Added server health-check verification steps and clarified verification workflow per install method
<!-- end of auto-generated comment: release notes by coderabbit.ai -->