### PR TITLE
Fix database switching not persisting in HTTP mode

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,16 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Database switching via `select_database_connection` now persists
+  correctly in HTTP mode for unbound API tokens.
+  `GetAccessibleDatabases` previously returned only the first
+  configured database for unbound tokens, causing `getClient` to
+  silently override the user's selection on every subsequent tool
+  call. The method now returns all databases, matching the behavior
+  of `CanAccessDatabase`. (#117)
+
 ### Added
 
 - Schema metadata cache now refreshes automatically based on a

--- a/internal/auth/access.go
+++ b/internal/auth/access.go
@@ -36,7 +36,7 @@ func NewDatabaseAccessChecker(tokenStore *TokenStore, authEnabled, isSTDIO bool)
 // Access rules:
 //   - STDIO mode: all databases accessible
 //   - Auth disabled (--no-auth): all databases accessible
-//   - API token: only bound database (or first if empty)
+//   - API token: only bound database (or all if unbound)
 //   - Session user: check available_to_users (empty = all)
 func (dac *DatabaseAccessChecker) CanAccessDatabase(ctx context.Context, db *config.NamedDatabaseConfig) bool {
 	// STDIO mode - all databases available
@@ -109,7 +109,7 @@ func (dac *DatabaseAccessChecker) GetBoundDatabase(ctx context.Context) string {
 }
 
 // GetAccessibleDatabases returns the list of databases accessible to the current context
-// For API tokens, returns only the bound database (or first if unbound)
+// For API tokens, returns only the bound database (or all if unbound)
 // For session users, filters by available_to_users
 // For STDIO/no-auth mode, returns all databases
 func (dac *DatabaseAccessChecker) GetAccessibleDatabases(ctx context.Context, databases []config.NamedDatabaseConfig) []config.NamedDatabaseConfig {
@@ -133,11 +133,8 @@ func (dac *DatabaseAccessChecker) GetAccessibleDatabases(ctx context.Context, da
 			return nil
 		}
 
-		// Token not bound - return first database
-		if len(databases) > 0 {
-			return []config.NamedDatabaseConfig{databases[0]}
-		}
-		return nil
+		// Token not bound - return all databases
+		return databases
 	}
 
 	// Session user - filter by available_to_users

--- a/internal/auth/access_test.go
+++ b/internal/auth/access_test.go
@@ -1,0 +1,203 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"pgedge-postgres-mcp/internal/config"
+)
+
+// helper to build a context with API token flag and optional token hash
+func apiTokenContext(tokenHash string) context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, IsAPITokenContextKey, true)
+	if tokenHash != "" {
+		ctx = context.WithValue(ctx, TokenHashContextKey, tokenHash)
+	}
+	return ctx
+}
+
+// helper to build a context with a session username
+func sessionUserContext(username string) context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, UsernameContextKey, username)
+	return ctx
+}
+
+func testDatabases() []config.NamedDatabaseConfig {
+	return []config.NamedDatabaseConfig{
+		{Name: "db1", Database: "db1"},
+		{Name: "db2", Database: "db2"},
+		{Name: "db3", Database: "db3"},
+	}
+}
+
+func TestGetAccessibleDatabases(t *testing.T) {
+	databases := testDatabases()
+
+	t.Run("STDIO mode returns all databases", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, true)
+		result := dac.GetAccessibleDatabases(context.Background(), databases)
+		if len(result) != len(databases) {
+			t.Fatalf("expected %d databases, got %d", len(databases), len(result))
+		}
+	})
+
+	t.Run("auth disabled returns all databases", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, false, false)
+		result := dac.GetAccessibleDatabases(context.Background(), databases)
+		if len(result) != len(databases) {
+			t.Fatalf("expected %d databases, got %d", len(databases), len(result))
+		}
+	})
+
+	t.Run("unbound API token returns all databases", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, false)
+		ctx := apiTokenContext("")
+		result := dac.GetAccessibleDatabases(ctx, databases)
+		if len(result) != len(databases) {
+			t.Fatalf("expected %d databases, got %d", len(databases), len(result))
+		}
+		for i, db := range result {
+			if db.Name != databases[i].Name {
+				t.Errorf("database %d: expected name %q, got %q", i, databases[i].Name, db.Name)
+			}
+		}
+	})
+
+	t.Run("bound API token returns only bound database", func(t *testing.T) {
+		store := InitializeTokenStore()
+		err := store.AddToken("test-token", "testhash123", "test", nil, "db2")
+		if err != nil {
+			t.Fatalf("failed to add token: %v", err)
+		}
+
+		dac := NewDatabaseAccessChecker(store, true, false)
+		ctx := apiTokenContext("testhash123")
+		result := dac.GetAccessibleDatabases(ctx, databases)
+		if len(result) != 1 {
+			t.Fatalf("expected 1 database, got %d", len(result))
+		}
+		if result[0].Name != "db2" {
+			t.Errorf("expected database name %q, got %q", "db2", result[0].Name)
+		}
+	})
+
+	t.Run("bound API token with nonexistent database returns nil", func(t *testing.T) {
+		store := InitializeTokenStore()
+		err := store.AddToken("test-token", "testhash456", "test", nil, "nonexistent")
+		if err != nil {
+			t.Fatalf("failed to add token: %v", err)
+		}
+
+		dac := NewDatabaseAccessChecker(store, true, false)
+		ctx := apiTokenContext("testhash456")
+		result := dac.GetAccessibleDatabases(ctx, databases)
+		if result != nil {
+			t.Fatalf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("session user with access returns filtered databases", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, false)
+		dbs := []config.NamedDatabaseConfig{
+			{Name: "db1", Database: "db1", AvailableToUsers: []string{"alice", "bob"}},
+			{Name: "db2", Database: "db2", AvailableToUsers: []string{"charlie"}},
+			{Name: "db3", Database: "db3", AvailableToUsers: []string{}},
+		}
+		ctx := sessionUserContext("alice")
+		result := dac.GetAccessibleDatabases(ctx, dbs)
+		// alice should see db1 (explicitly listed) and db3 (empty = all users)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 databases, got %d", len(result))
+		}
+		if result[0].Name != "db1" || result[1].Name != "db3" {
+			t.Errorf("unexpected databases: %v", result)
+		}
+	})
+
+	t.Run("session user with no username returns nil", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, false)
+		ctx := context.Background()
+		result := dac.GetAccessibleDatabases(ctx, databases)
+		if result != nil {
+			t.Fatalf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("empty database list returns empty", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, false)
+		ctx := apiTokenContext("")
+		result := dac.GetAccessibleDatabases(ctx, nil)
+		if len(result) != 0 {
+			t.Fatalf("expected 0 databases, got %d", len(result))
+		}
+	})
+}
+
+func TestCanAccessDatabase(t *testing.T) {
+	db := &config.NamedDatabaseConfig{Name: "testdb", Database: "testdb"}
+
+	t.Run("STDIO mode allows access", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, true)
+		if !dac.CanAccessDatabase(context.Background(), db) {
+			t.Fatal("expected access to be allowed in STDIO mode")
+		}
+	})
+
+	t.Run("auth disabled allows access", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, false, false)
+		if !dac.CanAccessDatabase(context.Background(), db) {
+			t.Fatal("expected access to be allowed with auth disabled")
+		}
+	})
+
+	t.Run("API token allows access", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, false)
+		ctx := apiTokenContext("")
+		if !dac.CanAccessDatabase(ctx, db) {
+			t.Fatal("expected access to be allowed for API token")
+		}
+	})
+
+	t.Run("session user with access allowed", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, false)
+		dbWithUsers := &config.NamedDatabaseConfig{
+			Name:             "testdb",
+			AvailableToUsers: []string{"alice"},
+		}
+		ctx := sessionUserContext("alice")
+		if !dac.CanAccessDatabase(ctx, dbWithUsers) {
+			t.Fatal("expected access to be allowed for alice")
+		}
+	})
+
+	t.Run("session user without access denied", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, false)
+		dbWithUsers := &config.NamedDatabaseConfig{
+			Name:             "testdb",
+			AvailableToUsers: []string{"bob"},
+		}
+		ctx := sessionUserContext("alice")
+		if dac.CanAccessDatabase(ctx, dbWithUsers) {
+			t.Fatal("expected access to be denied for alice")
+		}
+	})
+
+	t.Run("no username denies access", func(t *testing.T) {
+		dac := NewDatabaseAccessChecker(nil, true, false)
+		if dac.CanAccessDatabase(context.Background(), db) {
+			t.Fatal("expected access to be denied with no username")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Fix `GetAccessibleDatabases` returning only the first database for
  unbound API tokens, while `CanAccessDatabase` returns true for all.
  This caused `getClient()` to silently override the user's database
  selection on every subsequent tool call in HTTP mode.
- Add comprehensive test coverage for `GetAccessibleDatabases` and
  `CanAccessDatabase` (14 test cases).

Fixes #117

## Test plan

- [ ] All existing tests pass (`make test`)
- [ ] New `access_test.go` covers unbound API token, bound API token,
      session user, STDIO, and auth-disabled scenarios
- [ ] Manual verification: `select_database_connection` persists across
      subsequent `query_database` calls in HTTP mode with unbound tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed database selection persistence in HTTP mode for unbound API tokens. The system now returns all accessible databases instead of only the first one.

* **Tests**
  * Added comprehensive test coverage for database access control mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->