### PR TITLE
fix(http): return 202 Accepted with empty body for JSON-RPC notifications

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,15 @@ and this project adheres to
 
 ### Fixed
 
+- HTTP transport now returns `202 Accepted` with an empty body for
+  JSON-RPC notifications, per JSON-RPC 2.0 §4.1 and the MCP streamable
+  HTTP transport spec. Previously, the server replied to notifications
+  with a `200 OK` response that had no `id` field, which is itself not
+  a valid JSON-RPC message and caused strict clients (such as the .NET
+  MCP SDK) to throw on every notification. Unknown notification methods
+  are now also acknowledged silently rather than receiving a `-32601`
+  error reply. (#142)
+
 - Database switching via `select_database_connection` now persists
   correctly in HTTP mode for unbound API tokens.
   `GetAccessibleDatabases` previously returned only the first

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -189,6 +189,12 @@ func (s *Server) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Detect a JSON-RPC notification: a Request object without an "id" member
+	// (per JSON-RPC 2.0 §4.1). Note that "id": null is a valid request id and
+	// is NOT a notification, so we must inspect the raw JSON — interface{}
+	// unmarshaling collapses "absent" and "null" to the same nil value.
+	isNotification := !hasIDField(body)
+
 	// Set up tracing context
 	tokenHash := auth.GetTokenHashFromContext(ctx)
 	sessionID := tokenHash
@@ -205,12 +211,30 @@ func (s *Server) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Debug logging: log incoming request
 	if s.debug {
-		fmt.Fprintf(os.Stderr, "[DEBUG] Incoming request: method=%s id=%v ip=%s\n", req.Method, req.ID, ipAddress)
+		fmt.Fprintf(os.Stderr, "[DEBUG] Incoming request: method=%s id=%v ip=%s notification=%t\n",
+			req.Method, req.ID, ipAddress, isNotification)
 		if req.Params != nil {
 			if paramsJSON, err := json.Marshal(req.Params); err == nil {
 				fmt.Fprintf(os.Stderr, "[DEBUG] Request params: %s\n", string(paramsJSON))
 			}
 		}
+	}
+
+	// Per JSON-RPC 2.0 §4.1 ("The Server MUST NOT reply to a Notification")
+	// and the MCP streamable HTTP transport spec ("If the input consists
+	// solely of (any number of) JSON-RPC responses or notifications: ...
+	// the server MUST return HTTP status code 202 Accepted with no body"),
+	// short-circuit notifications before dispatch. This applies uniformly
+	// to known notification methods (e.g. notifications/initialized) and
+	// unknown ones — replying with -32601 Method not found to a
+	// notification would be doubly wrong (replying when forbidden, and
+	// replying without an id, which is itself a malformed JSON-RPC body).
+	if isNotification {
+		tracing.LogHTTPResponse(sessionID, tokenHash, requestID,
+			r.Method, "/mcp/v1", http.StatusAccepted, nil,
+			time.Since(httpStart))
+		w.WriteHeader(http.StatusAccepted)
+		return
 	}
 
 	// Handle the request and capture the response (pass context with IP address)
@@ -236,18 +260,16 @@ func (s *Server) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleRequestHTTP handles a JSON-RPC request and returns the response
+// handleRequestHTTP handles a JSON-RPC request and returns the response.
+//
+// Notifications (requests without an "id" member, per JSON-RPC 2.0 §4.1) are
+// filtered out by handleHTTPRequest before reaching this function and are
+// answered with 202 Accepted and an empty body. As a result, every dispatch
+// path here corresponds to a request that requires a response.
 func (s *Server) handleRequestHTTP(ctx context.Context, req JSONRPCRequest) JSONRPCResponse {
 	switch req.Method {
 	case "initialize":
 		return s.handleInitializeHTTP(req)
-	case "notifications/initialized":
-		// Client notification - return empty response
-		return JSONRPCResponse{
-			JSONRPC: "2.0",
-			ID:      req.ID,
-			Result:  json.RawMessage(`{}`),
-		}
 	case "tools/list":
 		return s.handleToolsListHTTP(ctx, req)
 	case "tools/call":
@@ -545,6 +567,21 @@ func (s *Server) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 // Helper functions
+
+// hasIDField reports whether the given raw JSON-RPC message body has an "id"
+// member at its top level. This is used to distinguish a JSON-RPC notification
+// (no id member) from a request whose id is explicitly null — the JSON-RPC 2.0
+// spec treats these very differently, but Go's interface{} unmarshaling
+// collapses both to nil. We probe the raw bytes via json.RawMessage so we do
+// not have to re-parse the entire payload.
+func hasIDField(body []byte) bool {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return false
+	}
+	_, ok := probe["id"]
+	return ok
+}
 
 func sendHTTPError(w http.ResponseWriter, id interface{}, code int, message string, data interface{}) {
 	response := createErrorResponse(id, code, message, data)

--- a/internal/mcp/http_server_test.go
+++ b/internal/mcp/http_server_test.go
@@ -786,26 +786,75 @@ func TestHandleNotificationsInitialized(t *testing.T) {
 	tools := &mockToolProvider{}
 	server := NewServer(tools)
 
-	rpcReq := JSONRPCRequest{
-		JSONRPC: "2.0",
-		ID:      1,
-		Method:  "notifications/initialized",
-	}
-
-	body, _ := json.Marshal(rpcReq)
+	// A real JSON-RPC notification has NO "id" member (per §4.1). The server
+	// must respond with 202 Accepted and an empty body.
+	body := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 
 	server.handleHTTPRequest(w, req)
 
+	if w.Code != http.StatusAccepted {
+		t.Errorf("expected status 202 Accepted for a notification, got %d", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty body for a notification, got %q", w.Body.String())
+	}
+}
+
+func TestHandleNotification_UnknownMethod(t *testing.T) {
+	// Per the issue, sending -32601 Method not found in response to a
+	// notification is doubly wrong: the server must not reply at all, and
+	// the reply has no id (which is itself a malformed JSON-RPC body).
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	for _, method := range []string{
+		"notifications/cancelled",
+		"notifications/roots/list_changed",
+		"some/unknown/notification",
+	} {
+		t.Run(method, func(t *testing.T) {
+			body := []byte(`{"jsonrpc":"2.0","method":"` + method + `","params":{}}`)
+			req := httptest.NewRequest(http.MethodPost, "/mcp/v1", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+
+			server.handleHTTPRequest(w, req)
+
+			if w.Code != http.StatusAccepted {
+				t.Errorf("expected status 202 Accepted, got %d", w.Code)
+			}
+			if w.Body.Len() != 0 {
+				t.Errorf("expected empty body, got %q", w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleNotification_NullIDIsRequest(t *testing.T) {
+	// JSON-RPC 2.0 distinguishes "id absent" (notification, no reply) from
+	// "id: null" (a request whose id happens to be null; reply required).
+	// A request with explicit null id targeting an unknown method must
+	// receive a -32601 response with id == null, not 202 Accepted.
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	body := []byte(`{"jsonrpc":"2.0","id":null,"method":"unknown/method"}`)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	server.handleHTTPRequest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for a request with null id, got %d", w.Code)
+	}
+
 	var response JSONRPCResponse
 	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-
-	// Should return empty response without error
-	if response.Error != nil {
-		t.Fatalf("unexpected error: %v", response.Error)
+	if response.Error == nil || response.Error.Code != -32601 {
+		t.Errorf("expected -32601 Method not found, got %+v", response.Error)
 	}
 }
 


### PR DESCRIPTION
Per JSON-RPC 2.0 §4.1, the server MUST NOT reply to a Notification (a Request object without an "id" member). Per the MCP streamable HTTP transport spec, the server MUST return 202 Accepted with no body for notifications. The previous behavior returned a 200 with a JSON-RPC Response/Error body that had no "id" field — which is itself not a valid JSON-RPC message and causes strict clients (e.g. the .NET MCP SDK polymorphic JsonRpcMessage converter) to throw on every notification.

Changes:
- handleHTTPRequest now inspects the raw request body for the presence of an "id" member and short-circuits notifications before dispatch, responding with 202 and an empty body. This applies uniformly to known notification methods (notifications/initialized) and unknown ones, closing the secondary bug where unknown notifications received a -32601 "Method not found" reply.
- Introduced hasIDField helper to distinguish "id absent" (notification, no reply) from "id": null (a request, must reply) — Go's interface{} unmarshaling collapses both to nil.
- Removed the now-dead notifications/initialized case in the dispatch switch; notifications no longer reach handleRequestHTTP.
- Updated TestHandleNotificationsInitialized to assert 202 + empty body for a real notification (the previous version sent an id, exercising the buggy path it claimed to verify).
- Added TestHandleNotification_UnknownMethod (covers /cancelled, /roots/list_changed, and any unknown notification) and TestHandleNotification_NullIDIsRequest (regression guard ensuring "id": null is treated as a request, not a notification).

Fixes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON-RPC notifications now return HTTP 202 Accepted with an empty body.
  * Better distinction between notifications (no id) and requests with explicit id: null.
  * Unknown notification methods are acknowledged silently (no error reply).

* **New Features**
  * Schema metadata cache now auto-refreshes with a configurable TTL (default: 5 minutes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->