### PR TITLE
fix(database): tolerate NULL columns in metadata LEFT JOIN

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,17 @@ and this project adheres to
 
 ### Fixed
 
+- Metadata loader now tolerates tables with zero columns
+  (e.g. `CREATE TABLE foo()`). The query LEFT JOINs against the
+  per-column catalog, so a zero-column table produced a row whose
+  `column_name`, `data_type`, and `is_nullable` were all NULL; the
+  scan declared those targets as plain `string` and aborted with
+  `cannot scan NULL into *string`, failing the entire metadata load
+  and surfacing as the misleading `no database connection
+  configured for this token` error. The three columns are now
+  scanned as `sql.NullString` and zero-column tables appear in the
+  metadata with an empty `Columns` slice. (#126)
+
 - Database switching via `select_database_connection` now persists
   correctly in HTTP mode for unbound API tokens.
   `GetAccessibleDatabases` previously returned only the first

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -482,7 +482,13 @@ func (c *Client) LoadMetadataFor(connStr string) error {
 	columnCount := 0
 
 	for rows.Next() {
-		var schemaName, tableName, tableType, tableDesc, columnName, dataType, isNullable, columnDesc string
+		// columnName, dataType, and isNullable come from the LEFT JOIN against
+		// column_info; they are NULL for tables that have zero columns
+		// (e.g. CREATE TABLE foo();). Scan them as NullString so the row
+		// scan does not abort the entire metadata load — the row is then
+		// skipped below by the columnName.Valid check. See issue #126.
+		var schemaName, tableName, tableType, tableDesc, columnDesc string
+		var columnName, dataType, isNullable sql.NullString
 		var isPartitioned, isPartition bool
 		var typeName sql.NullString
 		var typeModifier sql.NullInt32
@@ -512,7 +518,7 @@ func (c *Client) LoadMetadataFor(connStr string) error {
 			}
 		}
 
-		if columnName != "" {
+		if columnName.Valid && columnName.String != "" {
 			// Detect vector columns and extract dimensions
 			isVector := false
 			dimensions := 0
@@ -520,7 +526,7 @@ func (c *Client) LoadMetadataFor(connStr string) error {
 				isVector = true
 				// Parse dimensions from data_type (e.g., "vector(1536)")
 				re := regexp.MustCompile(`vector\((\d+)\)`)
-				if matches := re.FindStringSubmatch(dataType); len(matches) > 1 {
+				if matches := re.FindStringSubmatch(dataType.String); len(matches) > 1 {
 					if dim, err := strconv.Atoi(matches[1]); err == nil {
 						dimensions = dim
 					}
@@ -528,9 +534,9 @@ func (c *Client) LoadMetadataFor(connStr string) error {
 			}
 
 			table.Columns = append(table.Columns, ColumnInfo{
-				ColumnName:       columnName,
-				DataType:         dataType,
-				IsNullable:       isNullable,
+				ColumnName:       columnName.String,
+				DataType:         dataType.String,
+				IsNullable:       isNullable.String,
 				Description:      columnDesc,
 				IsPrimaryKey:     isPrimaryKey,
 				IsUnique:         isUnique,

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -11,6 +11,8 @@
 package database
 
 import (
+	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -471,4 +473,75 @@ func searchString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestLoadMetadata_TableWithNoColumns is a regression test for issue #126.
+//
+// Before the fix, LoadMetadata's row scan declared columnName/dataType/
+// isNullable as plain string. The metadata query LEFT JOINs against
+// column_info, so a table with zero columns (e.g. CREATE TABLE foo()) yields
+// a row whose ci.* fields are all NULL — pgx then aborts the row scan with
+// "cannot scan NULL into *string", failing the entire metadata load and
+// surfacing as the misleading "no database connection configured" error.
+//
+// This test creates such a table, loads metadata, and asserts that the load
+// succeeds and that the empty table is present in the metadata with zero
+// columns. It is gated on TEST_PGEDGE_POSTGRES_CONNECTION_STRING, matching
+// the convention used by tests in the test/ package.
+func TestLoadMetadata_TableWithNoColumns(t *testing.T) {
+	connStr := os.Getenv("TEST_PGEDGE_POSTGRES_CONNECTION_STRING")
+	if connStr == "" {
+		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set; skipping live-DB regression test for issue #126")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Use a dedicated pool to set up and tear down the fixture so we do not
+	// interfere with whatever the Client builds internally.
+	setupPool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("failed to open setup pool: %v", err)
+	}
+	defer setupPool.Close()
+
+	const tableName = "pgedge_mcp_issue126_empty"
+	if _, err := setupPool.Exec(ctx, "DROP TABLE IF EXISTS public."+tableName); err != nil {
+		t.Fatalf("failed to drop preexisting fixture table: %v", err)
+	}
+	if _, err := setupPool.Exec(ctx, "CREATE TABLE public."+tableName+"()"); err != nil {
+		t.Fatalf("failed to create empty-columns fixture table: %v", err)
+	}
+	defer func() {
+		_, _ = setupPool.Exec(context.Background(), "DROP TABLE IF EXISTS public."+tableName)
+	}()
+
+	client := NewClientWithConnectionString(connStr, nil)
+	defer client.Close()
+
+	if err := client.ConnectTo(connStr); err != nil {
+		t.Fatalf("ConnectTo failed: %v", err)
+	}
+
+	if err := client.LoadMetadataFor(connStr); err != nil {
+		t.Fatalf("LoadMetadataFor returned error for database containing a zero-column table; this is the regression in issue #126: %v", err)
+	}
+
+	meta := client.GetMetadataFor(connStr)
+	key := "public." + tableName
+	tableInfo, ok := meta[key]
+	if !ok {
+		t.Fatalf("expected metadata to contain %q, got keys: %v", key, mapKeys(meta))
+	}
+	if len(tableInfo.Columns) != 0 {
+		t.Errorf("expected empty-columns table to have 0 columns, got %d", len(tableInfo.Columns))
+	}
+}
+
+func mapKeys(m map[string]TableInfo) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
The metadata loader's main query LEFT JOINs the per-table catalog rows against column_info. When the database contains a table with zero columns (e.g. CREATE TABLE empty_columns_test()), the LEFT JOIN produces a row whose ci.column_name, ci.data_type, and ci.is_nullable are all NULL. The row scan declared those targets as plain string, so pgx aborts with:

  failed to scan row: can't scan into dest[6] (col: column_name):
  cannot scan NULL into *string

That single bad row failed the entire metadata load, which surfaced to callers as the misleading 'no database connection configured for this token' error and blocked every tool that depends on metadata (get_schema_info, similarity_search, etc.).

Fix: scan columnName/dataType/isNullable as sql.NullString (matching how typeName is already handled in the same scan) and gate the existing skip-row check on columnName.Valid. Tables with zero columns now appear in the metadata with an empty Columns slice and no longer poison the load.

Adds TestLoadMetadata_TableWithNoColumns, an integration-style regression test that creates an empty-columns table against the database referenced by TEST_PGEDGE_POSTGRES_CONNECTION_STRING (the same env var used elsewhere in this repo) and asserts the load succeeds and the table is present with zero columns. Skipped when the env var is unset.

Fixes #126