### PR TITLE
Add TTL-based metadata cache refresh

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Schema metadata cache now refreshes automatically based on a
+  configurable TTL. The `metadata_ttl` database option controls
+  how long cached metadata remains valid (default: 5 minutes).
+  This fixes an issue where `get_schema_info` returned stale
+  results when tables were created outside the MCP server or
+  when using read-only database connections.
+
 ## [1.0.0] - 2026-03-27
 
 ### Changed

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -72,6 +72,7 @@ details on configuring multiple databases and access control.
 | `databases[].pool_health_check_period` | N/A | N/A | Interval for background pool health checks (default: disabled) |
 | `databases[].pool_max_conn_lifetime` | N/A | N/A | Maximum lifetime of a connection before the pool closes the connection (default: "1h") |
 | `databases[].connect_timeout` | N/A | N/A | Timeout for the initial database connection as a Go duration string such as "10s" or "30s" (default: "10s") |
+| `databases[].metadata_ttl` | N/A | N/A | How long cached schema metadata remains valid before automatic refresh as a Go duration string such as "5m" or "30s"; use "0" to refresh on every request (default: "5m") |
 
 CLI flags and single-database environment variables (`PGEDGE_DB_*`,
 `PG*`) apply to the first database in the list. Use numbered

--- a/docs/reference/config-examples/server.md
+++ b/docs/reference/config-examples/server.md
@@ -232,6 +232,12 @@ databases:
       # Default: 10s
       # connect_timeout: "10s"
 
+      # How long cached schema metadata remains valid before
+      # automatic refresh (Go duration string).
+      # Use "0" to refresh on every request.
+      # Default: 5m
+      # metadata_ttl: "5m"
+
       # Users who can access this database (empty = all users)
       available_to_users: []
 

--- a/examples/pgedge-postgres-mcp-http.yaml.example
+++ b/examples/pgedge-postgres-mcp-http.yaml.example
@@ -40,6 +40,7 @@ databases:
       pool_min_conns: 2
       pool_max_conn_idle_time: "5m"
       connect_timeout: "10s"
+      # metadata_ttl: "5m"
       available_to_users: []  # Empty = available to all users
       # WARNING: allow_writes enables the AI to execute INSERT, UPDATE, DELETE, etc.
       # Only enable on non-production databases where data loss is acceptable.

--- a/examples/pgedge-postgres-mcp-stdio.yaml.example
+++ b/examples/pgedge-postgres-mcp-stdio.yaml.example
@@ -21,6 +21,7 @@ databases:
       password: ""  # Leave empty to use .pgpass file
       sslmode: "prefer"
       connect_timeout: "10s"
+      # metadata_ttl: "5m"
       pool_max_conns: 10
       pool_min_conns: 2
       pool_max_conn_idle_time: "5m"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -272,6 +272,7 @@ type NamedDatabaseConfig struct {
 	PoolHealthCheckPeriod string `yaml:"pool_health_check_period"` // How often idle connections are checked (default: 30s for multi-host, 0 for single-host)
 	PoolMaxConnLifetime   string `yaml:"pool_max_conn_lifetime"`   // Max lifetime of a connection before it is closed and recreated (default: 5m for multi-host, 0 for single-host)
 	ConnectTimeout        string `yaml:"connect_timeout"`          // Timeout for initial connection (default: 10s)
+	MetadataTTL           string `yaml:"metadata_ttl"`             // How long cached schema metadata remains valid before automatic refresh (default: "5m", "0" = always refresh)
 }
 
 // formatHostPort returns a host:port string, bracketing IPv6 addresses.

--- a/internal/database/client_manager.go
+++ b/internal/database/client_manager.go
@@ -327,7 +327,8 @@ func databaseConfigChanged(oldCfg, newCfg *config.NamedDatabaseConfig) bool {
 		oldCfg.PoolMaxConnIdleTime != newCfg.PoolMaxConnIdleTime ||
 		oldCfg.PoolHealthCheckPeriod != newCfg.PoolHealthCheckPeriod ||
 		oldCfg.PoolMaxConnLifetime != newCfg.PoolMaxConnLifetime ||
-		oldCfg.ConnectTimeout != newCfg.ConnectTimeout {
+		oldCfg.ConnectTimeout != newCfg.ConnectTimeout ||
+		oldCfg.MetadataTTL != newCfg.MetadataTTL {
 		return true
 	}
 	if !reflect.DeepEqual(oldCfg.Hosts, newCfg.Hosts) {

--- a/internal/database/client_manager_unit_test.go
+++ b/internal/database/client_manager_unit_test.go
@@ -449,6 +449,11 @@ func TestDatabaseConfigChanged(t *testing.T) {
 			changed: true,
 		},
 		{
+			name:    "changed MetadataTTL",
+			modify:  func(c *config.NamedDatabaseConfig) { c.MetadataTTL = "10m" },
+			changed: true,
+		},
+		{
 			name: "changed non-connection field only",
 			modify: func(c *config.NamedDatabaseConfig) {
 				c.AvailableToUsers = []string{"alice"}

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -28,10 +28,11 @@ import (
 
 // ConnectionInfo holds a connection pool and its metadata
 type ConnectionInfo struct {
-	ConnString     string
-	Pool           *pgxpool.Pool
-	Metadata       map[string]TableInfo
-	MetadataLoaded bool
+	ConnString       string
+	Pool             *pgxpool.Pool
+	Metadata         map[string]TableInfo
+	MetadataLoaded   bool
+	MetadataLoadedAt time.Time
 }
 
 // Client manages multiple PostgreSQL connections and metadata
@@ -556,6 +557,7 @@ func (c *Client) LoadMetadataFor(connStr string) error {
 	c.mu.Lock()
 	conn.Metadata = newMetadata
 	conn.MetadataLoaded = true
+	conn.MetadataLoadedAt = time.Now()
 	c.mu.Unlock()
 
 	duration := time.Since(startTime)
@@ -604,7 +606,10 @@ func (c *Client) IsMetadataLoaded() bool {
 	return c.IsMetadataLoadedFor(connStr)
 }
 
-// IsMetadataLoadedFor returns whether metadata has been loaded for a specific connection
+// IsMetadataLoadedFor returns whether valid (non-stale) metadata
+// exists for a specific connection. Metadata is considered stale
+// when it is older than the configured metadata_ttl (default: 5m).
+// A TTL of 0 means metadata is always considered stale.
 func (c *Client) IsMetadataLoadedFor(connStr string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -613,7 +618,24 @@ func (c *Client) IsMetadataLoadedFor(connStr string) bool {
 	if !exists {
 		return false
 	}
-	return conn.MetadataLoaded
+	if !conn.MetadataLoaded {
+		return false
+	}
+
+	// Resolve TTL: default 5 minutes
+	ttl := 5 * time.Minute
+	if c.dbConfig != nil && c.dbConfig.MetadataTTL != "" {
+		if parsed, err := time.ParseDuration(c.dbConfig.MetadataTTL); err == nil {
+			ttl = parsed
+		}
+	}
+
+	// TTL of 0 means always refresh
+	if ttl == 0 {
+		return false
+	}
+
+	return time.Since(conn.MetadataLoadedAt) <= ttl
 }
 
 // GetPool returns the connection pool for the default connection

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -106,9 +106,10 @@ func TestGetConnectionInfo(t *testing.T) {
 
 	// Add a mock connection
 	mockInfo := &ConnectionInfo{
-		ConnString:     "postgres://localhost/test",
-		Metadata:       make(map[string]TableInfo),
-		MetadataLoaded: true,
+		ConnString:       "postgres://localhost/test",
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now(),
 	}
 	client.connections["postgres://localhost/test"] = mockInfo
 
@@ -129,36 +130,103 @@ func TestGetConnectionInfo(t *testing.T) {
 }
 
 func TestIsMetadataLoadedFor(t *testing.T) {
-	client := NewClient(nil)
-
 	// Test with non-existent connection
+	client := NewClient(nil)
 	loaded := client.IsMetadataLoadedFor("postgres://localhost/nonexistent")
 	if loaded {
 		t.Error("IsMetadataLoadedFor() returned true for non-existent connection")
 	}
 
-	// Add connection with metadata not loaded
+	// Test with metadata not loaded
 	client.connections["postgres://localhost/test1"] = &ConnectionInfo{
 		ConnString:     "postgres://localhost/test1",
 		Metadata:       make(map[string]TableInfo),
 		MetadataLoaded: false,
 	}
-
 	loaded = client.IsMetadataLoadedFor("postgres://localhost/test1")
 	if loaded {
 		t.Error("IsMetadataLoadedFor() returned true when metadata not loaded")
 	}
 
-	// Add connection with metadata loaded
+	// Test with metadata loaded and fresh (within default 5m TTL)
 	client.connections["postgres://localhost/test2"] = &ConnectionInfo{
-		ConnString:     "postgres://localhost/test2",
-		Metadata:       make(map[string]TableInfo),
-		MetadataLoaded: true,
+		ConnString:       "postgres://localhost/test2",
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now(),
 	}
-
 	loaded = client.IsMetadataLoadedFor("postgres://localhost/test2")
 	if !loaded {
-		t.Error("IsMetadataLoadedFor() returned false when metadata is loaded")
+		t.Error("IsMetadataLoadedFor() returned false for fresh metadata")
+	}
+
+	// Test with metadata loaded but stale (older than default 5m TTL)
+	client.connections["postgres://localhost/test3"] = &ConnectionInfo{
+		ConnString:       "postgres://localhost/test3",
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now().Add(-6 * time.Minute),
+	}
+	loaded = client.IsMetadataLoadedFor("postgres://localhost/test3")
+	if loaded {
+		t.Error("IsMetadataLoadedFor() returned true for stale metadata")
+	}
+
+	// Test with TTL=0 (always refresh)
+	clientZero := NewClient(&config.NamedDatabaseConfig{
+		MetadataTTL: "0",
+	})
+	clientZero.connections["postgres://localhost/test4"] = &ConnectionInfo{
+		ConnString:       "postgres://localhost/test4",
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now(),
+	}
+	loaded = clientZero.IsMetadataLoadedFor("postgres://localhost/test4")
+	if loaded {
+		t.Error("IsMetadataLoadedFor() returned true with TTL=0 (should always refresh)")
+	}
+
+	// Test with custom TTL (10 minutes) and fresh metadata
+	clientCustom := NewClient(&config.NamedDatabaseConfig{
+		MetadataTTL: "10m",
+	})
+	clientCustom.connections["postgres://localhost/test5"] = &ConnectionInfo{
+		ConnString:       "postgres://localhost/test5",
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now().Add(-7 * time.Minute),
+	}
+	loaded = clientCustom.IsMetadataLoadedFor("postgres://localhost/test5")
+	if !loaded {
+		t.Error("IsMetadataLoadedFor() returned false for metadata within custom 10m TTL")
+	}
+
+	// Test with custom TTL (10 minutes) and stale metadata
+	clientCustom.connections["postgres://localhost/test6"] = &ConnectionInfo{
+		ConnString:       "postgres://localhost/test6",
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now().Add(-11 * time.Minute),
+	}
+	loaded = clientCustom.IsMetadataLoadedFor("postgres://localhost/test6")
+	if loaded {
+		t.Error("IsMetadataLoadedFor() returned true for metadata beyond custom 10m TTL")
+	}
+
+	// Test with invalid TTL (falls back to 5m default)
+	clientInvalid := NewClient(&config.NamedDatabaseConfig{
+		MetadataTTL: "not-a-duration",
+	})
+	clientInvalid.connections["postgres://localhost/test7"] = &ConnectionInfo{
+		ConnString:       "postgres://localhost/test7",
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now().Add(-4 * time.Minute),
+	}
+	loaded = clientInvalid.IsMetadataLoadedFor("postgres://localhost/test7")
+	if !loaded {
+		t.Error("IsMetadataLoadedFor() returned false for metadata within default 5m TTL (invalid TTL string)")
 	}
 }
 
@@ -208,9 +276,10 @@ func TestGetMetadataFor(t *testing.T) {
 	}
 
 	client.connections["postgres://localhost/test"] = &ConnectionInfo{
-		ConnString:     "postgres://localhost/test",
-		Metadata:       mockMetadata,
-		MetadataLoaded: true,
+		ConnString:       "postgres://localhost/test",
+		Metadata:         mockMetadata,
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now(),
 	}
 
 	metadata = client.GetMetadataFor("postgres://localhost/test")

--- a/internal/database/resource_helper_test.go
+++ b/internal/database/resource_helper_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"pgedge-postgres-mcp/internal/mcp"
 
@@ -281,10 +282,11 @@ func TestResourceHelperIntegration(t *testing.T) {
 // Test helper for creating mock connection info
 func createMockConnInfo(loaded bool, pool *pgxpool.Pool) *ConnectionInfo {
 	return &ConnectionInfo{
-		ConnString:     "postgres://test",
-		Pool:           pool,
-		Metadata:       make(map[string]TableInfo),
-		MetadataLoaded: loaded,
+		ConnString:       "postgres://test",
+		Pool:             pool,
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   loaded,
+		MetadataLoadedAt: time.Now(),
 	}
 }
 

--- a/internal/database/test_helpers.go
+++ b/internal/database/test_helpers.go
@@ -10,6 +10,8 @@
 
 package database
 
+import "time"
+
 // NewTestClient creates a database client for testing with mock data
 // This allows tests in other packages to create clients with predetermined metadata
 func NewTestClient(connStr string, metadata map[string]TableInfo) *Client {
@@ -17,10 +19,11 @@ func NewTestClient(connStr string, metadata map[string]TableInfo) *Client {
 
 	// Add mock connection info
 	client.connections[connStr] = &ConnectionInfo{
-		ConnString:     connStr,
-		Pool:           nil, // No actual connection pool needed for tests
-		Metadata:       metadata,
-		MetadataLoaded: true,
+		ConnString:       connStr,
+		Pool:             nil, // No actual connection pool needed for tests
+		Metadata:         metadata,
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now(),
 	}
 
 	// Set as default connection


### PR DESCRIPTION
Read-only database connections never refresh cached schema metadata, causing get_schema_info to return stale results when tables are created externally. Add a configurable metadata_ttl option (default 5m) that automatically refreshes metadata when it exceeds the TTL.

Changes:
- Add metadata_ttl field to NamedDatabaseConfig (default: "5m", "0" = always refresh)
- Add MetadataLoadedAt timestamp to ConnectionInfo
- Make IsMetadataLoadedFor() return false when metadata is stale, triggering automatic reload by existing callers
- Include metadata_ttl in config change detection
- Update test helpers and add comprehensive TTL tests
- Document the new option in config guide, examples, and changelog

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable schema metadata caching with auto-refresh via `metadata_ttl` database option (default: 5 minutes). Prevents stale results when tables are created outside the MCP server or when using read-only connections. Set `metadata_ttl: "0"` to force refresh on every request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->