### PR TITLE
Updates pgedge-nla-kb-builder.yaml for ace versions.

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -169,6 +169,30 @@ sources:
       project_version: "0.1.0"
 
     - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.7.1"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.7.1"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.7.0"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.7.0"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.6.0"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.6.0"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v1.5.5"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "1.5.5"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
       tag: "v1.5.4"
       doc_path: "docs"
       project_name: "pgEdge ACE"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation coverage for pgEdge ACE by adding support for multiple release versions. Documentation sources are now available for versions 1.7.1, 1.7.0, 1.6.0, and 1.5.5, in addition to the existing v1.5.4 release. Users can now easily access version-specific documentation to find the appropriate reference materials for their current pgEdge ACE installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->