### PR TITLE
sync: fix kb-builder drift against SSOT

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -86,18 +86,18 @@ sources:
       project_name: "pg_cron"
       project_version: "1.6.7"
 
-    - git_url: "git@github.com:pgEdge/pgedge-docs.git"
+    - git_url: "https://github.com/pgEdge/pgedge-docs.git"
       branch: "main"
       doc_path: "docs/cloud"
       project_name: "pgEdge Cloud"
       project_version: ""
 
-    - git_url: "git@github.com:pgEdge/pgedge-docs.git"
+    - git_url: "https://github.com/pgEdge/pgedge-docs.git"
       branch: "main"
       doc_path: "docs/platform"
       project_name: "pgEdge Platform"
 
-    - git_url: "git@github.com:pgEdge/pgedge-docs.git"
+    - git_url: "https://github.com/pgEdge/pgedge-docs.git"
       branch: "main"
       doc_path: "docs/enterprise"
       project_name: "pgEdge Enterprise"


### PR DESCRIPTION
## Sources Drift Report — kb-builder

### URL Issues (SSH → HTTPS)

  - **URL** `pgEdge Cloud` — SSH `git@github.com:pgEdge/pgedge-docs.git`, should be HTTPS
  - **URL** `pgEdge Platform` — SSH `git@github.com:pgEdge/pgedge-docs.git`, should be HTTPS
  - **URL** `pgEdge Enterprise` — SSH `git@github.com:pgEdge/pgedge-docs.git`, should be HTTPS

### Extra in consumer (not in SSOT — left as-is)

  - **EXTRA** `pgEdge ACE` — ref `v1.5.5`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.4`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.3`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.2`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.1`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.0`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.4.2`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.4.1`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.4.0`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.3.5`, doc_path `docs` (not in SSOT, left as-is)

### Policy-excluded versions present in consumer (informational)

  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.6.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.3 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.1.0 — beyond max_versions cutoff in SSOT

---
*0 missing, 10 extra, 3 URL issue(s)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation source configuration to use HTTPS for accessing pgEdge repositories instead of SSH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->