### PR TITLE
Fix self-hosted runner: disable osxkeychain and clean stale build art…

### DIFF
--- a/.github/workflows/release-kb.yml
+++ b/.github/workflows/release-kb.yml
@@ -25,6 +25,9 @@ jobs:
                   ref: ${{ github.event.inputs.branch }}
                   fetch-depth: 0
 
+            - name: Clean build artifacts from previous runs
+              run: rm -rf bin/ pgedge-nla-kb-builder examples/pgedge-nla-kb-builder-build.yaml
+
             - name: Validate allowed build ref
               env:
                   BUILD_REF: ${{ github.event.inputs.branch }}
@@ -46,6 +49,7 @@ jobs:
               run: |
                   [ -n "$PGEDGE_BUILDER_TOKEN" ] || { echo "PGEDGE_BUILDER_TOKEN secret is missing"; exit 1; }
                   echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+                  GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig" git config --global credential.helper ""
                   GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig" git config --global url."https://x-access-token:${PGEDGE_BUILDER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
             - name: Start Ollama service

--- a/.github/workflows/release-kb.yml
+++ b/.github/workflows/release-kb.yml
@@ -49,6 +49,7 @@ jobs:
               run: |
                   [ -n "$PGEDGE_BUILDER_TOKEN" ] || { echo "PGEDGE_BUILDER_TOKEN secret is missing"; exit 1; }
                   echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+                  printf '' > "$RUNNER_TEMP/gitconfig"
                   GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig" git config --global credential.helper ""
                   GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig" git config --global url."https://x-access-token:${PGEDGE_BUILDER_TOKEN}@github.com/".insteadOf "https://github.com/"
 


### PR DESCRIPTION
…ifacts before each run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build workflow now automatically cleans up previous build outputs and generated build config before each run, ensuring a consistently fresh workspace and reducing build artifacts.
  * Deployment process improves handling of git configuration for private repository access, resetting temporary settings and unsetting credential helpers to avoid stale credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->