### PR TITLE
Add Ollama API key to kb release workflow

### DIFF
--- a/.github/workflows/release-kb.yml
+++ b/.github/workflows/release-kb.yml
@@ -54,9 +54,11 @@ jobs:
               env:
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
                   VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
+                  OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
               run: |
                   [ -n "$OPENAI_API_KEY" ] || { echo "OPENAI_API_KEY secret is missing"; exit 1; }
                   [ -n "$VOYAGE_API_KEY" ] || { echo "VOYAGE_API_KEY secret is missing"; exit 1; }
+                  [ -n "$OLLAMA_API_KEY" ] || { echo "OLLAMA_API_KEY secret is missing"; exit 1; }
                   mkdir -p /tmp/api-keys
                   printf '%s' "$OPENAI_API_KEY" > /tmp/api-keys/openai-key
                   printf '%s' "$VOYAGE_API_KEY" > /tmp/api-keys/voyage-key
@@ -82,6 +84,7 @@ jobs:
               env:
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
                   VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
+                  OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
             - name: Verify kb.db was created
               run: |

--- a/.github/workflows/release-kb.yml
+++ b/.github/workflows/release-kb.yml
@@ -58,10 +58,10 @@ jobs:
               run: |
                   [ -n "$OPENAI_API_KEY" ] || { echo "OPENAI_API_KEY secret is missing"; exit 1; }
                   [ -n "$VOYAGE_API_KEY" ] || { echo "VOYAGE_API_KEY secret is missing"; exit 1; }
-                  [ -n "$OLLAMA_API_KEY" ] || { echo "OLLAMA_API_KEY secret is missing"; exit 1; }
                   mkdir -p /tmp/api-keys
                   printf '%s' "$OPENAI_API_KEY" > /tmp/api-keys/openai-key
                   printf '%s' "$VOYAGE_API_KEY" > /tmp/api-keys/voyage-key
+                  printf '%s' "$OLLAMA_API_KEY" > /tmp/api-keys/ollama-key
                   chmod 600 /tmp/api-keys/*
 
             - name: Configure kb-builder for cloud providers
@@ -71,10 +71,12 @@ jobs:
                   sed -i 's|endpoint: "http://localhost:11434"|endpoint: "https://ollama.com"|' examples/pgedge-nla-kb-builder-build.yaml
                   sed -i 's|api_key_file: "~/.openai-api-key"|api_key_file: "/tmp/api-keys/openai-key"|' examples/pgedge-nla-kb-builder-build.yaml
                   sed -i 's|api_key_file: "~/.voyage-api-key"|api_key_file: "/tmp/api-keys/voyage-key"|' examples/pgedge-nla-kb-builder-build.yaml
+                  sed -i 's|# api_key_file: "~/.ollama-api-key"|api_key_file: "/tmp/api-keys/ollama-key"|' examples/pgedge-nla-kb-builder-build.yaml
                   sed -i 's|git@github.com:|https://github.com/|g' examples/pgedge-nla-kb-builder-build.yaml
                   grep -q 'database_path: "bin/kb.db"' examples/pgedge-nla-kb-builder-build.yaml || { echo "database_path replacement failed"; exit 1; }
                   grep -q 'api_key_file: "/tmp/api-keys/openai-key"' examples/pgedge-nla-kb-builder-build.yaml || { echo "OpenAI key path replacement failed"; exit 1; }
                   grep -q 'api_key_file: "/tmp/api-keys/voyage-key"' examples/pgedge-nla-kb-builder-build.yaml || { echo "Voyage key path replacement failed"; exit 1; }
+                  grep -q 'api_key_file: "/tmp/api-keys/ollama-key"' examples/pgedge-nla-kb-builder-build.yaml || { echo "Ollama key path replacement failed"; exit 1; }
                   grep -q 'https://github.com/' examples/pgedge-nla-kb-builder-build.yaml || { echo "SSH URL replacement failed"; exit 1; }
 
             - name: Generate kb.db

--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -494,6 +494,7 @@ embeddings:
         enabled: true
         endpoint: "http://localhost:11434"  # Defaults to http://localhost:11434
         model: "nomic-embed-text"            # Defaults to nomic-embed-text
+        # api_key_file: "~/.ollama-api-key"  # Optional: only needed for Ollama Cloud
 
 # Notes:
 # - At least one embedding provider must be enabled

--- a/internal/kbconfig/config.go
+++ b/internal/kbconfig/config.go
@@ -80,6 +80,8 @@ type OllamaConfig struct {
 	Endpoint      string `yaml:"endpoint"`       // e.g., "http://localhost:11434"
 	Model         string `yaml:"model"`          // e.g., "nomic-embed-text"
 	ContextLength int    `yaml:"context_length"` // Context window size (num_ctx)
+	APIKeyFile    string `yaml:"api_key_file"`   // Optional, only needed for Ollama Cloud
+	APIKey        string // Loaded at runtime, not from YAML
 }
 
 // Load reads and parses the configuration file
@@ -183,6 +185,9 @@ func applyDefaults(config *Config, configPath string) error {
 	if config.Embeddings.Voyage.APIKeyFile != "" {
 		config.Embeddings.Voyage.APIKeyFile = expandPath(config.Embeddings.Voyage.APIKeyFile)
 	}
+	if config.Embeddings.Ollama.APIKeyFile != "" {
+		config.Embeddings.Ollama.APIKeyFile = expandPath(config.Embeddings.Ollama.APIKeyFile)
+	}
 
 	return nil
 }
@@ -238,6 +243,16 @@ func loadAPIKeys(config *Config) error {
 			return fmt.Errorf("Voyage API key: %w", err)
 		}
 		config.Embeddings.Voyage.APIKey = key
+	}
+
+	// Ollama API key is optional: only needed for Ollama Cloud, not
+	// for local Ollama deployments.
+	if config.Embeddings.Ollama.Enabled && config.Embeddings.Ollama.APIKeyFile != "" {
+		key, err := readAPIKey(config.Embeddings.Ollama.APIKeyFile)
+		if err != nil {
+			return fmt.Errorf("Ollama API key: %w", err)
+		}
+		config.Embeddings.Ollama.APIKey = key
 	}
 
 	return nil

--- a/internal/kbembed/embeddings.go
+++ b/internal/kbembed/embeddings.go
@@ -515,7 +515,7 @@ type ollamaEmbeddingResponse struct {
 // generateOllamaEmbeddings generates embeddings using Ollama
 func (eg *EmbeddingGenerator) generateOllamaEmbeddings(chunks []*kbtypes.Chunk) error {
 	config := eg.config.Embeddings.Ollama
-	endpoint := config.Endpoint + "/api/embed"
+	endpoint := strings.TrimRight(config.Endpoint, "/") + "/api/embed"
 
 	// Filter chunks that need Ollama embeddings
 	var chunksToProcess []*kbtypes.Chunk

--- a/internal/kbembed/embeddings.go
+++ b/internal/kbembed/embeddings.go
@@ -472,6 +472,14 @@ func isContextLengthError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), ollamaContextLengthError)
 }
 
+// isOllamaServerError checks whether an error from retryWithBackoff
+// represents an Ollama HTTP 500 server error.  Certain inputs cause
+// Ollama's model runner to crash; truncating the input often allows
+// the request to succeed on retry.
+func isOllamaServerError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "HTTP 500")
+}
+
 // truncateAtWordBoundary truncates text to approximately the given
 // fraction of its original length, cutting at a word boundary so
 // that no word is split in the middle.  The fraction must be between
@@ -549,11 +557,18 @@ func (eg *EmbeddingGenerator) generateOllamaEmbeddings(chunks []*kbtypes.Chunk) 
 			fmt.Sprintf("Ollama chunk %d/%d", i+1, len(chunksToProcess)),
 		)
 
-		// If the initial attempt failed with a context-length error,
-		// retry with progressively truncated text.
-		if isContextLengthError(err) {
-			fmt.Printf("  Ollama: Chunk %d/%d exceeds context length (%d chars, %d words); trying truncation\n",
-				i+1, len(chunksToProcess), len(chunk.Text), len(strings.Fields(chunk.Text)))
+		// If the initial attempt failed with a context-length error or
+		// a server error (HTTP 500), retry with progressively truncated
+		// text.  Some inputs cause Ollama's model runner to crash with
+		// HTTP 500; truncating the input often lets the request succeed.
+		if isContextLengthError(err) || isOllamaServerError(err) {
+			if isOllamaServerError(err) {
+				fmt.Printf("  Ollama: Chunk %d/%d caused server error (%d chars, %d words); trying truncation\n",
+					i+1, len(chunksToProcess), len(chunk.Text), len(strings.Fields(chunk.Text)))
+			} else {
+				fmt.Printf("  Ollama: Chunk %d/%d exceeds context length (%d chars, %d words); trying truncation\n",
+					i+1, len(chunksToProcess), len(chunk.Text), len(strings.Fields(chunk.Text)))
+			}
 
 			truncated := false
 			for _, fraction := range []float64{0.75, 0.50, 0.25} {
@@ -571,7 +586,7 @@ func (eg *EmbeddingGenerator) generateOllamaEmbeddings(chunks []*kbtypes.Chunk) 
 					truncated = true
 					break
 				}
-				if !isContextLengthError(err) {
+				if !isContextLengthError(err) && !isOllamaServerError(err) {
 					// A different error occurred; stop trying.
 					break
 				}
@@ -589,7 +604,7 @@ func (eg *EmbeddingGenerator) generateOllamaEmbeddings(chunks []*kbtypes.Chunk) 
 				fmt.Printf("    Succeeded with truncated text for chunk %d/%d\n", i+1, len(chunksToProcess))
 			}
 		} else if err != nil {
-			// Non-context-length error -- fail as before.
+			// Non-retryable error -- fail as before.
 			fmt.Printf("\n  Failed chunk details:\n")
 			fmt.Printf("     File: %s\n", chunk.FilePath)
 			fmt.Printf("     Section: %s\n", chunk.Section)

--- a/internal/kbembed/embeddings.go
+++ b/internal/kbembed/embeddings.go
@@ -504,18 +504,18 @@ func truncateAtWordBoundary(text string, fraction float64) string {
 // Ollama API structures
 type ollamaEmbeddingRequest struct {
 	Model   string                 `json:"model"`
-	Prompt  string                 `json:"prompt"`
+	Input   string                 `json:"input"`
 	Options map[string]interface{} `json:"options,omitempty"`
 }
 
 type ollamaEmbeddingResponse struct {
-	Embedding []float32 `json:"embedding"`
+	Embeddings [][]float32 `json:"embeddings"`
 }
 
 // generateOllamaEmbeddings generates embeddings using Ollama
 func (eg *EmbeddingGenerator) generateOllamaEmbeddings(chunks []*kbtypes.Chunk) error {
 	config := eg.config.Embeddings.Ollama
-	endpoint := config.Endpoint + "/api/embeddings"
+	endpoint := config.Endpoint + "/api/embed"
 
 	// Filter chunks that need Ollama embeddings
 	var chunksToProcess []*kbtypes.Chunk
@@ -630,8 +630,8 @@ func (eg *EmbeddingGenerator) ollamaEmbedSingle(
 ) ([]float32, error) {
 
 	reqBody := ollamaEmbeddingRequest{
-		Model:  model,
-		Prompt: text,
+		Model: model,
+		Input: text,
 		Options: map[string]interface{}{
 			"num_ctx": contextLength,
 		},
@@ -648,6 +648,9 @@ func (eg *EmbeddingGenerator) ollamaEmbedSingle(
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if eg.config.Embeddings.Ollama.APIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+eg.config.Embeddings.Ollama.APIKey)
+		}
 		return eg.client.Do(req)
 	})
 	if err != nil {
@@ -661,5 +664,9 @@ func (eg *EmbeddingGenerator) ollamaEmbedSingle(
 	}
 	resp.Body.Close()
 
-	return embResp.Embedding, nil
+	if len(embResp.Embeddings) == 0 {
+		return nil, fmt.Errorf("Ollama returned no embeddings")
+	}
+
+	return embResp.Embeddings[0], nil
 }

--- a/internal/kbembed/embeddings_test.go
+++ b/internal/kbembed/embeddings_test.go
@@ -109,8 +109,8 @@ func TestVoyageRequestStructure(t *testing.T) {
 func TestOllamaRequestStructure(t *testing.T) {
 	// Test that we can marshal Ollama request correctly
 	req := ollamaEmbeddingRequest{
-		Model:  "nomic-embed-text",
-		Prompt: "test text",
+		Model: "nomic-embed-text",
+		Input: "test text",
 	}
 
 	data, err := json.Marshal(req)
@@ -128,8 +128,8 @@ func TestOllamaRequestStructure(t *testing.T) {
 		t.Errorf("Expected model 'nomic-embed-text', got %q", decoded.Model)
 	}
 
-	if decoded.Prompt != "test text" {
-		t.Errorf("Expected prompt 'test text', got %q", decoded.Prompt)
+	if decoded.Input != "test text" {
+		t.Errorf("Expected input 'test text', got %q", decoded.Input)
 	}
 }
 
@@ -185,19 +185,23 @@ func TestVoyageResponseStructure(t *testing.T) {
 
 func TestOllamaResponseStructure(t *testing.T) {
 	// Test that we can unmarshal Ollama response correctly
-	responseJSON := `{"embedding": [0.1, 0.2, 0.3, 0.4, 0.5]}`
+	responseJSON := `{"embeddings": [[0.1, 0.2, 0.3, 0.4, 0.5]]}`
 
 	var resp ollamaEmbeddingResponse
 	if err := json.Unmarshal([]byte(responseJSON), &resp); err != nil {
 		t.Fatalf("Failed to unmarshal Ollama response: %v", err)
 	}
 
-	if len(resp.Embedding) != 5 {
-		t.Errorf("Expected embedding with 5 dimensions, got %d", len(resp.Embedding))
+	if len(resp.Embeddings) != 1 {
+		t.Fatalf("Expected 1 embedding, got %d", len(resp.Embeddings))
 	}
 
-	if resp.Embedding[0] != 0.1 {
-		t.Errorf("Expected first value 0.1, got %f", resp.Embedding[0])
+	if len(resp.Embeddings[0]) != 5 {
+		t.Errorf("Expected embedding with 5 dimensions, got %d", len(resp.Embeddings[0]))
+	}
+
+	if resp.Embeddings[0][0] != 0.1 {
+		t.Errorf("Expected first value 0.1, got %f", resp.Embeddings[0][0])
 	}
 }
 
@@ -500,10 +504,10 @@ func TestOllamaContextLengthTruncation(t *testing.T) {
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
 		}
-		requestTexts = append(requestTexts, req.Prompt)
+		requestTexts = append(requestTexts, req.Input)
 
 		// Simulate context length error for text over 100 chars
-		if len(req.Prompt) > 100 {
+		if len(req.Input) > 100 {
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{
 				"error": "the input length exceeds the context length",
@@ -514,7 +518,7 @@ func TestOllamaContextLengthTruncation(t *testing.T) {
 		// Return a valid embedding for short enough text
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(ollamaEmbeddingResponse{
-			Embedding: []float32{0.1, 0.2, 0.3},
+			Embeddings: [][]float32{{0.1, 0.2, 0.3}},
 		})
 	}))
 	defer server.Close()

--- a/internal/kbembed/embeddings_test.go
+++ b/internal/kbembed/embeddings_test.go
@@ -569,6 +569,146 @@ func TestOllamaContextLengthTruncation(t *testing.T) {
 	}
 }
 
+func TestIsOllamaServerError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "HTTP 500 error from retry",
+			err:  fmt.Errorf("failed after 5 retries: HTTP 500: internal server error"),
+			want: true,
+		},
+		{
+			name: "HTTP 500 with ollama crash details",
+			err:  fmt.Errorf("HTTP 500: {\"error\":\"llama runner process has terminated\"}"),
+			want: true,
+		},
+		{
+			name: "different HTTP error",
+			err:  fmt.Errorf("HTTP 400: bad request"),
+			want: false,
+		},
+		{
+			name: "connection error",
+			err:  fmt.Errorf("connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isOllamaServerError(tt.err)
+			if got != tt.want {
+				t.Errorf("isOllamaServerError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOllamaServerErrorTruncation(t *testing.T) {
+	// Track how many requests the server receives and at what text lengths
+	var requestTexts []string
+
+	// Create a mock Ollama server that returns HTTP 500 for long texts
+	// and succeeds for shorter (truncated) texts.  This simulates the
+	// Ollama model runner crashing on certain content; truncation
+	// should resolve the crash.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaEmbeddingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		requestTexts = append(requestTexts, req.Input)
+
+		// Simulate server error for text over 100 chars
+		if len(req.Input) > 100 {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "llama runner process has terminated: signal: aborted",
+			})
+			return
+		}
+
+		// Return a valid embedding for short enough text
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ollamaEmbeddingResponse{
+			Embeddings: [][]float32{{0.1, 0.2, 0.3}},
+		})
+	}))
+	defer server.Close()
+
+	config := &kbconfig.Config{
+		Embeddings: kbconfig.EmbeddingConfig{
+			Ollama: kbconfig.OllamaConfig{
+				Enabled:       true,
+				Endpoint:      server.URL,
+				Model:         "test-model",
+				ContextLength: 8192,
+			},
+		},
+	}
+
+	// Use maxRetries=1 so the retry/backoff loop in retryWithBackoff
+	// completes quickly.  HTTP 500 is retryable, so without this the
+	// test would wait through several seconds of exponential backoff
+	// before the truncation code path runs.
+	eg := NewEmbeddingGenerator(config, nil, 1)
+
+	// Create a chunk with text that is long enough to trigger HTTP 500
+	// initially but short enough that 50% truncation will succeed.
+	longText := "word "
+	for len(longText) < 250 {
+		longText += "word "
+	}
+
+	chunks := []*kbtypes.Chunk{
+		{
+			Text:           longText,
+			FilePath:       "test.md",
+			Section:        "Test Section",
+			ProjectName:    "Test",
+			ProjectVersion: "1.0",
+		},
+	}
+
+	err := eg.generateOllamaEmbeddings(chunks)
+	if err != nil {
+		t.Fatalf("generateOllamaEmbeddings failed: %v", err)
+	}
+
+	// The chunk should have received an embedding via truncation
+	if len(chunks[0].OllamaEmbedding) == 0 {
+		t.Error("Expected chunk to have Ollama embedding after truncation")
+	}
+
+	// Verify that multiple requests were made (initial failures plus
+	// at least one truncated attempt).
+	if len(requestTexts) < 2 {
+		t.Errorf("Expected multiple requests due to truncation, got %d", len(requestTexts))
+	}
+
+	// Verify that at least one successful request had a shorter text
+	// than the original, confirming that truncation occurred.
+	sawTruncated := false
+	for _, text := range requestTexts {
+		if len(text) > 0 && len(text) < len(longText) {
+			sawTruncated = true
+			break
+		}
+	}
+	if !sawTruncated {
+		t.Error("Expected at least one request with truncated text")
+	}
+}
+
 func TestOllamaContextLengthSkipsChunk(t *testing.T) {
 	// Create a mock Ollama server that always rejects with context length error.
 	// Uses HTTP 400 (non-retryable) to avoid slow backoff retries in tests.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for specifying an Ollama API key file and using it at runtime; requests may include an Authorization bearer header when configured.
* **Chores**
  * CI workflow now provisions the Ollama API key into the build environment used for knowledge-base generation.
* **Documentation**
  * Example configuration includes an optional Ollama api_key_file entry (commented).
* **Tests**
  * Provider tests updated to match the new Ollama request/response and error-retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->