### PR TITLE
Add Gemini provider, local LLM support, and custom headers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,16 +5,6 @@ to be assessed as part of the initial work, and inclusion here does not
 represent a roadmap or any guarantee that any features will actually be
 implemented.
 
-## LLM Support
-
--  Add support for use of Google Gemini as the LLM provider.
--  Add support for use of OpenAI API-compatible local LLM providers, such as
-    LM Studio, Docker Model Runner, and EXO. These should just work if 
-    configured as OpenAI, but without a requirement for an API key.
-- Add support for arbitrary request headers to be added to LLM request calls
-    to support servers such as Portkey which requires addition of headers such
-    as `x-portkey-provider: openai`
-
 ## Tools
 
 - Add an MCP tool for validating SQL queries before presentation to the user.

--- a/cmd/kb-builder/main.go
+++ b/cmd/kb-builder/main.go
@@ -46,7 +46,7 @@ pgEdge PostgreSQL MCP server.
 
 The tool converts documents from multiple formats (Markdown, HTML, RST, SGML),
 chunks them intelligently, generates embeddings using multiple providers (OpenAI,
-Voyage, Ollama), and stores everything in an optimized SQLite database.`,
+Voyage, Ollama, Gemini), and stores everything in an optimized SQLite database.`,
 	RunE: run,
 }
 
@@ -60,7 +60,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&addMissingEmbeddings, "add-missing-embeddings", false,
 		"Add missing embeddings to existing database instead of rebuilding")
 	rootCmd.Flags().StringVar(&clearEmbeddings, "clear-embeddings", "",
-		"Clear embeddings for specified provider (openai, voyage, or ollama)")
+		"Clear embeddings for specified provider (openai, voyage, ollama, or gemini)")
 	rootCmd.Flags().IntVar(&maxRetries, "max-retries", 5,
 		"Maximum number of retries for transient embedding API errors (0 = unlimited)")
 }
@@ -122,6 +122,9 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	if config.Embeddings.Ollama.Enabled {
 		enabledProviders = append(enabledProviders, "Ollama")
+	}
+	if config.Embeddings.Gemini.Enabled {
+		enabledProviders = append(enabledProviders, "Gemini")
 	}
 	fmt.Printf("Enabled embedding providers: %v\n", enabledProviders)
 
@@ -224,6 +227,9 @@ func runAddMissingEmbeddings(config *kbconfig.Config) error {
 			needsEmbedding = true
 		}
 		if config.Embeddings.Ollama.Enabled && len(chunk.OllamaEmbedding) == 0 {
+			needsEmbedding = true
+		}
+		if config.Embeddings.Gemini.Enabled && len(chunk.GeminiEmbedding) == 0 {
 			needsEmbedding = true
 		}
 
@@ -429,6 +435,7 @@ func processFile(filePath string, source kbsource.SourceInfo, db *kbdatabase.Dat
 				OpenAIEmbedding:    existingChunk.OpenAIEmbedding,
 				VoyageEmbedding:    existingChunk.VoyageEmbedding,
 				OllamaEmbedding:    existingChunk.OllamaEmbedding,
+				GeminiEmbedding:    existingChunk.GeminiEmbedding,
 			}
 			chunks = append(chunks, chunk)
 		}

--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -880,6 +880,9 @@ func main() {
 					OpenAIAPIKey:     cfg.LLM.OpenAIAPIKey,
 					OpenAIBaseURL:    cfg.LLM.OpenAIBaseURL,
 					OllamaURL:        cfg.LLM.OllamaURL,
+					GeminiAPIKey:     cfg.LLM.GeminiAPIKey,
+					GeminiBaseURL:    cfg.LLM.GeminiBaseURL,
+					CustomHeaders:    cfg.LLM.CustomHeaders,
 					MaxTokens:        cfg.LLM.MaxTokens,
 					Temperature:      cfg.LLM.Temperature,
 				}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,20 @@ and this project adheres to
 
 ### Added
 
+- Add Google Gemini as a chat LLM and embedding provider using
+  the Google AI Studio API.
+
+- Allow the OpenAI provider to work without an API key when a
+  custom base URL is configured; this enables use with LM Studio,
+  Docker Model Runner, EXO, and other OpenAI API-compatible local
+  LLM providers.
+
+- Add support for custom HTTP headers on all LLM and embedding
+  API requests; this enables proxy services such as Portkey.
+
+- Add Gemini embedding support to the knowledge base builder and
+  similarity search.
+
 - Schema metadata cache now refreshes automatically based on a
   configurable TTL. The `metadata_ttl` database option controls
   how long cached metadata remains valid (default: 5 minutes).

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -370,19 +370,25 @@ func (c *Client) initializeLLM() error {
 	switch provider {
 	case "anthropic":
 		tempClient, clientErr = NewAnthropicClient(
-			c.config.LLM.AnthropicAPIKey, c.config.LLM.AnthropicBaseURL, "", 0, 0, false)
+			c.config.LLM.AnthropicAPIKey, c.config.LLM.AnthropicBaseURL, "", 0, 0, c.config.LLM.CustomHeaders, false)
 		if clientErr != nil {
 			return fmt.Errorf("failed to create Anthropic client: %w", clientErr)
 		}
 	case "openai":
 		tempClient, clientErr = NewOpenAIClient(
-			c.config.LLM.OpenAIAPIKey, c.config.LLM.OpenAIBaseURL, "", 0, 0, false)
+			c.config.LLM.OpenAIAPIKey, c.config.LLM.OpenAIBaseURL, "", 0, 0, c.config.LLM.CustomHeaders, false)
 		if clientErr != nil {
 			return fmt.Errorf("failed to create OpenAI client: %w", clientErr)
 		}
 	case "ollama":
 		tempClient = NewOllamaClient(
-			c.config.LLM.OllamaURL, "", false)
+			c.config.LLM.OllamaURL, "", c.config.LLM.CustomHeaders, false)
+	case "gemini":
+		tempClient, clientErr = NewGeminiClient(
+			c.config.LLM.GeminiAPIKey, c.config.LLM.GeminiBaseURL, "", 0, 0, c.config.LLM.CustomHeaders, false)
+		if clientErr != nil {
+			return fmt.Errorf("failed to create Gemini client: %w", clientErr)
+		}
 	default:
 		return fmt.Errorf("unsupported LLM provider: %s", provider)
 	}
@@ -434,6 +440,7 @@ func (c *Client) initializeLLM() error {
 			c.config.LLM.Model,
 			c.config.LLM.MaxTokens,
 			c.config.LLM.Temperature,
+			c.config.LLM.CustomHeaders,
 			c.config.UI.Debug,
 		)
 		if clientErr != nil {
@@ -446,6 +453,7 @@ func (c *Client) initializeLLM() error {
 			c.config.LLM.Model,
 			c.config.LLM.MaxTokens,
 			c.config.LLM.Temperature,
+			c.config.LLM.CustomHeaders,
 			c.config.UI.Debug,
 		)
 		if clientErr != nil {
@@ -455,8 +463,22 @@ func (c *Client) initializeLLM() error {
 		c.llm = NewOllamaClient(
 			c.config.LLM.OllamaURL,
 			c.config.LLM.Model,
+			c.config.LLM.CustomHeaders,
 			c.config.UI.Debug,
 		)
+	case "gemini":
+		c.llm, clientErr = NewGeminiClient(
+			c.config.LLM.GeminiAPIKey,
+			c.config.LLM.GeminiBaseURL,
+			c.config.LLM.Model,
+			c.config.LLM.MaxTokens,
+			c.config.LLM.Temperature,
+			c.config.LLM.CustomHeaders,
+			c.config.UI.Debug,
+		)
+		if clientErr != nil {
+			return fmt.Errorf("failed to create Gemini client: %w", clientErr)
+		}
 	}
 
 	return nil
@@ -1298,6 +1320,8 @@ func getDefaultModelForProvider(provider string) string {
 		return "gpt-4o"
 	case "ollama":
 		return "qwen3-coder:latest"
+	case "gemini":
+		return "gemini-2.5-flash"
 	default:
 		return ""
 	}

--- a/internal/chat/config.go
+++ b/internal/chat/config.go
@@ -48,14 +48,14 @@ type MCPConfig struct {
 
 // LLMConfig holds LLM provider configuration
 type LLMConfig struct {
-	Provider            string  `yaml:"provider"`               // anthropic, openai, or ollama
-	Model               string  `yaml:"model"`                  // Model to use
-	AnthropicAPIKey     string  `yaml:"anthropic_api_key"`      // API key for Anthropic (direct - discouraged, use api_key_file or env var)
-	AnthropicAPIKeyFile string  `yaml:"anthropic_api_key_file"` // Path to file containing Anthropic API key
-	AnthropicBaseURL    string  `yaml:"anthropic_base_url"`     // Base URL for Anthropic API (default: https://api.anthropic.com)
-	OpenAIAPIKey        string  `yaml:"openai_api_key"`         // API key for OpenAI (direct - discouraged, use api_key_file or env var)
-	OpenAIAPIKeyFile    string  `yaml:"openai_api_key_file"`    // Path to file containing OpenAI API key
-	OpenAIBaseURL       string  `yaml:"openai_base_url"`        // Base URL for OpenAI API (default: https://api.openai.com)
+	Provider            string            `yaml:"provider"`               // anthropic, openai, or ollama
+	Model               string            `yaml:"model"`                  // Model to use
+	AnthropicAPIKey     string            `yaml:"anthropic_api_key"`      // API key for Anthropic (direct - discouraged, use api_key_file or env var)
+	AnthropicAPIKeyFile string            `yaml:"anthropic_api_key_file"` // Path to file containing Anthropic API key
+	AnthropicBaseURL    string            `yaml:"anthropic_base_url"`     // Base URL for Anthropic API (default: https://api.anthropic.com)
+	OpenAIAPIKey        string            `yaml:"openai_api_key"`         // API key for OpenAI (direct - discouraged, use api_key_file or env var)
+	OpenAIAPIKeyFile    string            `yaml:"openai_api_key_file"`    // Path to file containing OpenAI API key
+	OpenAIBaseURL       string            `yaml:"openai_base_url"`        // Base URL for OpenAI API (default: https://api.openai.com)
 	OllamaURL           string            `yaml:"ollama_url"`             // Ollama server URL
 	GeminiAPIKey        string            `yaml:"gemini_api_key"`         // API key for Google Gemini
 	GeminiAPIKeyFile    string            `yaml:"gemini_api_key_file"`    // Path to file containing Gemini API key

--- a/internal/chat/config.go
+++ b/internal/chat/config.go
@@ -56,9 +56,13 @@ type LLMConfig struct {
 	OpenAIAPIKey        string  `yaml:"openai_api_key"`         // API key for OpenAI (direct - discouraged, use api_key_file or env var)
 	OpenAIAPIKeyFile    string  `yaml:"openai_api_key_file"`    // Path to file containing OpenAI API key
 	OpenAIBaseURL       string  `yaml:"openai_base_url"`        // Base URL for OpenAI API (default: https://api.openai.com)
-	OllamaURL           string  `yaml:"ollama_url"`             // Ollama server URL
-	MaxTokens           int     `yaml:"max_tokens"`             // Max tokens for response
-	Temperature         float64 `yaml:"temperature"`            // Temperature for sampling
+	OllamaURL           string            `yaml:"ollama_url"`             // Ollama server URL
+	GeminiAPIKey        string            `yaml:"gemini_api_key"`         // API key for Google Gemini
+	GeminiAPIKeyFile    string            `yaml:"gemini_api_key_file"`    // Path to file containing Gemini API key
+	GeminiBaseURL       string            `yaml:"gemini_base_url"`        // Base URL for Gemini API
+	CustomHeaders       map[string]string `yaml:"custom_headers"`         // Custom HTTP headers for LLM API requests
+	MaxTokens           int               `yaml:"max_tokens"`             // Max tokens for response
+	Temperature         float64           `yaml:"temperature"`            // Temperature for sampling
 }
 
 // UIConfig holds UI configuration
@@ -91,6 +95,8 @@ func LoadConfig(configPath string) (*Config, error) {
 			OpenAIAPIKey:     getEnvWithFallback("PGEDGE_OPENAI_API_KEY", "OPENAI_API_KEY"),
 			OpenAIBaseURL:    os.Getenv("PGEDGE_OPENAI_BASE_URL"), // Empty string uses default
 			OllamaURL:        getEnvOrDefault("PGEDGE_OLLAMA_URL", "http://localhost:11434"),
+			GeminiAPIKey:     getEnvWithFallback("PGEDGE_GEMINI_API_KEY", "GEMINI_API_KEY"),
+			GeminiBaseURL:    os.Getenv("PGEDGE_GEMINI_BASE_URL"),
 			MaxTokens:        4096,
 			Temperature:      0.7,
 		},
@@ -138,7 +144,13 @@ func LoadConfig(configPath string) (*Config, error) {
 		}
 		// Note: errors are silently ignored - file may not exist and that's ok
 	}
-	// 2. Direct config value (if set) is already in cfg.LLM.AnthropicAPIKey/OpenAIAPIKey from loadConfigFile
+	if cfg.LLM.GeminiAPIKey == "" && cfg.LLM.GeminiAPIKeyFile != "" {
+		if key, err := readAPIKeyFromFile(cfg.LLM.GeminiAPIKeyFile); err == nil && key != "" {
+			cfg.LLM.GeminiAPIKey = key
+		}
+		// Note: errors are silently ignored - file may not exist and that's ok
+	}
+	// 2. Direct config value (if set) is already in cfg.LLM.AnthropicAPIKey/OpenAIAPIKey/GeminiAPIKey from loadConfigFile
 
 	// Load authentication token with priority
 	cfg.MCP.Token = loadAuthToken()
@@ -198,8 +210,8 @@ func (c *Config) Validate() error {
 	}
 
 	// Validate LLM provider
-	if c.LLM.Provider != "anthropic" && c.LLM.Provider != "openai" && c.LLM.Provider != "ollama" {
-		return fmt.Errorf("invalid llm-provider: %s (must be anthropic, openai, or ollama)", c.LLM.Provider)
+	if c.LLM.Provider != "anthropic" && c.LLM.Provider != "openai" && c.LLM.Provider != "ollama" && c.LLM.Provider != "gemini" {
+		return fmt.Errorf("invalid llm-provider: %s (must be anthropic, openai, ollama, or gemini)", c.LLM.Provider)
 	}
 
 	// Validate LLM configuration based on provider
@@ -212,11 +224,18 @@ func (c *Config) Validate() error {
 			c.LLM.Model = "claude-sonnet-4-5-20250929"
 		}
 	case "openai":
-		if c.LLM.OpenAIAPIKey == "" {
-			return fmt.Errorf("PGEDGE_OPENAI_API_KEY environment variable or openai_api_key config is required for OpenAI")
+		if c.LLM.OpenAIAPIKey == "" && c.LLM.OpenAIBaseURL == "" {
+			return fmt.Errorf("PGEDGE_OPENAI_API_KEY environment variable or openai_api_key config is required for OpenAI (unless using a custom base URL for local LLMs)")
 		}
 		if c.LLM.Model == "" {
 			c.LLM.Model = "gpt-4o"
+		}
+	case "gemini":
+		if c.LLM.GeminiAPIKey == "" {
+			return fmt.Errorf("PGEDGE_GEMINI_API_KEY environment variable or gemini_api_key config is required for Gemini")
+		}
+		if c.LLM.Model == "" {
+			c.LLM.Model = "gemini-2.5-flash"
 		}
 	default:
 		if c.LLM.OllamaURL == "" {
@@ -236,7 +255,9 @@ func (c *Config) IsProviderConfigured(provider string) bool {
 	case "anthropic":
 		return c.LLM.AnthropicAPIKey != ""
 	case "openai":
-		return c.LLM.OpenAIAPIKey != ""
+		return c.LLM.OpenAIAPIKey != "" || c.LLM.OpenAIBaseURL != ""
+	case "gemini":
+		return c.LLM.GeminiAPIKey != ""
 	case "ollama":
 		// Ollama is configured if URL is set (defaults to localhost)
 		return c.LLM.OllamaURL != ""
@@ -254,6 +275,9 @@ func (c *Config) GetConfiguredProviders() []string {
 	}
 	if c.IsProviderConfigured("openai") {
 		providers = append(providers, "openai")
+	}
+	if c.IsProviderConfigured("gemini") {
+		providers = append(providers, "gemini")
 	}
 	if c.IsProviderConfigured("ollama") {
 		providers = append(providers, "ollama")

--- a/internal/chat/llm.go
+++ b/internal/chat/llm.go
@@ -13,6 +13,8 @@ package chat
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -102,14 +104,15 @@ type LLMClient interface {
 
 // anthropicClient implements LLMClient for Anthropic Claude
 type anthropicClient struct {
-	apiKey      string
-	baseURL     string
-	model       string
-	maxTokens   int
-	temperature float64
-	debug       bool
-	readOnly    bool
-	client      *http.Client
+	apiKey        string
+	baseURL       string
+	model         string
+	maxTokens     int
+	temperature   float64
+	debug         bool
+	readOnly      bool
+	customHeaders map[string]string
+	client        *http.Client
 }
 
 // SetReadOnlyMode sets whether the database is in read-only mode.
@@ -138,7 +141,7 @@ func ValidateBaseURL(baseURL, providerName string) (string, error) {
 
 // NewAnthropicClient creates a new Anthropic client
 // baseURL can be empty to use the default (https://api.anthropic.com)
-func NewAnthropicClient(apiKey, baseURL, model string, maxTokens int, temperature float64, debug bool) (LLMClient, error) {
+func NewAnthropicClient(apiKey, baseURL, model string, maxTokens int, temperature float64, customHeaders map[string]string, debug bool) (LLMClient, error) {
 	if baseURL == "" {
 		baseURL = "https://api.anthropic.com"
 	} else {
@@ -149,13 +152,14 @@ func NewAnthropicClient(apiKey, baseURL, model string, maxTokens int, temperatur
 		}
 	}
 	return &anthropicClient{
-		apiKey:      apiKey,
-		baseURL:     baseURL,
-		model:       model,
-		maxTokens:   maxTokens,
-		temperature: temperature,
-		debug:       debug,
-		client:      &http.Client{},
+		apiKey:        apiKey,
+		baseURL:       baseURL,
+		model:         model,
+		maxTokens:     maxTokens,
+		temperature:   temperature,
+		customHeaders: customHeaders,
+		debug:         debug,
+		client:        &http.Client{},
 	}, nil
 }
 
@@ -288,6 +292,9 @@ When executing tools:
 	httpReq.Header.Set("x-api-key", c.apiKey)
 	httpReq.Header.Set("anthropic-version", "2023-06-01")
 	httpReq.Header.Set("anthropic-beta", "prompt-caching-2024-07-31")
+	for k, v := range c.customHeaders {
+		httpReq.Header.Set(k, v)
+	}
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
@@ -429,6 +436,9 @@ func (c *anthropicClient) ListModels(ctx context.Context) ([]string, error) {
 
 	req.Header.Set("x-api-key", c.apiKey)
 	req.Header.Set("anthropic-version", "2023-06-01")
+	for k, v := range c.customHeaders {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -466,11 +476,12 @@ func (c *anthropicClient) ListModels(ctx context.Context) ([]string, error) {
 
 // ollamaClient implements LLMClient for Ollama
 type ollamaClient struct {
-	baseURL  string
-	model    string
-	debug    bool
-	readOnly bool
-	client   *http.Client
+	baseURL       string
+	model         string
+	debug         bool
+	readOnly      bool
+	customHeaders map[string]string
+	client        *http.Client
 }
 
 // SetReadOnlyMode sets whether the database is in read-only mode.
@@ -479,12 +490,13 @@ func (c *ollamaClient) SetReadOnlyMode(readOnly bool) {
 }
 
 // NewOllamaClient creates a new Ollama client
-func NewOllamaClient(baseURL, model string, debug bool) LLMClient {
+func NewOllamaClient(baseURL, model string, customHeaders map[string]string, debug bool) LLMClient {
 	return &ollamaClient{
-		baseURL: baseURL,
-		model:   model,
-		debug:   debug,
-		client:  &http.Client{},
+		baseURL:       baseURL,
+		model:         model,
+		customHeaders: customHeaders,
+		debug:         debug,
+		client:        &http.Client{},
 	}
 }
 
@@ -823,6 +835,9 @@ When executing tools:
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
+	for k, v := range c.customHeaders {
+		httpReq.Header.Set(k, v)
+	}
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
@@ -980,6 +995,10 @@ func (c *ollamaClient) ListModels(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
+	for k, v := range c.customHeaders {
+		req.Header.Set(k, v)
+	}
+
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
@@ -1010,16 +1029,584 @@ func (c *ollamaClient) ListModels(ctx context.Context) ([]string, error) {
 	return models, nil
 }
 
+// geminiClient implements LLMClient for Google Gemini models
+type geminiClient struct {
+	apiKey        string
+	baseURL       string
+	model         string
+	maxTokens     int
+	temperature   float64
+	debug         bool
+	readOnly      bool
+	customHeaders map[string]string
+	client        *http.Client
+}
+
+// SetReadOnlyMode sets whether the database is in read-only mode.
+func (c *geminiClient) SetReadOnlyMode(readOnly bool) {
+	c.readOnly = readOnly
+}
+
+// NewGeminiClient creates a new Gemini client
+// baseURL can be empty to use the default (https://generativelanguage.googleapis.com)
+func NewGeminiClient(apiKey, baseURL, model string, maxTokens int, temperature float64, customHeaders map[string]string, debug bool) (LLMClient, error) {
+	if baseURL == "" {
+		baseURL = "https://generativelanguage.googleapis.com"
+	} else {
+		var err error
+		baseURL, err = ValidateBaseURL(baseURL, "Gemini")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &geminiClient{
+		apiKey:        apiKey,
+		baseURL:       baseURL,
+		model:         model,
+		maxTokens:     maxTokens,
+		temperature:   temperature,
+		customHeaders: customHeaders,
+		debug:         debug,
+		client:        &http.Client{},
+	}, nil
+}
+
+type geminiRequest struct {
+	Contents          []geminiContent         `json:"contents"`
+	Tools             []geminiToolDeclaration `json:"tools,omitempty"`
+	SystemInstruction *geminiContent          `json:"systemInstruction,omitempty"`
+	GenerationConfig  *geminiGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text             string                  `json:"text,omitempty"`
+	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+type geminiFunctionCall struct {
+	Name string                 `json:"name"`
+	Args map[string]interface{} `json:"args"`
+}
+
+type geminiFunctionResponse struct {
+	Name     string                 `json:"name"`
+	Response map[string]interface{} `json:"response"`
+}
+
+type geminiToolDeclaration struct {
+	FunctionDeclarations []geminiFunction `json:"functionDeclarations"`
+}
+
+type geminiFunction struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Parameters  interface{} `json:"parameters,omitempty"`
+}
+
+type geminiGenerationConfig struct {
+	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
+	Temperature     float64 `json:"temperature,omitempty"`
+}
+
+type geminiResponse struct {
+	Candidates    []geminiCandidate    `json:"candidates"`
+	UsageMetadata *geminiUsageMetadata `json:"usageMetadata,omitempty"`
+}
+
+type geminiCandidate struct {
+	Content      geminiContent `json:"content"`
+	FinishReason string        `json:"finishReason"`
+}
+
+type geminiUsageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+}
+
+type geminiErrorResponse struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+// extractGeminiErrorMessage parses Gemini's error response to get a user-friendly message
+func extractGeminiErrorMessage(statusCode int, body []byte) string {
+	var errResp geminiErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error.Message != "" {
+		return fmt.Sprintf("API error (%d): %s", statusCode, errResp.Error.Message)
+	}
+	return fmt.Sprintf("API error (%d): %s", statusCode, string(body))
+}
+
+// generateToolID creates a unique identifier for tool calls
+func generateToolID() string {
+	b := make([]byte, 12)
+	_, err := crand.Read(b)
+	if err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
+}
+
+func (c *geminiClient) Chat(ctx context.Context, messages []Message, tools interface{}) (LLMResponse, error) {
+	startTime := time.Now()
+	operation := "chat"
+	requestURL := c.baseURL + "/v1beta/models/" + c.model + ":generateContent?key=" + c.apiKey
+
+	// Log the URL without the API key for security
+	safeURL := c.baseURL + "/v1beta/models/" + c.model + ":generateContent?key=***"
+	embedding.LogLLMCallDetails("gemini", c.model, operation, safeURL, len(messages))
+
+	// Convert interface{} tools to []mcp.Tool via JSON
+	var mcpTools []mcp.Tool
+	if tools != nil {
+		toolsJSON, err := json.Marshal(tools)
+		if err != nil {
+			return LLMResponse{}, fmt.Errorf("failed to marshal tools: %w", err)
+		}
+		if err := json.Unmarshal(toolsJSON, &mcpTools); err != nil {
+			return LLMResponse{}, fmt.Errorf("failed to unmarshal tools: %w", err)
+		}
+	}
+
+	// Convert MCP tools to Gemini's functionDeclarations format
+	var geminiTools []geminiToolDeclaration
+	if len(mcpTools) > 0 {
+		var functions []geminiFunction
+		for _, tool := range mcpTools {
+			functions = append(functions, geminiFunction{
+				Name:        tool.Name,
+				Description: tool.Description,
+				Parameters:  tool.InputSchema,
+			})
+		}
+		geminiTools = []geminiToolDeclaration{
+			{FunctionDeclarations: functions},
+		}
+	}
+
+	// Build system instruction
+	systemContent := `You are a helpful PostgreSQL database assistant with expert knowledge on PostgreSQL and products from pgEdge with access to MCP tools.
+
+When executing tools:
+- Be concise and direct
+- Show results without explaining your methodology unless specifically asked
+- Base responses ONLY on actual tool results - never make up or guess data
+- Format results clearly for the user
+- Only use tools when necessary to answer the question`
+
+	if c.readOnly {
+		systemContent += readOnlySafetyPrompt
+	}
+
+	systemInstruction := &geminiContent{
+		Parts: []geminiPart{
+			{Text: systemContent},
+		},
+	}
+
+	// Build a map of tool use IDs to tool names for correlating
+	// tool results with their original tool calls.
+	toolNameByID := make(map[string]string)
+	for _, msg := range messages {
+		if items, ok := msg.Content.([]interface{}); ok && msg.Role == "assistant" {
+			for _, item := range items {
+				switch v := item.(type) {
+				case ToolUse:
+					toolNameByID[v.ID] = v.Name
+				default:
+					if itemMap, ok := item.(map[string]interface{}); ok {
+						if itemType, ok2 := itemMap["type"].(string); ok2 && itemType == "tool_use" {
+							if id, ok1 := itemMap["id"].(string); ok1 {
+								if name, ok2 := itemMap["name"].(string); ok2 {
+									toolNameByID[id] = name
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Convert messages to Gemini format
+	var contents []geminiContent
+	for _, msg := range messages {
+		switch content := msg.Content.(type) {
+		case string:
+			role := msg.Role
+			if role == "assistant" {
+				role = "model"
+			}
+			contents = append(contents, geminiContent{
+				Role:  role,
+				Parts: []geminiPart{{Text: content}},
+			})
+		case []ToolResult:
+			// Handle []ToolResult directly (from client.go tool execution)
+			var parts []geminiPart
+			for _, v := range content {
+				contentStr := toolResultContentString(v.Content)
+				if contentStr == "" {
+					contentStr = "{}"
+				}
+				toolName := toolNameByID[v.ToolUseID]
+				parts = append(parts, geminiPart{
+					FunctionResponse: &geminiFunctionResponse{
+						Name: toolName,
+						Response: map[string]interface{}{
+							"result": contentStr,
+						},
+					},
+				})
+			}
+			if len(parts) > 0 {
+				contents = append(contents, geminiContent{
+					Role:  "user",
+					Parts: parts,
+				})
+			}
+		case []interface{}:
+			if msg.Role == "assistant" {
+				// Handle assistant messages with text and tool_use
+				var parts []geminiPart
+				for _, item := range content {
+					switch v := item.(type) {
+					case TextContent:
+						parts = append(parts, geminiPart{Text: v.Text})
+					case ToolUse:
+						parts = append(parts, geminiPart{
+							FunctionCall: &geminiFunctionCall{
+								Name: v.Name,
+								Args: v.Input,
+							},
+						})
+					default:
+						itemMap, ok := item.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						itemType, ok2 := itemMap["type"].(string)
+						if !ok2 {
+							continue
+						}
+						switch itemType {
+						case "text":
+							if text, ok := itemMap["text"].(string); ok {
+								parts = append(parts, geminiPart{Text: text})
+							}
+						case "tool_use":
+							name, ok1 := itemMap["name"].(string)
+							if !ok1 {
+								continue
+							}
+							input, ok2 := itemMap["input"].(map[string]interface{})
+							if !ok2 || input == nil {
+								input = map[string]interface{}{}
+							}
+							parts = append(parts, geminiPart{
+								FunctionCall: &geminiFunctionCall{
+									Name: name,
+									Args: input,
+								},
+							})
+						}
+					}
+				}
+				if len(parts) > 0 {
+					contents = append(contents, geminiContent{
+						Role:  "model",
+						Parts: parts,
+					})
+				}
+			} else {
+				// Handle user messages with tool_result content
+				var parts []geminiPart
+				for _, item := range content {
+					switch v := item.(type) {
+					case ToolResult:
+						contentStr := toolResultContentString(v.Content)
+						if contentStr == "" {
+							contentStr = "{}"
+						}
+						toolName := toolNameByID[v.ToolUseID]
+						parts = append(parts, geminiPart{
+							FunctionResponse: &geminiFunctionResponse{
+								Name: toolName,
+								Response: map[string]interface{}{
+									"result": contentStr,
+								},
+							},
+						})
+					default:
+						itemMap, ok := item.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						itemType, ok2 := itemMap["type"].(string)
+						if !ok2 {
+							continue
+						}
+						if itemType == "tool_result" {
+							toolUseID, ok := itemMap["tool_use_id"].(string)
+							if !ok {
+								continue
+							}
+							resultContent := itemMap["content"]
+							contentStr := extractTextFromContent(resultContent)
+							if contentStr == "" {
+								contentStr = "{}"
+							}
+							toolName := toolNameByID[toolUseID]
+							parts = append(parts, geminiPart{
+								FunctionResponse: &geminiFunctionResponse{
+									Name: toolName,
+									Response: map[string]interface{}{
+										"result": contentStr,
+									},
+								},
+							})
+						}
+					}
+				}
+				if len(parts) > 0 {
+					contents = append(contents, geminiContent{
+						Role:  "user",
+						Parts: parts,
+					})
+				}
+			}
+		}
+	}
+
+	// Build request
+	geminiReq := geminiRequest{
+		Contents:          contents,
+		Tools:             geminiTools,
+		SystemInstruction: systemInstruction,
+		GenerationConfig: &geminiGenerationConfig{
+			MaxOutputTokens: c.maxTokens,
+			Temperature:     c.temperature,
+		},
+	}
+
+	reqData, err := json.Marshal(geminiReq)
+	if err != nil {
+		return LLMResponse{}, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	embedding.LogLLMRequestTrace("gemini", c.model, operation, string(reqData))
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", requestURL, bytes.NewBuffer(reqData))
+	if err != nil {
+		return LLMResponse{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	for k, v := range c.customHeaders {
+		httpReq.Header.Set(k, v)
+	}
+
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		embedding.LogConnectionError("gemini", safeURL, err)
+		duration := time.Since(startTime)
+		embedding.LogLLMCall("gemini", c.model, operation, 0, 0, duration, err)
+		return LLMResponse{}, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			duration := time.Since(startTime)
+			readErr := fmt.Errorf("API error %d (failed to read body: %w)", resp.StatusCode, err)
+			embedding.LogLLMCall("gemini", c.model, operation, 0, 0, duration, readErr)
+			return LLMResponse{}, readErr
+		}
+
+		// Check if this is a rate limit error
+		if resp.StatusCode == 429 {
+			embedding.LogRateLimitError("gemini", c.model, resp.StatusCode, string(body))
+		}
+
+		// Extract user-friendly error message from Gemini's error response
+		userFriendlyMsg := extractGeminiErrorMessage(resp.StatusCode, body)
+
+		duration := time.Since(startTime)
+		apiErr := fmt.Errorf("%s", userFriendlyMsg)
+		embedding.LogLLMCall("gemini", c.model, operation, 0, 0, duration, apiErr)
+		return LLMResponse{}, apiErr
+	}
+
+	var geminiResp geminiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
+		duration := time.Since(startTime)
+		embedding.LogLLMCall("gemini", c.model, operation, 0, 0, duration, err)
+		return LLMResponse{}, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if len(geminiResp.Candidates) == 0 {
+		duration := time.Since(startTime)
+		err := fmt.Errorf("no candidates in response")
+		embedding.LogLLMCall("gemini", c.model, operation, 0, 0, duration, err)
+		return LLMResponse{}, err
+	}
+
+	candidate := geminiResp.Candidates[0]
+
+	// Convert response content to typed structs
+	var responseContent []interface{}
+	hasToolUse := false
+	for _, part := range candidate.Content.Parts {
+		if part.FunctionCall != nil {
+			hasToolUse = true
+			responseContent = append(responseContent, ToolUse{
+				Type:  "tool_use",
+				ID:    generateToolID(),
+				Name:  part.FunctionCall.Name,
+				Input: part.FunctionCall.Args,
+			})
+		} else if part.Text != "" {
+			responseContent = append(responseContent, TextContent{
+				Type: "text",
+				Text: part.Text,
+			})
+		}
+	}
+
+	// Determine stop reason
+	stopReason := "end_turn"
+	if hasToolUse {
+		stopReason = "tool_use"
+	} else {
+		switch candidate.FinishReason {
+		case "STOP":
+			stopReason = "end_turn"
+		case "MAX_TOKENS":
+			stopReason = "max_tokens"
+		}
+	}
+
+	// Extract token usage
+	promptTokens := 0
+	completionTokens := 0
+	totalTokens := 0
+	if geminiResp.UsageMetadata != nil {
+		promptTokens = geminiResp.UsageMetadata.PromptTokenCount
+		completionTokens = geminiResp.UsageMetadata.CandidatesTokenCount
+		totalTokens = geminiResp.UsageMetadata.TotalTokenCount
+	}
+
+	duration := time.Since(startTime)
+	embedding.LogLLMResponseTrace("gemini", c.model, operation, resp.StatusCode, stopReason)
+	embedding.LogLLMCall("gemini", c.model, operation, promptTokens, completionTokens, duration, nil)
+
+	// Build token usage for debug
+	var tokenUsage *TokenUsage
+	if c.debug {
+		tokenUsage = &TokenUsage{
+			Provider:         "gemini",
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      totalTokens,
+		}
+
+		// Log to stderr for CLI
+		fmt.Fprintf(os.Stderr, "\r\n[LLM] [DEBUG] Gemini - Tokens: Prompt %d, Completion %d, Total %d\n",
+			promptTokens,
+			completionTokens,
+			totalTokens,
+		)
+	}
+
+	return LLMResponse{
+		Content:    responseContent,
+		StopReason: stopReason,
+		TokenUsage: tokenUsage,
+	}, nil
+}
+
+// ListModels returns available models from Gemini
+// Filters to models that support generateContent
+func (c *geminiClient) ListModels(ctx context.Context) ([]string, error) {
+	requestURL := c.baseURL + "/v1beta/models?key=" + c.apiKey
+
+	req, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	for k, v := range c.customHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body) //nolint:errcheck // Error response body read is best effort
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response: {"models": [{"name": "models/gemini-pro", "supportedGenerationMethods": [...], ...}, ...]}
+	var response struct {
+		Models []struct {
+			Name                       string   `json:"name"`
+			SupportedGenerationMethods []string `json:"supportedGenerationMethods"`
+		} `json:"models"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	models := make([]string, 0, len(response.Models))
+	for _, model := range response.Models {
+		// Only include models that support generateContent
+		supportsGenerate := false
+		for _, method := range model.SupportedGenerationMethods {
+			if method == "generateContent" {
+				supportsGenerate = true
+				break
+			}
+		}
+		if !supportsGenerate {
+			continue
+		}
+
+		// Strip "models/" prefix from model names
+		name := model.Name
+		name = strings.TrimPrefix(name, "models/")
+		models = append(models, name)
+	}
+
+	return models, nil
+}
+
 // openaiClient implements LLMClient for OpenAI GPT models
 type openaiClient struct {
-	apiKey      string
-	baseURL     string
-	model       string
-	maxTokens   int
-	temperature float64
-	debug       bool
-	readOnly    bool
-	client      *http.Client
+	apiKey        string
+	baseURL       string
+	model         string
+	maxTokens     int
+	temperature   float64
+	debug         bool
+	readOnly      bool
+	customHeaders map[string]string
+	client        *http.Client
 }
 
 // SetReadOnlyMode sets whether the database is in read-only mode.
@@ -1029,7 +1616,7 @@ func (c *openaiClient) SetReadOnlyMode(readOnly bool) {
 
 // NewOpenAIClient creates a new OpenAI client
 // baseURL can be empty to use the default (https://api.openai.com)
-func NewOpenAIClient(apiKey, baseURL, model string, maxTokens int, temperature float64, debug bool) (LLMClient, error) {
+func NewOpenAIClient(apiKey, baseURL, model string, maxTokens int, temperature float64, customHeaders map[string]string, debug bool) (LLMClient, error) {
 	if baseURL == "" {
 		baseURL = "https://api.openai.com"
 	} else {
@@ -1040,13 +1627,14 @@ func NewOpenAIClient(apiKey, baseURL, model string, maxTokens int, temperature f
 		}
 	}
 	return &openaiClient{
-		apiKey:      apiKey,
-		baseURL:     baseURL,
-		model:       model,
-		maxTokens:   maxTokens,
-		temperature: temperature,
-		debug:       debug,
-		client:      &http.Client{},
+		apiKey:        apiKey,
+		baseURL:       baseURL,
+		model:         model,
+		maxTokens:     maxTokens,
+		temperature:   temperature,
+		customHeaders: customHeaders,
+		debug:         debug,
+		client:        &http.Client{},
 	}, nil
 }
 
@@ -1386,7 +1974,12 @@ When executing tools:
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	for k, v := range c.customHeaders {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -1563,7 +2156,12 @@ func (c *openaiClient) ListModels(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	for k, v := range c.customHeaders {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/internal/chat/llm_test.go
+++ b/internal/chat/llm_test.go
@@ -104,7 +104,7 @@ func TestOllamaClient_ToolCall(t *testing.T) {
 	defer server.Close()
 
 	// Create client
-	client := NewOllamaClient(server.URL, "test-model", false)
+	client := NewOllamaClient(server.URL, "test-model", nil, false)
 
 	// Test tool call
 	ctx := context.Background()
@@ -172,7 +172,7 @@ func TestOllamaClient_TextResponse(t *testing.T) {
 	defer server.Close()
 
 	// Create client
-	client := NewOllamaClient(server.URL, "test-model", false)
+	client := NewOllamaClient(server.URL, "test-model", nil, false)
 
 	// Test text response
 	ctx := context.Background()
@@ -254,7 +254,7 @@ func TestOllamaClient_NativeToolCall(t *testing.T) {
 	defer server.Close()
 
 	// Create client
-	client := NewOllamaClient(server.URL, "test-model", false)
+	client := NewOllamaClient(server.URL, "test-model", nil, false)
 
 	// Test native tool call
 	ctx := context.Background()
@@ -376,7 +376,7 @@ func TestOllamaClient_ToolResultMessages(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewOllamaClient(server.URL, "test-model", false)
+	client := NewOllamaClient(server.URL, "test-model", nil, false)
 	ctx := context.Background()
 
 	tools := []mcp.Tool{
@@ -813,7 +813,7 @@ func TestOpenAIClient_GPT5UsesMaxCompletionTokens(t *testing.T) {
 
 func TestNewAnthropicClient_BaseURL(t *testing.T) {
 	t.Run("default base URL when empty", func(t *testing.T) {
-		client, err := NewAnthropicClient("test-key", "", "claude-3-sonnet", 4096, 0.7, false)
+		client, err := NewAnthropicClient("test-key", "", "claude-3-sonnet", 4096, 0.7, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -827,7 +827,7 @@ func TestNewAnthropicClient_BaseURL(t *testing.T) {
 	})
 
 	t.Run("custom base URL", func(t *testing.T) {
-		client, err := NewAnthropicClient("test-key", "https://proxy.example.com", "claude-3-sonnet", 4096, 0.7, false)
+		client, err := NewAnthropicClient("test-key", "https://proxy.example.com", "claude-3-sonnet", 4096, 0.7, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -841,7 +841,7 @@ func TestNewAnthropicClient_BaseURL(t *testing.T) {
 	})
 
 	t.Run("base URL with trailing slash normalized", func(t *testing.T) {
-		client, err := NewAnthropicClient("test-key", "https://proxy.example.com/", "claude-3-sonnet", 4096, 0.7, false)
+		client, err := NewAnthropicClient("test-key", "https://proxy.example.com/", "claude-3-sonnet", 4096, 0.7, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -855,21 +855,21 @@ func TestNewAnthropicClient_BaseURL(t *testing.T) {
 	})
 
 	t.Run("invalid base URL scheme", func(t *testing.T) {
-		_, err := NewAnthropicClient("test-key", "ftp://proxy.example.com", "claude-3-sonnet", 4096, 0.7, false)
+		_, err := NewAnthropicClient("test-key", "ftp://proxy.example.com", "claude-3-sonnet", 4096, 0.7, nil, false)
 		if err == nil {
 			t.Fatal("expected error for invalid URL scheme")
 		}
 	})
 
 	t.Run("invalid base URL format", func(t *testing.T) {
-		_, err := NewAnthropicClient("test-key", "://invalid", "claude-3-sonnet", 4096, 0.7, false)
+		_, err := NewAnthropicClient("test-key", "://invalid", "claude-3-sonnet", 4096, 0.7, nil, false)
 		if err == nil {
 			t.Fatal("expected error for invalid URL format")
 		}
 	})
 
 	t.Run("base URL without host", func(t *testing.T) {
-		_, err := NewAnthropicClient("test-key", "https://", "claude-3-sonnet", 4096, 0.7, false)
+		_, err := NewAnthropicClient("test-key", "https://", "claude-3-sonnet", 4096, 0.7, nil, false)
 		if err == nil {
 			t.Fatal("expected error for URL without host")
 		}
@@ -878,7 +878,7 @@ func TestNewAnthropicClient_BaseURL(t *testing.T) {
 
 func TestNewOpenAIClient_BaseURL(t *testing.T) {
 	t.Run("default base URL when empty", func(t *testing.T) {
-		client, err := NewOpenAIClient("test-key", "", "gpt-4o", 4096, 0.7, false)
+		client, err := NewOpenAIClient("test-key", "", "gpt-4o", 4096, 0.7, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -892,7 +892,7 @@ func TestNewOpenAIClient_BaseURL(t *testing.T) {
 	})
 
 	t.Run("custom base URL", func(t *testing.T) {
-		client, err := NewOpenAIClient("test-key", "https://proxy.example.com", "gpt-4o", 4096, 0.7, false)
+		client, err := NewOpenAIClient("test-key", "https://proxy.example.com", "gpt-4o", 4096, 0.7, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -906,7 +906,7 @@ func TestNewOpenAIClient_BaseURL(t *testing.T) {
 	})
 
 	t.Run("base URL with trailing slash normalized", func(t *testing.T) {
-		client, err := NewOpenAIClient("test-key", "https://proxy.example.com/", "gpt-4o", 4096, 0.7, false)
+		client, err := NewOpenAIClient("test-key", "https://proxy.example.com/", "gpt-4o", 4096, 0.7, nil, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -920,21 +920,21 @@ func TestNewOpenAIClient_BaseURL(t *testing.T) {
 	})
 
 	t.Run("invalid base URL scheme", func(t *testing.T) {
-		_, err := NewOpenAIClient("test-key", "ftp://proxy.example.com", "gpt-4o", 4096, 0.7, false)
+		_, err := NewOpenAIClient("test-key", "ftp://proxy.example.com", "gpt-4o", 4096, 0.7, nil, false)
 		if err == nil {
 			t.Fatal("expected error for invalid URL scheme")
 		}
 	})
 
 	t.Run("invalid base URL format", func(t *testing.T) {
-		_, err := NewOpenAIClient("test-key", "://invalid", "gpt-4o", 4096, 0.7, false)
+		_, err := NewOpenAIClient("test-key", "://invalid", "gpt-4o", 4096, 0.7, nil, false)
 		if err == nil {
 			t.Fatal("expected error for invalid URL format")
 		}
 	})
 
 	t.Run("base URL without host", func(t *testing.T) {
-		_, err := NewOpenAIClient("test-key", "https://", "gpt-4o", 4096, 0.7, false)
+		_, err := NewOpenAIClient("test-key", "https://", "gpt-4o", 4096, 0.7, nil, false)
 		if err == nil {
 			t.Fatal("expected error for URL without host")
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -440,7 +440,11 @@ type EmbeddingConfig struct {
 	OpenAIAPIKey     string `yaml:"openai_api_key"`      // API key for OpenAI (direct - discouraged, use api_key_file or env var)
 	OpenAIAPIKeyFile string `yaml:"openai_api_key_file"` // Path to file containing OpenAI API key
 	OpenAIBaseURL    string `yaml:"openai_base_url"`     // Base URL for OpenAI API (default: https://api.openai.com/v1)
-	OllamaURL        string `yaml:"ollama_url"`          // URL for Ollama service (default: http://localhost:11434)
+	OllamaURL        string            `yaml:"ollama_url"`          // URL for Ollama service (default: http://localhost:11434)
+	GeminiAPIKey     string            `yaml:"gemini_api_key"`      // API key for Google Gemini (direct - discouraged, use api_key_file or env var)
+	GeminiAPIKeyFile string            `yaml:"gemini_api_key_file"` // Path to file containing Gemini API key
+	GeminiBaseURL    string            `yaml:"gemini_base_url"`     // Base URL for Gemini API (default: https://generativelanguage.googleapis.com)
+	CustomHeaders    map[string]string `yaml:"custom_headers"`      // Custom HTTP headers for embedding API requests
 }
 
 // LLMConfig holds LLM configuration for web client chat proxy
@@ -454,9 +458,13 @@ type LLMConfig struct {
 	OpenAIAPIKey        string  `yaml:"openai_api_key"`         // API key for OpenAI (direct - discouraged, use api_key_file or env var instead)
 	OpenAIAPIKeyFile    string  `yaml:"openai_api_key_file"`    // Path to file containing OpenAI API key
 	OpenAIBaseURL       string  `yaml:"openai_base_url"`        // Base URL for OpenAI API (default: https://api.openai.com)
-	OllamaURL           string  `yaml:"ollama_url"`             // URL for Ollama service (default: http://localhost:11434)
-	MaxTokens           int     `yaml:"max_tokens"`             // Maximum tokens for LLM response (default: 4096)
-	Temperature         float64 `yaml:"temperature"`            // Temperature for LLM sampling (default: 0.7)
+	OllamaURL           string            `yaml:"ollama_url"`             // URL for Ollama service (default: http://localhost:11434)
+	GeminiAPIKey        string            `yaml:"gemini_api_key"`         // API key for Google Gemini (direct - discouraged, use api_key_file or env var)
+	GeminiAPIKeyFile    string            `yaml:"gemini_api_key_file"`    // Path to file containing Gemini API key
+	GeminiBaseURL       string            `yaml:"gemini_base_url"`        // Base URL for Gemini API (default: https://generativelanguage.googleapis.com)
+	CustomHeaders       map[string]string `yaml:"custom_headers"`         // Custom HTTP headers for LLM API requests
+	MaxTokens           int               `yaml:"max_tokens"`             // Maximum tokens for LLM response (default: 4096)
+	Temperature         float64           `yaml:"temperature"`            // Temperature for LLM sampling (default: 0.7)
 }
 
 // KnowledgebaseConfig holds knowledgebase configuration
@@ -473,7 +481,11 @@ type KnowledgebaseConfig struct {
 	EmbeddingOpenAIAPIKey     string `yaml:"embedding_openai_api_key"`      // API key for OpenAI
 	EmbeddingOpenAIAPIKeyFile string `yaml:"embedding_openai_api_key_file"` // Path to file containing OpenAI API key
 	EmbeddingOpenAIBaseURL    string `yaml:"embedding_openai_base_url"`     // Base URL for OpenAI API (default: https://api.openai.com/v1)
-	EmbeddingOllamaURL        string `yaml:"embedding_ollama_url"`          // URL for Ollama service (default: http://localhost:11434)
+	EmbeddingOllamaURL        string            `yaml:"embedding_ollama_url"`          // URL for Ollama service (default: http://localhost:11434)
+	EmbeddingGeminiAPIKey     string            `yaml:"embedding_gemini_api_key"`      // API key for Google Gemini
+	EmbeddingGeminiAPIKeyFile string            `yaml:"embedding_gemini_api_key_file"` // Path to file containing Gemini API key
+	EmbeddingGeminiBaseURL    string            `yaml:"embedding_gemini_base_url"`     // Base URL for Gemini API
+	EmbeddingCustomHeaders    map[string]string `yaml:"embedding_custom_headers"`      // Custom HTTP headers for embedding API requests
 }
 
 // LoadConfig loads configuration with proper priority:
@@ -1002,6 +1014,14 @@ func applyEnvironmentVariables(cfg *Config) {
 	// Base URL overrides for embedding providers (useful for proxies)
 	setStringFromEnv(&cfg.Embedding.VoyageBaseURL, "PGEDGE_VOYAGE_BASE_URL")
 	setStringFromEnv(&cfg.Embedding.OpenAIBaseURL, "PGEDGE_OPENAI_EMBEDDING_BASE_URL")
+	// Gemini embedding
+	setStringFromEnvWithFallback(&cfg.Embedding.GeminiAPIKey, "PGEDGE_GEMINI_API_KEY", "GEMINI_API_KEY")
+	if cfg.Embedding.GeminiAPIKey == "" && cfg.Embedding.GeminiAPIKeyFile != "" {
+		if key, err := readAPIKeyFromFile(cfg.Embedding.GeminiAPIKeyFile); err == nil && key != "" {
+			cfg.Embedding.GeminiAPIKey = key
+		}
+	}
+	setStringFromEnv(&cfg.Embedding.GeminiBaseURL, "PGEDGE_GEMINI_BASE_URL")
 
 	// LLM
 	setBoolFromEnv(&cfg.LLM.Enabled, "PGEDGE_LLM_ENABLED")
@@ -1029,6 +1049,14 @@ func applyEnvironmentVariables(cfg *Config) {
 	// Base URL overrides for LLM providers (useful for proxies)
 	setStringFromEnv(&cfg.LLM.AnthropicBaseURL, "PGEDGE_ANTHROPIC_BASE_URL")
 	setStringFromEnv(&cfg.LLM.OpenAIBaseURL, "PGEDGE_OPENAI_BASE_URL")
+	// Gemini LLM
+	setStringFromEnvWithFallback(&cfg.LLM.GeminiAPIKey, "PGEDGE_GEMINI_API_KEY", "GEMINI_API_KEY")
+	if cfg.LLM.GeminiAPIKey == "" && cfg.LLM.GeminiAPIKeyFile != "" {
+		if key, err := readAPIKeyFromFile(cfg.LLM.GeminiAPIKeyFile); err == nil && key != "" {
+			cfg.LLM.GeminiAPIKey = key
+		}
+	}
+	setStringFromEnv(&cfg.LLM.GeminiBaseURL, "PGEDGE_GEMINI_BASE_URL")
 	setIntFromEnv(&cfg.LLM.MaxTokens, "PGEDGE_LLM_MAX_TOKENS")
 	// Temperature is a float, but we'll handle it specially
 	if val := os.Getenv("PGEDGE_LLM_TEMPERATURE"); val != "" {
@@ -1066,6 +1094,14 @@ func applyEnvironmentVariables(cfg *Config) {
 	// Base URL overrides for KB embedding providers (useful for proxies)
 	setStringFromEnv(&cfg.Knowledgebase.EmbeddingVoyageBaseURL, "PGEDGE_KB_VOYAGE_BASE_URL")
 	setStringFromEnv(&cfg.Knowledgebase.EmbeddingOpenAIBaseURL, "PGEDGE_KB_OPENAI_BASE_URL")
+	// Gemini KB embedding
+	setStringFromEnvWithFallback(&cfg.Knowledgebase.EmbeddingGeminiAPIKey, "PGEDGE_KB_GEMINI_API_KEY", "GEMINI_API_KEY")
+	if cfg.Knowledgebase.EmbeddingGeminiAPIKey == "" && cfg.Knowledgebase.EmbeddingGeminiAPIKeyFile != "" {
+		if key, err := readAPIKeyFromFile(cfg.Knowledgebase.EmbeddingGeminiAPIKeyFile); err == nil && key != "" {
+			cfg.Knowledgebase.EmbeddingGeminiAPIKey = key
+		}
+	}
+	setStringFromEnv(&cfg.Knowledgebase.EmbeddingGeminiBaseURL, "PGEDGE_KB_GEMINI_BASE_URL")
 
 	// Secret file
 	setStringFromEnv(&cfg.SecretFile, "PGEDGE_SECRET_FILE")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -431,15 +431,15 @@ func (cfg *NamedDatabaseConfig) IsAllowedForLLMSwitching() bool {
 
 // EmbeddingConfig holds embedding generation settings
 type EmbeddingConfig struct {
-	Enabled          bool   `yaml:"enabled"`             // Whether embedding generation is enabled (default: false)
-	Provider         string `yaml:"provider"`            // "voyage", "openai", or "ollama"
-	Model            string `yaml:"model"`               // Provider-specific model name
-	VoyageAPIKey     string `yaml:"voyage_api_key"`      // API key for Voyage AI (direct - discouraged, use api_key_file or env var)
-	VoyageAPIKeyFile string `yaml:"voyage_api_key_file"` // Path to file containing Voyage API key
-	VoyageBaseURL    string `yaml:"voyage_base_url"`     // Base URL for Voyage API (default: https://api.voyageai.com/v1/embeddings)
-	OpenAIAPIKey     string `yaml:"openai_api_key"`      // API key for OpenAI (direct - discouraged, use api_key_file or env var)
-	OpenAIAPIKeyFile string `yaml:"openai_api_key_file"` // Path to file containing OpenAI API key
-	OpenAIBaseURL    string `yaml:"openai_base_url"`     // Base URL for OpenAI API (default: https://api.openai.com/v1)
+	Enabled          bool              `yaml:"enabled"`             // Whether embedding generation is enabled (default: false)
+	Provider         string            `yaml:"provider"`            // "voyage", "openai", or "ollama"
+	Model            string            `yaml:"model"`               // Provider-specific model name
+	VoyageAPIKey     string            `yaml:"voyage_api_key"`      // API key for Voyage AI (direct - discouraged, use api_key_file or env var)
+	VoyageAPIKeyFile string            `yaml:"voyage_api_key_file"` // Path to file containing Voyage API key
+	VoyageBaseURL    string            `yaml:"voyage_base_url"`     // Base URL for Voyage API (default: https://api.voyageai.com/v1/embeddings)
+	OpenAIAPIKey     string            `yaml:"openai_api_key"`      // API key for OpenAI (direct - discouraged, use api_key_file or env var)
+	OpenAIAPIKeyFile string            `yaml:"openai_api_key_file"` // Path to file containing OpenAI API key
+	OpenAIBaseURL    string            `yaml:"openai_base_url"`     // Base URL for OpenAI API (default: https://api.openai.com/v1)
 	OllamaURL        string            `yaml:"ollama_url"`          // URL for Ollama service (default: http://localhost:11434)
 	GeminiAPIKey     string            `yaml:"gemini_api_key"`      // API key for Google Gemini (direct - discouraged, use api_key_file or env var)
 	GeminiAPIKeyFile string            `yaml:"gemini_api_key_file"` // Path to file containing Gemini API key
@@ -449,15 +449,15 @@ type EmbeddingConfig struct {
 
 // LLMConfig holds LLM configuration for web client chat proxy
 type LLMConfig struct {
-	Enabled             bool    `yaml:"enabled"`                // Whether LLM proxy is enabled (default: false)
-	Provider            string  `yaml:"provider"`               // "anthropic", "openai", or "ollama"
-	Model               string  `yaml:"model"`                  // Provider-specific model name
-	AnthropicAPIKey     string  `yaml:"anthropic_api_key"`      // API key for Anthropic (direct - discouraged, use api_key_file or env var instead)
-	AnthropicAPIKeyFile string  `yaml:"anthropic_api_key_file"` // Path to file containing Anthropic API key
-	AnthropicBaseURL    string  `yaml:"anthropic_base_url"`     // Base URL for Anthropic API (default: https://api.anthropic.com)
-	OpenAIAPIKey        string  `yaml:"openai_api_key"`         // API key for OpenAI (direct - discouraged, use api_key_file or env var instead)
-	OpenAIAPIKeyFile    string  `yaml:"openai_api_key_file"`    // Path to file containing OpenAI API key
-	OpenAIBaseURL       string  `yaml:"openai_base_url"`        // Base URL for OpenAI API (default: https://api.openai.com)
+	Enabled             bool              `yaml:"enabled"`                // Whether LLM proxy is enabled (default: false)
+	Provider            string            `yaml:"provider"`               // "anthropic", "openai", or "ollama"
+	Model               string            `yaml:"model"`                  // Provider-specific model name
+	AnthropicAPIKey     string            `yaml:"anthropic_api_key"`      // API key for Anthropic (direct - discouraged, use api_key_file or env var instead)
+	AnthropicAPIKeyFile string            `yaml:"anthropic_api_key_file"` // Path to file containing Anthropic API key
+	AnthropicBaseURL    string            `yaml:"anthropic_base_url"`     // Base URL for Anthropic API (default: https://api.anthropic.com)
+	OpenAIAPIKey        string            `yaml:"openai_api_key"`         // API key for OpenAI (direct - discouraged, use api_key_file or env var instead)
+	OpenAIAPIKeyFile    string            `yaml:"openai_api_key_file"`    // Path to file containing OpenAI API key
+	OpenAIBaseURL       string            `yaml:"openai_base_url"`        // Base URL for OpenAI API (default: https://api.openai.com)
 	OllamaURL           string            `yaml:"ollama_url"`             // URL for Ollama service (default: http://localhost:11434)
 	GeminiAPIKey        string            `yaml:"gemini_api_key"`         // API key for Google Gemini (direct - discouraged, use api_key_file or env var)
 	GeminiAPIKeyFile    string            `yaml:"gemini_api_key_file"`    // Path to file containing Gemini API key
@@ -473,14 +473,14 @@ type KnowledgebaseConfig struct {
 	DatabasePath string `yaml:"database_path"` // Path to SQLite knowledgebase database
 
 	// Embedding provider configuration for KB similarity search (independent of generate_embeddings tool)
-	EmbeddingProvider         string `yaml:"embedding_provider"`            // "voyage", "openai", or "ollama"
-	EmbeddingModel            string `yaml:"embedding_model"`               // Provider-specific model name
-	EmbeddingVoyageAPIKey     string `yaml:"embedding_voyage_api_key"`      // API key for Voyage AI
-	EmbeddingVoyageAPIKeyFile string `yaml:"embedding_voyage_api_key_file"` // Path to file containing Voyage API key
-	EmbeddingVoyageBaseURL    string `yaml:"embedding_voyage_base_url"`     // Base URL for Voyage API (default: https://api.voyageai.com/v1/embeddings)
-	EmbeddingOpenAIAPIKey     string `yaml:"embedding_openai_api_key"`      // API key for OpenAI
-	EmbeddingOpenAIAPIKeyFile string `yaml:"embedding_openai_api_key_file"` // Path to file containing OpenAI API key
-	EmbeddingOpenAIBaseURL    string `yaml:"embedding_openai_base_url"`     // Base URL for OpenAI API (default: https://api.openai.com/v1)
+	EmbeddingProvider         string            `yaml:"embedding_provider"`            // "voyage", "openai", or "ollama"
+	EmbeddingModel            string            `yaml:"embedding_model"`               // Provider-specific model name
+	EmbeddingVoyageAPIKey     string            `yaml:"embedding_voyage_api_key"`      // API key for Voyage AI
+	EmbeddingVoyageAPIKeyFile string            `yaml:"embedding_voyage_api_key_file"` // Path to file containing Voyage API key
+	EmbeddingVoyageBaseURL    string            `yaml:"embedding_voyage_base_url"`     // Base URL for Voyage API (default: https://api.voyageai.com/v1/embeddings)
+	EmbeddingOpenAIAPIKey     string            `yaml:"embedding_openai_api_key"`      // API key for OpenAI
+	EmbeddingOpenAIAPIKeyFile string            `yaml:"embedding_openai_api_key_file"` // Path to file containing OpenAI API key
+	EmbeddingOpenAIBaseURL    string            `yaml:"embedding_openai_base_url"`     // Base URL for OpenAI API (default: https://api.openai.com/v1)
 	EmbeddingOllamaURL        string            `yaml:"embedding_ollama_url"`          // URL for Ollama service (default: http://localhost:11434)
 	EmbeddingGeminiAPIKey     string            `yaml:"embedding_gemini_api_key"`      // API key for Google Gemini
 	EmbeddingGeminiAPIKeyFile string            `yaml:"embedding_gemini_api_key_file"` // Path to file containing Gemini API key

--- a/internal/embedding/gemini.go
+++ b/internal/embedding/gemini.go
@@ -66,7 +66,7 @@ var geminiModelDimensions = map[string]int{
 // baseURL can be empty to use the default (https://generativelanguage.googleapis.com)
 func NewGeminiProvider(apiKey, model, baseURL string, customHeaders map[string]string) (*GeminiProvider, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("Gemini API key cannot be empty")
+		return nil, fmt.Errorf("gemini API key cannot be empty")
 	}
 	if model == "" {
 		model = "text-embedding-004"
@@ -143,7 +143,7 @@ func (p *GeminiProvider) Embed(ctx context.Context, text string) ([]float64, err
 		body, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			duration := time.Since(startTime)
-			err := fmt.Errorf("API request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
+			err := fmt.Errorf("api request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
 			LogAPICall("gemini", p.model, textLen, duration, 0, err)
 			return nil, err
 		}
@@ -154,7 +154,7 @@ func (p *GeminiProvider) Embed(ctx context.Context, text string) ([]float64, err
 		}
 
 		duration := time.Since(startTime)
-		err := fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+		err := fmt.Errorf("api request failed with status %d: %s", resp.StatusCode, string(body))
 		LogAPICall("gemini", p.model, textLen, duration, 0, err)
 		return nil, err
 	}

--- a/internal/embedding/gemini.go
+++ b/internal/embedding/gemini.go
@@ -1,0 +1,200 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	// GeminiHTTPTimeout is the HTTP client timeout for Gemini API requests
+	GeminiHTTPTimeout = 30 * time.Second
+)
+
+// GeminiProvider implements embedding generation using Google's Gemini API
+type GeminiProvider struct {
+	apiKey        string
+	model         string
+	baseURL       string
+	customHeaders map[string]string
+	client        *http.Client
+}
+
+// geminiEmbedRequest represents a request to Gemini's embedding API
+type geminiEmbedRequest struct {
+	Model   string             `json:"model"`
+	Content geminiEmbedContent `json:"content"`
+}
+
+// geminiEmbedContent represents the content field of a Gemini embed request
+type geminiEmbedContent struct {
+	Parts []geminiEmbedPart `json:"parts"`
+}
+
+// geminiEmbedPart represents a single text part in a Gemini embed request
+type geminiEmbedPart struct {
+	Text string `json:"text"`
+}
+
+// geminiEmbedResponse represents a response from Gemini's embedding API
+type geminiEmbedResponse struct {
+	Embedding struct {
+		Values []float64 `json:"values"`
+	} `json:"embedding"`
+}
+
+// Model dimensions for Gemini embedding models
+var geminiModelDimensions = map[string]int{
+	"text-embedding-004": 768,
+}
+
+// NewGeminiProvider creates a new Gemini embedding provider
+// baseURL can be empty to use the default (https://generativelanguage.googleapis.com)
+func NewGeminiProvider(apiKey, model, baseURL string, customHeaders map[string]string) (*GeminiProvider, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("Gemini API key cannot be empty")
+	}
+	if model == "" {
+		model = "text-embedding-004"
+	}
+	if baseURL == "" {
+		baseURL = "https://generativelanguage.googleapis.com"
+	}
+
+	// Mask the API key for logging (show only first/last few characters)
+	maskedKey := "(redacted)"
+	if len(apiKey) > 8 {
+		maskedKey = apiKey[:4] + "..." + apiKey[len(apiKey)-4:]
+	}
+
+	LogProviderInit("gemini", model, map[string]string{
+		"api_key":  maskedKey,
+		"base_url": baseURL,
+	})
+
+	return &GeminiProvider{
+		apiKey:        apiKey,
+		model:         model,
+		baseURL:       baseURL,
+		customHeaders: customHeaders,
+		client:        &http.Client{Timeout: GeminiHTTPTimeout},
+	}, nil
+}
+
+// Embed generates an embedding vector for the given text
+func (p *GeminiProvider) Embed(ctx context.Context, text string) ([]float64, error) {
+	startTime := time.Now()
+	textLen := len(text)
+
+	if text == "" {
+		return nil, fmt.Errorf("text cannot be empty")
+	}
+
+	apiURL := fmt.Sprintf("%s/v1beta/models/%s:embedContent?key=%s", p.baseURL, p.model, p.apiKey)
+	logURL := fmt.Sprintf("%s/v1beta/models/%s:embedContent", p.baseURL, p.model)
+	LogAPICallDetails("gemini", p.model, logURL, textLen)
+	LogRequestTrace("gemini", p.model, text)
+
+	reqBody := geminiEmbedRequest{
+		Model: "models/" + p.model,
+		Content: geminiEmbedContent{
+			Parts: []geminiEmbedPart{{Text: text}},
+		},
+	}
+
+	reqBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(reqBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range p.customHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		LogConnectionError("gemini", logURL, err)
+		duration := time.Since(startTime)
+		LogAPICall("gemini", p.model, textLen, duration, 0, err)
+		return nil, fmt.Errorf("failed to make API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			duration := time.Since(startTime)
+			err := fmt.Errorf("API request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
+			LogAPICall("gemini", p.model, textLen, duration, 0, err)
+			return nil, err
+		}
+
+		// Check if this is a rate limit error
+		if resp.StatusCode == 429 {
+			LogRateLimitError("gemini", p.model, resp.StatusCode, string(body))
+		}
+
+		duration := time.Since(startTime)
+		err := fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+		LogAPICall("gemini", p.model, textLen, duration, 0, err)
+		return nil, err
+	}
+
+	var embResp geminiEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embResp); err != nil {
+		duration := time.Since(startTime)
+		LogAPICall("gemini", p.model, textLen, duration, 0, err)
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if len(embResp.Embedding.Values) == 0 {
+		duration := time.Since(startTime)
+		err := fmt.Errorf("received empty embedding from API")
+		LogAPICall("gemini", p.model, textLen, duration, 0, err)
+		return nil, err
+	}
+
+	duration := time.Since(startTime)
+	dimensions := len(embResp.Embedding.Values)
+	LogResponseTrace("gemini", p.model, resp.StatusCode, dimensions)
+	LogAPICall("gemini", p.model, textLen, duration, dimensions, nil)
+
+	return embResp.Embedding.Values, nil
+}
+
+// Dimensions returns the number of dimensions for this model
+func (p *GeminiProvider) Dimensions() int {
+	if dims, ok := geminiModelDimensions[p.model]; ok {
+		return dims
+	}
+	return 768
+}
+
+// ModelName returns the model name
+func (p *GeminiProvider) ModelName() string {
+	return p.model
+}
+
+// ProviderName returns "gemini"
+func (p *GeminiProvider) ProviderName() string {
+	return "gemini"
+}

--- a/internal/embedding/ollama.go
+++ b/internal/embedding/ollama.go
@@ -132,7 +132,7 @@ func (p *OllamaProvider) Embed(ctx context.Context, text string) ([]float64, err
 		body, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			duration := time.Since(startTime)
-			err := fmt.Errorf("Ollama API request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
+			err := fmt.Errorf("ollama API request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
 			LogAPICall("ollama", p.model, textLen, duration, 0, err)
 			return nil, err
 		}
@@ -143,7 +143,7 @@ func (p *OllamaProvider) Embed(ctx context.Context, text string) ([]float64, err
 		}
 
 		duration := time.Since(startTime)
-		err := fmt.Errorf("Ollama API request failed with status %d: %s", resp.StatusCode, string(body))
+		err := fmt.Errorf("ollama API request failed with status %d: %s", resp.StatusCode, string(body))
 		LogAPICall("ollama", p.model, textLen, duration, 0, err)
 		return nil, err
 	}

--- a/internal/embedding/ollama.go
+++ b/internal/embedding/ollama.go
@@ -29,9 +29,10 @@ const (
 
 // OllamaProvider implements embedding generation using Ollama
 type OllamaProvider struct {
-	baseURL string
-	model   string
-	client  *http.Client
+	baseURL       string
+	model         string
+	customHeaders map[string]string
+	client        *http.Client
 }
 
 // ollamaEmbeddingRequest represents a request to Ollama's embeddings API
@@ -59,7 +60,7 @@ var ollamaModelDimensions = map[string]int{
 var ollamaModelDimensionsMu sync.RWMutex
 
 // NewOllamaProvider creates a new Ollama embedding provider
-func NewOllamaProvider(baseURL, model string) (*OllamaProvider, error) {
+func NewOllamaProvider(baseURL, model string, customHeaders map[string]string) (*OllamaProvider, error) {
 	if baseURL == "" {
 		baseURL = "http://localhost:11434"
 	}
@@ -76,8 +77,9 @@ func NewOllamaProvider(baseURL, model string) (*OllamaProvider, error) {
 	})
 
 	return &OllamaProvider{
-		baseURL: baseURL,
-		model:   model,
+		baseURL:       baseURL,
+		model:         model,
+		customHeaders: customHeaders,
 		client: &http.Client{
 			Timeout: OllamaHTTPTimeout,
 		},
@@ -113,6 +115,9 @@ func (p *OllamaProvider) Embed(ctx context.Context, text string) ([]float64, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	for k, v := range p.customHeaders {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/internal/embedding/ollama_test.go
+++ b/internal/embedding/ollama_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestNewOllamaProvider(t *testing.T) {
 	t.Run("valid config", func(t *testing.T) {
-		provider, err := NewOllamaProvider("http://localhost:11434", "nomic-embed-text")
+		provider, err := NewOllamaProvider("http://localhost:11434", "nomic-embed-text", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -30,7 +30,7 @@ func TestNewOllamaProvider(t *testing.T) {
 	})
 
 	t.Run("default URL", func(t *testing.T) {
-		provider, err := NewOllamaProvider("", "nomic-embed-text")
+		provider, err := NewOllamaProvider("", "nomic-embed-text", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -40,7 +40,7 @@ func TestNewOllamaProvider(t *testing.T) {
 	})
 
 	t.Run("default model", func(t *testing.T) {
-		provider, err := NewOllamaProvider("http://localhost:11434", "")
+		provider, err := NewOllamaProvider("http://localhost:11434", "", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -51,7 +51,7 @@ func TestNewOllamaProvider(t *testing.T) {
 }
 
 func TestOllamaProvider_Methods(t *testing.T) {
-	provider, err := NewOllamaProvider("http://localhost:11434", "nomic-embed-text")
+	provider, err := NewOllamaProvider("http://localhost:11434", "nomic-embed-text", nil)
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestOllamaProvider_Dimensions_KnownModels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
-			provider, err := NewOllamaProvider("http://localhost:11434", tt.model)
+			provider, err := NewOllamaProvider("http://localhost:11434", tt.model, nil)
 			if err != nil {
 				t.Fatalf("failed to create provider: %v", err)
 			}
@@ -102,7 +102,7 @@ func TestOllamaProvider_Dimensions_KnownModels(t *testing.T) {
 }
 
 func TestOllamaProvider_Dimensions_UnknownModel(t *testing.T) {
-	provider, err := NewOllamaProvider("http://localhost:11434", "custom-model")
+	provider, err := NewOllamaProvider("http://localhost:11434", "custom-model", nil)
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestOllamaProvider_Dimensions_UnknownModel(t *testing.T) {
 }
 
 func TestOllamaProvider_Embed_EmptyText(t *testing.T) {
-	provider, err := NewOllamaProvider("http://localhost:11434", "nomic-embed-text")
+	provider, err := NewOllamaProvider("http://localhost:11434", "nomic-embed-text", nil)
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}

--- a/internal/embedding/openai.go
+++ b/internal/embedding/openai.go
@@ -91,10 +91,10 @@ func NewOpenAIProvider(apiKey, model, baseURL string, customHeaders map[string]s
 			return nil, fmt.Errorf("invalid OpenAI base URL: %w", err)
 		}
 		if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
-			return nil, fmt.Errorf("OpenAI base URL must use http or https scheme, got: %s", parsedURL.Scheme)
+			return nil, fmt.Errorf("openAI base URL must use http or https scheme, got: %s", parsedURL.Scheme)
 		}
 		if parsedURL.Host == "" {
-			return nil, fmt.Errorf("OpenAI base URL must include a host")
+			return nil, fmt.Errorf("openAI base URL must include a host")
 		}
 	}
 
@@ -176,7 +176,7 @@ func (p *OpenAIProvider) Embed(ctx context.Context, text string) ([]float64, err
 		body, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			duration := time.Since(startTime)
-			err := fmt.Errorf("API request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
+			err := fmt.Errorf("api request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
 			LogAPICall("openai", p.model, textLen, duration, 0, err)
 			return nil, err
 		}
@@ -187,7 +187,7 @@ func (p *OpenAIProvider) Embed(ctx context.Context, text string) ([]float64, err
 		}
 
 		duration := time.Since(startTime)
-		err := fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+		err := fmt.Errorf("api request failed with status %d: %s", resp.StatusCode, string(body))
 		LogAPICall("openai", p.model, textLen, duration, 0, err)
 		return nil, err
 	}

--- a/internal/embedding/openai.go
+++ b/internal/embedding/openai.go
@@ -29,10 +29,11 @@ const (
 
 // OpenAIProvider implements embedding generation using OpenAI's API
 type OpenAIProvider struct {
-	apiKey  string
-	model   string
-	baseURL string
-	client  *http.Client
+	apiKey        string
+	model         string
+	baseURL       string
+	customHeaders map[string]string
+	client        *http.Client
 }
 
 // openaiEmbeddingRequest represents a request to OpenAI's embeddings API
@@ -65,11 +66,8 @@ var openaiModelDimensions = map[string]int{
 
 // NewOpenAIProvider creates a new OpenAI embedding provider
 // baseURL can be empty to use the default (https://api.openai.com/v1)
-func NewOpenAIProvider(apiKey, model, baseURL string) (*OpenAIProvider, error) {
-	if apiKey == "" {
-		return nil, fmt.Errorf("OpenAI API key cannot be empty")
-	}
-
+// apiKey is optional when using a custom baseURL for local models
+func NewOpenAIProvider(apiKey, model, baseURL string, customHeaders map[string]string) (*OpenAIProvider, error) {
 	// Default to text-embedding-3-small if no model specified
 	if model == "" {
 		model = "text-embedding-3-small"
@@ -101,20 +99,28 @@ func NewOpenAIProvider(apiKey, model, baseURL string) (*OpenAIProvider, error) {
 	}
 
 	// Mask the API key for logging (show only first/last few characters)
-	maskedKey := "(redacted)"
-	if len(apiKey) > 8 {
-		maskedKey = apiKey[:4] + "..." + apiKey[len(apiKey)-4:]
+	if apiKey != "" {
+		maskedKey := "(redacted)"
+		if len(apiKey) > 8 {
+			maskedKey = apiKey[:4] + "..." + apiKey[len(apiKey)-4:]
+		}
+
+		LogProviderInit("openai", model, map[string]string{
+			"api_key":  maskedKey,
+			"base_url": baseURL,
+		})
+	} else {
+		LogProviderInit("openai", model, map[string]string{
+			"api_key":  "(none)",
+			"base_url": baseURL,
+		})
 	}
 
-	LogProviderInit("openai", model, map[string]string{
-		"api_key":  maskedKey,
-		"base_url": baseURL,
-	})
-
 	return &OpenAIProvider{
-		apiKey:  apiKey,
-		model:   model,
-		baseURL: baseURL,
+		apiKey:        apiKey,
+		model:         model,
+		baseURL:       baseURL,
+		customHeaders: customHeaders,
 		client: &http.Client{
 			Timeout: OpenAIHTTPTimeout,
 		},
@@ -150,7 +156,12 @@ func (p *OpenAIProvider) Embed(ctx context.Context, text string) ([]float64, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	if p.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
+	for k, v := range p.customHeaders {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/internal/embedding/openai_test.go
+++ b/internal/embedding/openai_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestNewOpenAIProvider(t *testing.T) {
 	t.Run("valid config", func(t *testing.T) {
-		provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "")
+		provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -29,18 +29,19 @@ func TestNewOpenAIProvider(t *testing.T) {
 		}
 	})
 
-	t.Run("empty API key", func(t *testing.T) {
-		_, err := NewOpenAIProvider("", "text-embedding-3-small", "")
-		if err == nil {
-			t.Fatal("expected error for empty API key")
+	t.Run("empty API key with default base URL", func(t *testing.T) {
+		// API key is optional in NewOpenAIProvider; validation happens in NewProvider
+		provider, err := NewOpenAIProvider("", "text-embedding-3-small", "", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
-		if err.Error() != "OpenAI API key cannot be empty" {
-			t.Errorf("unexpected error: %v", err)
+		if provider == nil {
+			t.Fatal("expected non-nil provider")
 		}
 	})
 
 	t.Run("default model", func(t *testing.T) {
-		provider, err := NewOpenAIProvider("sk-test-key-12345678", "", "")
+		provider, err := NewOpenAIProvider("sk-test-key-12345678", "", "", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -50,14 +51,14 @@ func TestNewOpenAIProvider(t *testing.T) {
 	})
 
 	t.Run("unsupported model", func(t *testing.T) {
-		_, err := NewOpenAIProvider("sk-test-key-12345678", "unsupported-model", "")
+		_, err := NewOpenAIProvider("sk-test-key-12345678", "unsupported-model", "", nil)
 		if err == nil {
 			t.Fatal("expected error for unsupported model")
 		}
 	})
 
 	t.Run("custom base URL", func(t *testing.T) {
-		provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "https://proxy.example.com/v1")
+		provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "https://proxy.example.com/v1", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -67,7 +68,7 @@ func TestNewOpenAIProvider(t *testing.T) {
 	})
 
 	t.Run("default base URL when empty", func(t *testing.T) {
-		provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "")
+		provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -77,7 +78,7 @@ func TestNewOpenAIProvider(t *testing.T) {
 	})
 
 	t.Run("base URL with trailing slash normalized", func(t *testing.T) {
-		provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "https://proxy.example.com/v1/")
+		provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "https://proxy.example.com/v1/", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -87,21 +88,21 @@ func TestNewOpenAIProvider(t *testing.T) {
 	})
 
 	t.Run("invalid base URL scheme", func(t *testing.T) {
-		_, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "ftp://proxy.example.com")
+		_, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "ftp://proxy.example.com", nil)
 		if err == nil {
 			t.Fatal("expected error for invalid URL scheme")
 		}
 	})
 
 	t.Run("invalid base URL format", func(t *testing.T) {
-		_, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "://invalid")
+		_, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "://invalid", nil)
 		if err == nil {
 			t.Fatal("expected error for invalid URL format")
 		}
 	})
 
 	t.Run("base URL without host", func(t *testing.T) {
-		_, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "https://")
+		_, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "https://", nil)
 		if err == nil {
 			t.Fatal("expected error for URL without host")
 		}
@@ -109,7 +110,7 @@ func TestNewOpenAIProvider(t *testing.T) {
 }
 
 func TestOpenAIProvider_Methods(t *testing.T) {
-	provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-large", "")
+	provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-large", "", nil)
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}
@@ -148,7 +149,7 @@ func TestOpenAIProvider_Dimensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
-			provider, err := NewOpenAIProvider("sk-test-key", tt.model, "")
+			provider, err := NewOpenAIProvider("sk-test-key", tt.model, "", nil)
 			if err != nil {
 				t.Fatalf("failed to create provider: %v", err)
 			}
@@ -160,7 +161,7 @@ func TestOpenAIProvider_Dimensions(t *testing.T) {
 }
 
 func TestOpenAIProvider_Embed_EmptyText(t *testing.T) {
-	provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "")
+	provider, err := NewOpenAIProvider("sk-test-key-12345678", "text-embedding-3-small", "", nil)
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -59,13 +59,13 @@ func NewProvider(cfg Config) (Provider, error) {
 	switch cfg.Provider {
 	case "voyage":
 		if cfg.VoyageAPIKey == "" {
-			return nil, fmt.Errorf("Voyage AI API key is required when provider is 'voyage'")
+			return nil, fmt.Errorf("voyage AI API key is required when provider is 'voyage'")
 		}
 		return NewVoyageProvider(cfg.VoyageAPIKey, cfg.Model, cfg.VoyageBaseURL, cfg.CustomHeaders)
 
 	case "openai":
 		if cfg.OpenAIAPIKey == "" && cfg.OpenAIBaseURL == "" {
-			return nil, fmt.Errorf("OpenAI API key is required when provider is 'openai' (unless using a custom base URL for local models)")
+			return nil, fmt.Errorf("openAI API key is required when provider is 'openai' (unless using a custom base URL for local models)")
 		}
 		return NewOpenAIProvider(cfg.OpenAIAPIKey, cfg.Model, cfg.OpenAIBaseURL, cfg.CustomHeaders)
 
@@ -80,7 +80,7 @@ func NewProvider(cfg Config) (Provider, error) {
 
 	case "gemini":
 		if cfg.GeminiAPIKey == "" {
-			return nil, fmt.Errorf("Gemini API key is required when provider is 'gemini'")
+			return nil, fmt.Errorf("gemini API key is required when provider is 'gemini'")
 		}
 		return NewGeminiProvider(cfg.GeminiAPIKey, cfg.Model, cfg.GeminiBaseURL, cfg.CustomHeaders)
 

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -32,7 +32,7 @@ type Provider interface {
 
 // Config holds configuration for embedding providers
 type Config struct {
-	Provider string // "voyage", "ollama", or "openai"
+	Provider string // "voyage", "ollama", "openai", or "gemini"
 	Model    string // Model name (provider-specific)
 
 	// Voyage AI-specific
@@ -45,6 +45,13 @@ type Config struct {
 
 	// Ollama-specific
 	OllamaURL string
+
+	// Gemini-specific
+	GeminiAPIKey  string
+	GeminiBaseURL string // Base URL for Gemini API (optional, uses default if empty)
+
+	// Custom HTTP headers applied to all provider API requests
+	CustomHeaders map[string]string
 }
 
 // NewProvider creates a new embedding provider based on configuration
@@ -54,13 +61,13 @@ func NewProvider(cfg Config) (Provider, error) {
 		if cfg.VoyageAPIKey == "" {
 			return nil, fmt.Errorf("Voyage AI API key is required when provider is 'voyage'")
 		}
-		return NewVoyageProvider(cfg.VoyageAPIKey, cfg.Model, cfg.VoyageBaseURL)
+		return NewVoyageProvider(cfg.VoyageAPIKey, cfg.Model, cfg.VoyageBaseURL, cfg.CustomHeaders)
 
 	case "openai":
-		if cfg.OpenAIAPIKey == "" {
-			return nil, fmt.Errorf("OpenAI API key is required when provider is 'openai'")
+		if cfg.OpenAIAPIKey == "" && cfg.OpenAIBaseURL == "" {
+			return nil, fmt.Errorf("OpenAI API key is required when provider is 'openai' (unless using a custom base URL for local models)")
 		}
-		return NewOpenAIProvider(cfg.OpenAIAPIKey, cfg.Model, cfg.OpenAIBaseURL)
+		return NewOpenAIProvider(cfg.OpenAIAPIKey, cfg.Model, cfg.OpenAIBaseURL, cfg.CustomHeaders)
 
 	case "ollama":
 		if cfg.OllamaURL == "" {
@@ -69,9 +76,15 @@ func NewProvider(cfg Config) (Provider, error) {
 		if cfg.Model == "" {
 			cfg.Model = "nomic-embed-text" // Default model
 		}
-		return NewOllamaProvider(cfg.OllamaURL, cfg.Model)
+		return NewOllamaProvider(cfg.OllamaURL, cfg.Model, cfg.CustomHeaders)
+
+	case "gemini":
+		if cfg.GeminiAPIKey == "" {
+			return nil, fmt.Errorf("Gemini API key is required when provider is 'gemini'")
+		}
+		return NewGeminiProvider(cfg.GeminiAPIKey, cfg.Model, cfg.GeminiBaseURL, cfg.CustomHeaders)
 
 	default:
-		return nil, fmt.Errorf("unsupported embedding provider: %s (supported: voyage, openai, ollama)", cfg.Provider)
+		return nil, fmt.Errorf("unsupported embedding provider: %s (supported: voyage, openai, ollama, gemini)", cfg.Provider)
 	}
 }

--- a/internal/embedding/provider_test.go
+++ b/internal/embedding/provider_test.go
@@ -128,7 +128,7 @@ func TestNewProvider_Unsupported(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported provider")
 	}
-	if err.Error() != "unsupported embedding provider: unsupported (supported: voyage, openai, ollama)" {
+	if err.Error() != "unsupported embedding provider: unsupported (supported: voyage, openai, ollama, gemini)" {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -69,7 +69,7 @@ var voyageModelDimensions = map[string]int{
 // host. The URL is used directly without appending any path.
 func NewVoyageProvider(apiKey, model, baseURL string, customHeaders map[string]string) (*VoyageProvider, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("Voyage AI API key cannot be empty")
+		return nil, fmt.Errorf("voyage AI API key cannot be empty")
 	}
 
 	// Default to voyage-3-lite if no model specified
@@ -95,10 +95,10 @@ func NewVoyageProvider(apiKey, model, baseURL string, customHeaders map[string]s
 			return nil, fmt.Errorf("invalid Voyage AI base URL: %w", err)
 		}
 		if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
-			return nil, fmt.Errorf("Voyage AI base URL must use http or https scheme, got: %s", parsedURL.Scheme)
+			return nil, fmt.Errorf("voyage AI base URL must use http or https scheme, got: %s", parsedURL.Scheme)
 		}
 		if parsedURL.Host == "" {
-			return nil, fmt.Errorf("Voyage AI base URL must include a host")
+			return nil, fmt.Errorf("voyage AI base URL must include a host")
 		}
 	}
 
@@ -171,7 +171,7 @@ func (p *VoyageProvider) Embed(ctx context.Context, text string) ([]float64, err
 		body, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			duration := time.Since(startTime)
-			err := fmt.Errorf("API request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
+			err := fmt.Errorf("api request failed with status %d (error reading response body: %w)", resp.StatusCode, readErr)
 			LogAPICall("voyage", p.model, textLen, duration, 0, err)
 			return nil, err
 		}
@@ -182,7 +182,7 @@ func (p *VoyageProvider) Embed(ctx context.Context, text string) ([]float64, err
 		}
 
 		duration := time.Since(startTime)
-		err := fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+		err := fmt.Errorf("api request failed with status %d: %s", resp.StatusCode, string(body))
 		LogAPICall("voyage", p.model, textLen, duration, 0, err)
 		return nil, err
 	}

--- a/internal/embedding/voyage.go
+++ b/internal/embedding/voyage.go
@@ -29,10 +29,11 @@ const (
 
 // VoyageProvider implements embedding generation using Voyage AI's API
 type VoyageProvider struct {
-	apiKey  string
-	model   string
-	baseURL string
-	client  *http.Client
+	apiKey        string
+	model         string
+	baseURL       string
+	customHeaders map[string]string
+	client        *http.Client
 }
 
 // voyageEmbeddingRequest represents a request to Voyage AI's embeddings API
@@ -66,7 +67,7 @@ var voyageModelDimensions = map[string]int{
 // NOTE: Unlike some other providers, custom baseURL values must include the full
 // API path (e.g., "https://proxy.example.com/v1/embeddings"), not just the base
 // host. The URL is used directly without appending any path.
-func NewVoyageProvider(apiKey, model, baseURL string) (*VoyageProvider, error) {
+func NewVoyageProvider(apiKey, model, baseURL string, customHeaders map[string]string) (*VoyageProvider, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("Voyage AI API key cannot be empty")
 	}
@@ -113,9 +114,10 @@ func NewVoyageProvider(apiKey, model, baseURL string) (*VoyageProvider, error) {
 	})
 
 	return &VoyageProvider{
-		apiKey:  apiKey,
-		model:   model,
-		baseURL: baseURL,
+		apiKey:        apiKey,
+		model:         model,
+		baseURL:       baseURL,
+		customHeaders: customHeaders,
 		client: &http.Client{
 			Timeout: VoyageHTTPTimeout,
 		},
@@ -152,6 +154,9 @@ func (p *VoyageProvider) Embed(ctx context.Context, text string) ([]float64, err
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	for k, v := range p.customHeaders {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestNewVoyageProvider(t *testing.T) {
 	t.Run("valid config", func(t *testing.T) {
-		provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "")
+		provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -30,7 +30,7 @@ func TestNewVoyageProvider(t *testing.T) {
 	})
 
 	t.Run("empty API key", func(t *testing.T) {
-		_, err := NewVoyageProvider("", "voyage-3-lite", "")
+		_, err := NewVoyageProvider("", "voyage-3-lite", "", nil)
 		if err == nil {
 			t.Fatal("expected error for empty API key")
 		}
@@ -40,7 +40,7 @@ func TestNewVoyageProvider(t *testing.T) {
 	})
 
 	t.Run("default model", func(t *testing.T) {
-		provider, err := NewVoyageProvider("pa-test-key-12345678", "", "")
+		provider, err := NewVoyageProvider("pa-test-key-12345678", "", "", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -50,14 +50,14 @@ func TestNewVoyageProvider(t *testing.T) {
 	})
 
 	t.Run("unsupported model", func(t *testing.T) {
-		_, err := NewVoyageProvider("pa-test-key-12345678", "unsupported-model", "")
+		_, err := NewVoyageProvider("pa-test-key-12345678", "unsupported-model", "", nil)
 		if err == nil {
 			t.Fatal("expected error for unsupported model")
 		}
 	})
 
 	t.Run("custom base URL", func(t *testing.T) {
-		provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "https://proxy.example.com/v1/embeddings")
+		provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "https://proxy.example.com/v1/embeddings", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -67,7 +67,7 @@ func TestNewVoyageProvider(t *testing.T) {
 	})
 
 	t.Run("default base URL when empty", func(t *testing.T) {
-		provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "")
+		provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -77,7 +77,7 @@ func TestNewVoyageProvider(t *testing.T) {
 	})
 
 	t.Run("base URL with trailing slash normalized", func(t *testing.T) {
-		provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "https://proxy.example.com/v1/embeddings/")
+		provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "https://proxy.example.com/v1/embeddings/", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -87,21 +87,21 @@ func TestNewVoyageProvider(t *testing.T) {
 	})
 
 	t.Run("invalid base URL scheme", func(t *testing.T) {
-		_, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "ftp://proxy.example.com")
+		_, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "ftp://proxy.example.com", nil)
 		if err == nil {
 			t.Fatal("expected error for invalid URL scheme")
 		}
 	})
 
 	t.Run("invalid base URL format", func(t *testing.T) {
-		_, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "://invalid")
+		_, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "://invalid", nil)
 		if err == nil {
 			t.Fatal("expected error for invalid URL format")
 		}
 	})
 
 	t.Run("base URL without host", func(t *testing.T) {
-		_, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "https://")
+		_, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "https://", nil)
 		if err == nil {
 			t.Fatal("expected error for URL without host")
 		}
@@ -109,7 +109,7 @@ func TestNewVoyageProvider(t *testing.T) {
 }
 
 func TestVoyageProvider_Methods(t *testing.T) {
-	provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3", "")
+	provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3", "", nil)
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestVoyageProvider_Dimensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
-			provider, err := NewVoyageProvider("pa-test-key", tt.model, "")
+			provider, err := NewVoyageProvider("pa-test-key", tt.model, "", nil)
 			if err != nil {
 				t.Fatalf("failed to create provider: %v", err)
 			}
@@ -161,7 +161,7 @@ func TestVoyageProvider_Dimensions(t *testing.T) {
 }
 
 func TestVoyageProvider_Embed_EmptyText(t *testing.T) {
-	provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "")
+	provider, err := NewVoyageProvider("pa-test-key-12345678", "voyage-3-lite", "", nil)
 	if err != nil {
 		t.Fatalf("failed to create provider: %v", err)
 	}

--- a/internal/embedding/voyage_test.go
+++ b/internal/embedding/voyage_test.go
@@ -34,7 +34,7 @@ func TestNewVoyageProvider(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for empty API key")
 		}
-		if err.Error() != "Voyage AI API key cannot be empty" {
+		if err.Error() != "voyage AI API key cannot be empty" {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})

--- a/internal/kbchunker/elements.go
+++ b/internal/kbchunker/elements.go
@@ -327,12 +327,13 @@ func parseParagraph(lines []string, i int) (StructuralElement, int) {
 func getIndentation(line string) int {
 	count := 0
 	for _, r := range line {
-		if r == ' ' {
+		switch r {
+		case ' ':
 			count++
-		} else if r == '\t' {
+		case '\t':
 			count += 4 // Treat tab as 4 spaces
-		} else {
-			break
+		default:
+			return count
 		}
 	}
 	return count

--- a/internal/kbconfig/config.go
+++ b/internal/kbconfig/config.go
@@ -258,7 +258,7 @@ func loadAPIKeys(config *Config) error {
 	if config.Embeddings.OpenAI.Enabled {
 		key, err := readAPIKey(config.Embeddings.OpenAI.APIKeyFile)
 		if err != nil {
-			return fmt.Errorf("OpenAI API key: %w", err)
+			return fmt.Errorf("openAI API key: %w", err)
 		}
 		config.Embeddings.OpenAI.APIKey = key
 	}
@@ -266,7 +266,7 @@ func loadAPIKeys(config *Config) error {
 	if config.Embeddings.Voyage.Enabled {
 		key, err := readAPIKey(config.Embeddings.Voyage.APIKeyFile)
 		if err != nil {
-			return fmt.Errorf("Voyage API key: %w", err)
+			return fmt.Errorf("voyage API key: %w", err)
 		}
 		config.Embeddings.Voyage.APIKey = key
 	}
@@ -274,7 +274,7 @@ func loadAPIKeys(config *Config) error {
 	if config.Embeddings.Gemini.Enabled {
 		key, err := readAPIKey(config.Embeddings.Gemini.APIKeyFile)
 		if err != nil {
-			return fmt.Errorf("Gemini API key: %w", err)
+			return fmt.Errorf("gemini API key: %w", err)
 		}
 		config.Embeddings.Gemini.APIKey = key
 	}
@@ -291,7 +291,7 @@ func readAPIKey(path string) (string, error) {
 
 	key := strings.TrimSpace(string(data))
 	if key == "" {
-		return "", fmt.Errorf("API key file %s is empty", path)
+		return "", fmt.Errorf("api key file %s is empty", path)
 	}
 
 	return key, nil

--- a/internal/kbconfig/config.go
+++ b/internal/kbconfig/config.go
@@ -55,6 +55,7 @@ type EmbeddingConfig struct {
 	OpenAI OpenAIConfig `yaml:"openai"`
 	Voyage VoyageConfig `yaml:"voyage"`
 	Ollama OllamaConfig `yaml:"ollama"`
+	Gemini GeminiConfig `yaml:"gemini"`
 }
 
 // OpenAIConfig contains OpenAI embedding configuration
@@ -80,6 +81,15 @@ type OllamaConfig struct {
 	Endpoint      string `yaml:"endpoint"`       // e.g., "http://localhost:11434"
 	Model         string `yaml:"model"`          // e.g., "nomic-embed-text"
 	ContextLength int    `yaml:"context_length"` // Context window size (num_ctx)
+}
+
+// GeminiConfig contains Gemini embedding configuration
+type GeminiConfig struct {
+	Enabled    bool   `yaml:"enabled"`
+	APIKeyFile string `yaml:"api_key_file"`
+	APIKey     string // Loaded at runtime, not from YAML
+	Model      string `yaml:"model"`
+	Dimensions int    `yaml:"dimensions"`
 }
 
 // Load reads and parses the configuration file
@@ -174,6 +184,23 @@ func applyDefaults(config *Config, configPath string) error {
 		}
 	}
 
+	// Default Gemini settings
+	if config.Embeddings.Gemini.Enabled {
+		if config.Embeddings.Gemini.APIKeyFile == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("failed to get home directory: %w", err)
+			}
+			config.Embeddings.Gemini.APIKeyFile = filepath.Join(home, ".gemini-api-key")
+		}
+		if config.Embeddings.Gemini.Model == "" {
+			config.Embeddings.Gemini.Model = "text-embedding-004"
+		}
+		if config.Embeddings.Gemini.Dimensions == 0 {
+			config.Embeddings.Gemini.Dimensions = 768
+		}
+	}
+
 	// Expand paths with ~
 	config.DatabasePath = expandPath(config.DatabasePath)
 	config.DocSourcePath = expandPath(config.DocSourcePath)
@@ -182,6 +209,9 @@ func applyDefaults(config *Config, configPath string) error {
 	}
 	if config.Embeddings.Voyage.APIKeyFile != "" {
 		config.Embeddings.Voyage.APIKeyFile = expandPath(config.Embeddings.Voyage.APIKeyFile)
+	}
+	if config.Embeddings.Gemini.APIKeyFile != "" {
+		config.Embeddings.Gemini.APIKeyFile = expandPath(config.Embeddings.Gemini.APIKeyFile)
 	}
 
 	return nil
@@ -215,7 +245,8 @@ func validate(config *Config) error {
 	// Check that at least one embedding provider is enabled
 	if !config.Embeddings.OpenAI.Enabled &&
 		!config.Embeddings.Voyage.Enabled &&
-		!config.Embeddings.Ollama.Enabled {
+		!config.Embeddings.Ollama.Enabled &&
+		!config.Embeddings.Gemini.Enabled {
 		return fmt.Errorf("at least one embedding provider must be enabled")
 	}
 
@@ -238,6 +269,14 @@ func loadAPIKeys(config *Config) error {
 			return fmt.Errorf("Voyage API key: %w", err)
 		}
 		config.Embeddings.Voyage.APIKey = key
+	}
+
+	if config.Embeddings.Gemini.Enabled {
+		key, err := readAPIKey(config.Embeddings.Gemini.APIKeyFile)
+		if err != nil {
+			return fmt.Errorf("Gemini API key: %w", err)
+		}
+		config.Embeddings.Gemini.APIKey = key
 	}
 
 	return nil

--- a/internal/kbconverter/converter.go
+++ b/internal/kbconverter/converter.go
@@ -320,7 +320,7 @@ func extractRSTTitle(content string) string {
 
 			// Make sure the text line is not a directive either
 			if text != "" && current == underline && isUnderline(underline) &&
-				!(strings.HasPrefix(text, "..") && strings.HasSuffix(text, ":")) {
+				(!strings.HasPrefix(text, "..") || !strings.HasSuffix(text, ":")) {
 				// This is a heading with overline and underline - likely the title
 				return cleanHeadingText(text)
 			}

--- a/internal/kbdatabase/database.go
+++ b/internal/kbdatabase/database.go
@@ -66,6 +66,7 @@ func (d *Database) createSchema() error {
         openai_embedding BLOB,
         voyage_embedding BLOB,
         ollama_embedding BLOB,
+        gemini_embedding BLOB,
 
         -- Metadata
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -110,8 +111,8 @@ func (d *Database) InsertChunks(chunks []*kbtypes.Chunk) error {
 	stmt, err := tx.Prepare(`
         INSERT INTO chunks (
             text, title, section, project_name, project_version, file_path, source_file_checksum,
-            openai_embedding, voyage_embedding, ollama_embedding
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            openai_embedding, voyage_embedding, ollama_embedding, gemini_embedding
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
@@ -123,7 +124,7 @@ func (d *Database) InsertChunks(chunks []*kbtypes.Chunk) error {
 
 	for i, chunk := range chunks {
 		// Serialize embeddings to BLOB
-		var openaiBlob, voyageBlob, ollamaBlob []byte
+		var openaiBlob, voyageBlob, ollamaBlob, geminiBlob []byte
 
 		if len(chunk.OpenAIEmbedding) > 0 {
 			openaiBlob = serializeEmbedding(chunk.OpenAIEmbedding)
@@ -133,6 +134,9 @@ func (d *Database) InsertChunks(chunks []*kbtypes.Chunk) error {
 		}
 		if len(chunk.OllamaEmbedding) > 0 {
 			ollamaBlob = serializeEmbedding(chunk.OllamaEmbedding)
+		}
+		if len(chunk.GeminiEmbedding) > 0 {
+			geminiBlob = serializeEmbedding(chunk.GeminiEmbedding)
 		}
 
 		_, err := stmt.Exec(
@@ -146,6 +150,7 @@ func (d *Database) InsertChunks(chunks []*kbtypes.Chunk) error {
 			openaiBlob,
 			voyageBlob,
 			ollamaBlob,
+			geminiBlob,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert chunk %d: %w", i, err)
@@ -271,7 +276,7 @@ func (d *Database) GetStats() (map[string]interface{}, error) {
 func (d *Database) SearchChunks(query string, limit int) ([]*kbtypes.Chunk, error) {
 	rows, err := d.db.Query(`
         SELECT id, text, title, section, project_name, project_version, file_path,
-               openai_embedding, voyage_embedding, ollama_embedding
+               openai_embedding, voyage_embedding, ollama_embedding, gemini_embedding
         FROM chunks
         WHERE text LIKE ?
         LIMIT ?
@@ -285,10 +290,10 @@ func (d *Database) SearchChunks(query string, limit int) ([]*kbtypes.Chunk, erro
 	for rows.Next() {
 		var id int
 		var text, title, section, projectName, projectVersion, filePath string
-		var openaiBlob, voyageBlob, ollamaBlob []byte
+		var openaiBlob, voyageBlob, ollamaBlob, geminiBlob []byte
 
 		err := rows.Scan(&id, &text, &title, &section, &projectName, &projectVersion,
-			&filePath, &openaiBlob, &voyageBlob, &ollamaBlob)
+			&filePath, &openaiBlob, &voyageBlob, &ollamaBlob, &geminiBlob)
 		if err != nil {
 			return nil, err
 		}
@@ -303,6 +308,7 @@ func (d *Database) SearchChunks(query string, limit int) ([]*kbtypes.Chunk, erro
 			OpenAIEmbedding: deserializeEmbedding(openaiBlob),
 			VoyageEmbedding: deserializeEmbedding(voyageBlob),
 			OllamaEmbedding: deserializeEmbedding(ollamaBlob),
+			GeminiEmbedding: deserializeEmbedding(geminiBlob),
 		}
 
 		chunks = append(chunks, chunk)
@@ -315,7 +321,7 @@ func (d *Database) SearchChunks(query string, limit int) ([]*kbtypes.Chunk, erro
 func (d *Database) GetAllChunks() ([]*kbtypes.Chunk, error) {
 	rows, err := d.db.Query(`
         SELECT id, text, title, section, project_name, project_version, file_path,
-               openai_embedding, voyage_embedding, ollama_embedding
+               openai_embedding, voyage_embedding, ollama_embedding, gemini_embedding
         FROM chunks
     `)
 	if err != nil {
@@ -327,10 +333,10 @@ func (d *Database) GetAllChunks() ([]*kbtypes.Chunk, error) {
 	for rows.Next() {
 		var id int
 		var text, title, section, projectName, projectVersion, filePath string
-		var openaiBlob, voyageBlob, ollamaBlob []byte
+		var openaiBlob, voyageBlob, ollamaBlob, geminiBlob []byte
 
 		err := rows.Scan(&id, &text, &title, &section, &projectName, &projectVersion,
-			&filePath, &openaiBlob, &voyageBlob, &ollamaBlob)
+			&filePath, &openaiBlob, &voyageBlob, &ollamaBlob, &geminiBlob)
 		if err != nil {
 			return nil, err
 		}
@@ -346,6 +352,7 @@ func (d *Database) GetAllChunks() ([]*kbtypes.Chunk, error) {
 			OpenAIEmbedding: deserializeEmbedding(openaiBlob),
 			VoyageEmbedding: deserializeEmbedding(voyageBlob),
 			OllamaEmbedding: deserializeEmbedding(ollamaBlob),
+			GeminiEmbedding: deserializeEmbedding(geminiBlob),
 		}
 
 		chunks = append(chunks, chunk)
@@ -369,7 +376,8 @@ func (d *Database) UpdateChunkEmbeddings(chunks []*kbtypes.Chunk) error {
         UPDATE chunks
         SET openai_embedding = ?,
             voyage_embedding = ?,
-            ollama_embedding = ?
+            ollama_embedding = ?,
+            gemini_embedding = ?
         WHERE id = ?
     `)
 	if err != nil {
@@ -381,8 +389,9 @@ func (d *Database) UpdateChunkEmbeddings(chunks []*kbtypes.Chunk) error {
 		openaiBlob := serializeEmbedding(chunk.OpenAIEmbedding)
 		voyageBlob := serializeEmbedding(chunk.VoyageEmbedding)
 		ollamaBlob := serializeEmbedding(chunk.OllamaEmbedding)
+		geminiBlob := serializeEmbedding(chunk.GeminiEmbedding)
 
-		_, err := stmt.Exec(openaiBlob, voyageBlob, ollamaBlob, chunk.ID)
+		_, err := stmt.Exec(openaiBlob, voyageBlob, ollamaBlob, geminiBlob, chunk.ID)
 		if err != nil {
 			return err
 		}
@@ -472,6 +481,32 @@ func (d *Database) UpdateOllamaEmbeddings(chunks []*kbtypes.Chunk) error {
 	return tx.Commit()
 }
 
+// UpdateGeminiEmbeddings updates only Gemini embeddings for existing chunks
+func (d *Database) UpdateGeminiEmbeddings(chunks []*kbtypes.Chunk) error {
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	stmt, err := tx.Prepare(`UPDATE chunks SET gemini_embedding = ? WHERE id = ?`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, chunk := range chunks {
+		blob := serializeEmbedding(chunk.GeminiEmbedding)
+		if _, err := stmt.Exec(blob, chunk.ID); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
 // ClearEmbeddings clears all embeddings for a specific provider
 func (d *Database) ClearEmbeddings(provider string) (int64, error) {
 	var column string
@@ -482,8 +517,10 @@ func (d *Database) ClearEmbeddings(provider string) (int64, error) {
 		column = "voyage_embedding"
 	case "ollama":
 		column = "ollama_embedding"
+	case "gemini":
+		column = "gemini_embedding"
 	default:
-		return 0, fmt.Errorf("invalid provider: %s (must be openai, voyage, or ollama)", provider)
+		return 0, fmt.Errorf("invalid provider: %s (must be openai, voyage, ollama, or gemini)", provider)
 	}
 
 	query := fmt.Sprintf("UPDATE chunks SET %s = NULL", column)
@@ -516,7 +553,7 @@ func (d *Database) FileNeedsProcessing(checksum, projectName, projectVersion str
 func (d *Database) GetChunksForChecksum(checksum string) ([]*kbtypes.Chunk, error) {
 	rows, err := d.db.Query(`
         SELECT text, title, section, file_path,
-               openai_embedding, voyage_embedding, ollama_embedding
+               openai_embedding, voyage_embedding, ollama_embedding, gemini_embedding
         FROM chunks
         WHERE source_file_checksum = ?
         LIMIT 1000
@@ -529,10 +566,10 @@ func (d *Database) GetChunksForChecksum(checksum string) ([]*kbtypes.Chunk, erro
 	var chunks []*kbtypes.Chunk
 	for rows.Next() {
 		var text, title, section, filePath string
-		var openaiBlob, voyageBlob, ollamaBlob []byte
+		var openaiBlob, voyageBlob, ollamaBlob, geminiBlob []byte
 
 		err := rows.Scan(&text, &title, &section, &filePath,
-			&openaiBlob, &voyageBlob, &ollamaBlob)
+			&openaiBlob, &voyageBlob, &ollamaBlob, &geminiBlob)
 		if err != nil {
 			return nil, err
 		}
@@ -546,6 +583,7 @@ func (d *Database) GetChunksForChecksum(checksum string) ([]*kbtypes.Chunk, erro
 			OpenAIEmbedding:    deserializeEmbedding(openaiBlob),
 			VoyageEmbedding:    deserializeEmbedding(voyageBlob),
 			OllamaEmbedding:    deserializeEmbedding(ollamaBlob),
+			GeminiEmbedding:    deserializeEmbedding(geminiBlob),
 		}
 
 		chunks = append(chunks, chunk)

--- a/internal/kbembed/embeddings.go
+++ b/internal/kbembed/embeddings.go
@@ -72,7 +72,7 @@ func (eg *EmbeddingGenerator) GenerateEmbeddings(chunks []*kbtypes.Chunk) map[st
 		name string
 		err  error
 	}
-	resultChan := make(chan providerResult, 3)
+	resultChan := make(chan providerResult, 4)
 
 	startTime := time.Now()
 
@@ -122,6 +122,22 @@ func (eg *EmbeddingGenerator) GenerateEmbeddings(chunks []*kbtypes.Chunk) map[st
 			}
 			fmt.Printf("✓ Ollama embeddings completed in %.2fs\n", time.Since(providerStart).Seconds())
 			resultChan <- providerResult{"Ollama", nil}
+		}()
+	}
+
+	if eg.config.Embeddings.Gemini.Enabled {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fmt.Printf("Starting Gemini embeddings...\n")
+			providerStart := time.Now()
+			if err := eg.generateGeminiEmbeddings(chunks); err != nil {
+				fmt.Printf("⚠️  Gemini embeddings failed: %v\n", err)
+				resultChan <- providerResult{"Gemini", err}
+				return
+			}
+			fmt.Printf("✓ Gemini embeddings completed in %.2fs\n", time.Since(providerStart).Seconds())
+			resultChan <- providerResult{"Gemini", nil}
 		}()
 	}
 
@@ -662,4 +678,104 @@ func (eg *EmbeddingGenerator) ollamaEmbedSingle(
 	resp.Body.Close()
 
 	return embResp.Embedding, nil
+}
+
+// Gemini API structures
+type geminiEmbedBatchRequest struct {
+	Model   string `json:"model"`
+	Content struct {
+		Parts []struct {
+			Text string `json:"text"`
+		} `json:"parts"`
+	} `json:"content"`
+}
+
+type geminiEmbedBatchResponse struct {
+	Embedding struct {
+		Values []float32 `json:"values"`
+	} `json:"embedding"`
+}
+
+// generateGeminiEmbeddings generates embeddings using Google Gemini
+func (eg *EmbeddingGenerator) generateGeminiEmbeddings(chunks []*kbtypes.Chunk) error {
+	config := eg.config.Embeddings.Gemini
+	endpoint := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:embedContent?key=%s",
+		config.Model, config.APIKey)
+
+	var chunksToProcess []*kbtypes.Chunk
+	for _, chunk := range chunks {
+		if len(chunk.GeminiEmbedding) == 0 && strings.TrimSpace(chunk.Text) != "" {
+			chunksToProcess = append(chunksToProcess, chunk)
+		}
+	}
+
+	if len(chunksToProcess) == 0 {
+		fmt.Printf("  Gemini: All chunks already have embeddings, skipping\n")
+		return nil
+	}
+
+	if len(chunksToProcess) < len(chunks) {
+		fmt.Printf("  Gemini: Processing %d chunks (%d already have Gemini embeddings)\n",
+			len(chunksToProcess), len(chunks)-len(chunksToProcess))
+	} else {
+		fmt.Printf("  Gemini: Processing %d chunks\n", len(chunksToProcess))
+	}
+
+	const saveInterval = 50
+	var pendingSave []*kbtypes.Chunk
+
+	for i, chunk := range chunksToProcess {
+		reqBody := geminiEmbedBatchRequest{
+			Model: "models/" + config.Model,
+		}
+		reqBody.Content.Parts = []struct {
+			Text string `json:"text"`
+		}{{Text: chunk.Text}}
+
+		jsonData, err := json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request: %w", err)
+		}
+
+		operation := fmt.Sprintf("Gemini chunk %d/%d", i+1, len(chunksToProcess))
+		resp, err := eg.retryWithBackoff(operation, func() (*http.Response, error) {
+			req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonData))
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			return eg.client.Do(req)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to make request: %w", err)
+		}
+
+		var embResp geminiEmbedBatchResponse
+		if err := json.NewDecoder(resp.Body).Decode(&embResp); err != nil {
+			resp.Body.Close()
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
+		resp.Body.Close()
+
+		chunk.GeminiEmbedding = embResp.Embedding.Values
+		pendingSave = append(pendingSave, chunk)
+
+		if len(pendingSave) >= saveInterval || i == len(chunksToProcess)-1 {
+			if eg.db != nil && len(pendingSave) > 0 && pendingSave[0].ID != 0 {
+				eg.dbMux.Lock()
+				if err := eg.db.UpdateGeminiEmbeddings(pendingSave); err != nil {
+					eg.dbMux.Unlock()
+					return fmt.Errorf("failed to save chunks to database: %w", err)
+				}
+				eg.dbMux.Unlock()
+				pendingSave = nil
+			}
+		}
+
+		if (i+1)%10 == 0 || i == len(chunksToProcess)-1 {
+			fmt.Printf("  Gemini: Processed %d/%d chunks\n", i+1, len(chunksToProcess))
+		}
+	}
+
+	return nil
 }

--- a/internal/kbtypes/types.go
+++ b/internal/kbtypes/types.go
@@ -70,4 +70,5 @@ type Chunk struct {
 	OpenAIEmbedding []float32
 	VoyageEmbedding []float32
 	OllamaEmbedding []float32
+	GeminiEmbedding []float32
 }

--- a/internal/llmproxy/proxy.go
+++ b/internal/llmproxy/proxy.go
@@ -31,6 +31,9 @@ type Config struct {
 	OpenAIAPIKey     string
 	OpenAIBaseURL    string // Base URL for OpenAI API (optional, uses default if empty)
 	OllamaURL        string
+	GeminiAPIKey     string
+	GeminiBaseURL    string // Base URL for Gemini API (optional, uses default if empty)
+	CustomHeaders    map[string]string
 	MaxTokens        int
 	Temperature      float64
 }
@@ -130,6 +133,14 @@ func HandleProviders(w http.ResponseWriter, r *http.Request, config *Config) {
 		})
 	}
 
+	if config.GeminiAPIKey != "" {
+		providers = append(providers, ProviderInfo{
+			Name:      "gemini",
+			Display:   "Google Gemini",
+			IsDefault: config.Provider == "gemini",
+		})
+	}
+
 	response := ProvidersResponse{
 		Providers:    providers,
 		DefaultModel: config.Model,
@@ -163,7 +174,7 @@ func HandleModels(w http.ResponseWriter, r *http.Request, config *Config) {
 			http.Error(w, "Anthropic API key not configured", http.StatusBadRequest)
 			return
 		}
-		client, clientErr = chat.NewAnthropicClient(config.AnthropicAPIKey, config.AnthropicBaseURL, config.Model, config.MaxTokens, config.Temperature, false)
+		client, clientErr = chat.NewAnthropicClient(config.AnthropicAPIKey, config.AnthropicBaseURL, config.Model, config.MaxTokens, config.Temperature, config.CustomHeaders, false)
 		if clientErr != nil {
 			http.Error(w, fmt.Sprintf("Failed to create Anthropic client: %v", clientErr), http.StatusBadRequest)
 			return
@@ -173,7 +184,7 @@ func HandleModels(w http.ResponseWriter, r *http.Request, config *Config) {
 			http.Error(w, "OpenAI API key not configured", http.StatusBadRequest)
 			return
 		}
-		client, clientErr = chat.NewOpenAIClient(config.OpenAIAPIKey, config.OpenAIBaseURL, config.Model, config.MaxTokens, config.Temperature, false)
+		client, clientErr = chat.NewOpenAIClient(config.OpenAIAPIKey, config.OpenAIBaseURL, config.Model, config.MaxTokens, config.Temperature, config.CustomHeaders, false)
 		if clientErr != nil {
 			http.Error(w, fmt.Sprintf("Failed to create OpenAI client: %v", clientErr), http.StatusBadRequest)
 			return
@@ -183,7 +194,17 @@ func HandleModels(w http.ResponseWriter, r *http.Request, config *Config) {
 			http.Error(w, "Ollama URL not configured", http.StatusBadRequest)
 			return
 		}
-		client = chat.NewOllamaClient(config.OllamaURL, config.Model, false)
+		client = chat.NewOllamaClient(config.OllamaURL, config.Model, config.CustomHeaders, false)
+	case "gemini":
+		if config.GeminiAPIKey == "" {
+			http.Error(w, "Gemini API key not configured", http.StatusBadRequest)
+			return
+		}
+		client, clientErr = chat.NewGeminiClient(config.GeminiAPIKey, config.GeminiBaseURL, config.Model, config.MaxTokens, config.Temperature, config.CustomHeaders, false)
+		if clientErr != nil {
+			http.Error(w, fmt.Sprintf("Failed to create Gemini client: %v", clientErr), http.StatusBadRequest)
+			return
+		}
 	default:
 		http.Error(w, fmt.Sprintf("Unsupported provider: %s", provider), http.StatusBadRequest)
 		return
@@ -255,7 +276,7 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 			http.Error(w, "Anthropic API key not configured", http.StatusBadRequest)
 			return
 		}
-		client, clientErr = chat.NewAnthropicClient(config.AnthropicAPIKey, config.AnthropicBaseURL, model, config.MaxTokens, config.Temperature, req.Debug)
+		client, clientErr = chat.NewAnthropicClient(config.AnthropicAPIKey, config.AnthropicBaseURL, model, config.MaxTokens, config.Temperature, config.CustomHeaders, req.Debug)
 		if clientErr != nil {
 			http.Error(w, fmt.Sprintf("Failed to create Anthropic client: %v", clientErr), http.StatusBadRequest)
 			return
@@ -265,7 +286,7 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 			http.Error(w, "OpenAI API key not configured", http.StatusBadRequest)
 			return
 		}
-		client, clientErr = chat.NewOpenAIClient(config.OpenAIAPIKey, config.OpenAIBaseURL, model, config.MaxTokens, config.Temperature, req.Debug)
+		client, clientErr = chat.NewOpenAIClient(config.OpenAIAPIKey, config.OpenAIBaseURL, model, config.MaxTokens, config.Temperature, config.CustomHeaders, req.Debug)
 		if clientErr != nil {
 			http.Error(w, fmt.Sprintf("Failed to create OpenAI client: %v", clientErr), http.StatusBadRequest)
 			return
@@ -275,7 +296,17 @@ func HandleChat(w http.ResponseWriter, r *http.Request, config *Config) {
 			http.Error(w, "Ollama URL not configured", http.StatusBadRequest)
 			return
 		}
-		client = chat.NewOllamaClient(config.OllamaURL, model, req.Debug)
+		client = chat.NewOllamaClient(config.OllamaURL, model, config.CustomHeaders, req.Debug)
+	case "gemini":
+		if config.GeminiAPIKey == "" {
+			http.Error(w, "Gemini API key not configured", http.StatusBadRequest)
+			return
+		}
+		client, clientErr = chat.NewGeminiClient(config.GeminiAPIKey, config.GeminiBaseURL, model, config.MaxTokens, config.Temperature, config.CustomHeaders, req.Debug)
+		if clientErr != nil {
+			http.Error(w, fmt.Sprintf("Failed to create Gemini client: %v", clientErr), http.StatusBadRequest)
+			return
+		}
 	default:
 		http.Error(w, fmt.Sprintf("Unsupported provider: %s", provider), http.StatusBadRequest)
 		return

--- a/internal/tools/generate_embedding.go
+++ b/internal/tools/generate_embedding.go
@@ -64,6 +64,9 @@ func GenerateEmbeddingTool(cfg *config.Config) Tool {
 				OpenAIAPIKey:  cfg.Embedding.OpenAIAPIKey,
 				OpenAIBaseURL: cfg.Embedding.OpenAIBaseURL,
 				OllamaURL:     cfg.Embedding.OllamaURL,
+				GeminiAPIKey:  cfg.Embedding.GeminiAPIKey,
+				GeminiBaseURL: cfg.Embedding.GeminiBaseURL,
+				CustomHeaders: cfg.Embedding.CustomHeaders,
 			}
 
 			provider, err := embedding.NewProvider(embCfg)

--- a/internal/tools/search_knowledgebase.go
+++ b/internal/tools/search_knowledgebase.go
@@ -304,7 +304,7 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 	// Build query
 	query := `
         SELECT text, title, section, project_name, project_version, file_path,
-               openai_embedding, voyage_embedding, ollama_embedding
+               openai_embedding, voyage_embedding, ollama_embedding, gemini_embedding
         FROM chunks
         WHERE 1=1
     `
@@ -340,10 +340,10 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 
 	for rows.Next() {
 		var text, title, section, pName, pVersion, filePath string
-		var openaiBlob, voyageBlob, ollamaBlob []byte
+		var openaiBlob, voyageBlob, ollamaBlob, geminiBlob []byte
 
 		err := rows.Scan(&text, &title, &section, &pName, &pVersion, &filePath,
-			&openaiBlob, &voyageBlob, &ollamaBlob)
+			&openaiBlob, &voyageBlob, &ollamaBlob, &geminiBlob)
 		if err != nil {
 			continue
 		}
@@ -355,6 +355,8 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 			embBlob = voyageBlob
 		case "ollama":
 			embBlob = ollamaBlob
+		case "gemini":
+			embBlob = geminiBlob
 		default: // openai
 			embBlob = openaiBlob
 		}
@@ -367,6 +369,8 @@ func searchKB(kbPath string, queryEmbedding []float32, projectNames, projectVers
 				embBlob = voyageBlob
 			} else if len(ollamaBlob) > 0 {
 				embBlob = ollamaBlob
+			} else if len(geminiBlob) > 0 {
+				embBlob = geminiBlob
 			} else {
 				continue // No embeddings available
 			}

--- a/internal/tools/search_knowledgebase.go
+++ b/internal/tools/search_knowledgebase.go
@@ -264,6 +264,9 @@ func generateKBQueryEmbedding(serverCfg *config.Config, queryText string) ([]flo
 		OpenAIAPIKey:  kbCfg.EmbeddingOpenAIAPIKey,
 		OpenAIBaseURL: kbCfg.EmbeddingOpenAIBaseURL,
 		OllamaURL:     kbCfg.EmbeddingOllamaURL,
+		GeminiAPIKey:  kbCfg.EmbeddingGeminiAPIKey,
+		GeminiBaseURL: kbCfg.EmbeddingGeminiBaseURL,
+		CustomHeaders: kbCfg.EmbeddingCustomHeaders,
 	}
 
 	provider, err := embedding.NewProvider(embCfg)

--- a/internal/tools/similarity_search.go
+++ b/internal/tools/similarity_search.go
@@ -625,6 +625,9 @@ func generateQueryEmbeddingWithConfig(serverCfg *config.Config, queryText string
 		OpenAIAPIKey:  serverCfg.Embedding.OpenAIAPIKey,
 		OpenAIBaseURL: serverCfg.Embedding.OpenAIBaseURL,
 		OllamaURL:     serverCfg.Embedding.OllamaURL,
+		GeminiAPIKey:  serverCfg.Embedding.GeminiAPIKey,
+		GeminiBaseURL: serverCfg.Embedding.GeminiBaseURL,
+		CustomHeaders: serverCfg.Embedding.CustomHeaders,
 	}
 
 	provider, err := embedding.NewProvider(embCfg)


### PR DESCRIPTION
## Summary

- Add Google Gemini as a chat LLM and embedding provider using the
  Google AI Studio API.
- Allow the OpenAI provider to work without an API key when a custom
  base URL is configured, enabling use with LM Studio, Docker Model
  Runner, EXO, and other OpenAI API-compatible local LLM providers.
- Add support for custom HTTP headers on all LLM and embedding API
  requests, enabling proxy services such as Portkey.
- Add Gemini embedding support to the knowledge base builder,
  including a new `gemini_embedding` column in the KB database.

## Test plan

- [ ] Verify all existing tests pass (`make test`)
- [ ] Verify linting passes (`make lint`)
- [ ] Test Gemini chat provider with a valid API key
- [ ] Test Gemini embedding provider with a valid API key
- [ ] Test OpenAI provider without API key against a local LLM (e.g. LM Studio)
- [ ] Test custom headers with a proxy service (e.g. Portkey)
- [ ] Test KB builder with Gemini embeddings enabled
- [ ] Test similarity search with Gemini embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Gemini as a supported chat LLM and embedding provider.
  * Added custom HTTP headers support for all LLM and embedding API requests, enabling use behind proxies and gateways.
  * OpenAI-compatible local LLM providers can now operate without requiring an API key when configured with a custom base URL.

* **Documentation**
  * Updated changelog with Gemini integration and custom headers information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->