### PR TITLE
sync: fix kb-builder drift against SSOT

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -86,18 +86,18 @@ sources:
       project_name: "pg_cron"
       project_version: "1.6.7"
 
-    - git_url: "git@github.com:pgEdge/pgedge-docs.git"
+    - git_url: "https://github.com/pgEdge/pgedge-docs.git"
       branch: "main"
       doc_path: "docs/cloud"
       project_name: "pgEdge Cloud"
       project_version: ""
 
-    - git_url: "git@github.com:pgEdge/pgedge-docs.git"
+    - git_url: "https://github.com/pgEdge/pgedge-docs.git"
       branch: "main"
       doc_path: "docs/platform"
       project_name: "pgEdge Platform"
 
-    - git_url: "git@github.com:pgEdge/pgedge-docs.git"
+    - git_url: "https://github.com/pgEdge/pgedge-docs.git"
       branch: "main"
       doc_path: "docs/enterprise"
       project_name: "pgEdge Enterprise"
@@ -502,3 +502,11 @@ embeddings:
 # - For Git sources, you can specify either 'branch' or 'tag', not both
 # - Supported document formats: Markdown (.md), HTML (.html, .htm),
 #   reStructuredText (.rst), SGML (.sgml, .sgm), DocBook XML (.xml)
+
+    # Spock — added by auto/sync-kb-builder
+
+    - git_url: "https://github.com/pgEdge/spock.git"
+      tag: "v5.0.7"
+      doc_path: "docs"
+      project_name: "Spock"
+      project_version: "5.0.7"


### PR DESCRIPTION
## Sources Drift Report — kb-builder

### URL Issues (SSH → HTTPS)

  - **URL** `pgEdge Cloud` — SSH `git@github.com:pgEdge/pgedge-docs.git`, should be HTTPS
  - **URL** `pgEdge Platform` — SSH `git@github.com:pgEdge/pgedge-docs.git`, should be HTTPS
  - **URL** `pgEdge Enterprise` — SSH `git@github.com:pgEdge/pgedge-docs.git`, should be HTTPS

### Missing from consumer (in SSOT, absent here)

  - **MISSING** `spock-507` (Spock 5.0.7) — ref `v5.0.7`, doc_path `docs`

### Extra in consumer (not in SSOT — left as-is)

  - **EXTRA** `pgEdge ACE` — ref `v1.5.5`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.4`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.3`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.2`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.1`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.0`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.4.2`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.4.1`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.4.0`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.3.5`, doc_path `docs` (not in SSOT, left as-is)

### Policy-excluded versions present in consumer (informational)

  - **POLICY-EXCLUDED** `Spock` v5.0.4 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.6.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.3 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.1.0 — beyond max_versions cutoff in SSOT

---
*1 missing, 10 extra, 3 URL issue(s)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation sources to use HTTPS URLs
  * Added Cloud and Platform documentation sources
  * Added Spock v5.0.7 documentation source

<!-- end of auto-generated comment: release notes by coderabbit.ai -->