### PR TITLE
sync: fix kb-builder drift against SSOT

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -63,6 +63,18 @@ sources:
       project_version: "1.0.0-beta1"
 
     - git_url: "https://github.com/pgEdge/3rd-party-docs.git"
+      branch: "patroni413"
+      doc_path: "docs"
+      project_name: "patroni"
+      project_version: "4.1.3"
+
+    - git_url: "https://github.com/pgEdge/3rd-party-docs.git"
+      branch: "patroni412"
+      doc_path: "docs"
+      project_name: "patroni"
+      project_version: "4.1.2"
+
+    - git_url: "https://github.com/pgEdge/3rd-party-docs.git"
       branch: "patroni411"
       doc_path: "docs"
       project_name: "patroni"
@@ -185,6 +197,12 @@ sources:
       doc_path: "docs"
       project_name: "pgEdge Helm"
       project_version: "0.1.0"
+
+    - git_url: "https://github.com/pgEdge/ace.git"
+      tag: "v2.0.0"
+      doc_path: "docs"
+      project_name: "pgEdge ACE"
+      project_version: "2.0.0"
 
     - git_url: "https://github.com/pgEdge/ace.git"
       tag: "v1.9.0"


### PR DESCRIPTION
## Sources Drift Report — kb-builder

### Missing from consumer (in SSOT, absent here)

  - **MISSING** `ace-200` (pgEdge ACE 2.0.0) — ref `v2.0.0`, doc_path `docs`
  - **MISSING** `patroni-413` (patroni 4.1.3) — ref `patroni413`, doc_path `docs`
  - **MISSING** `patroni-412` (patroni 4.1.2) — ref `patroni412`, doc_path `docs`

### Extra in consumer (not in SSOT — left as-is)

  - **EXTRA** `pgEdge ACE` — ref `v1.5.0`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.3.5`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge Radar` — ref `v0.2.1`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge Radar` — ref `v0.2.0`, doc_path `docs` (not in SSOT, left as-is)

### Policy-excluded versions present in consumer (informational)

  - **POLICY-EXCLUDED** `Spock` v5.0.4 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.8.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.6.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.5 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.4 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.3 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.3 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.1.0 — beyond max_versions cutoff in SSOT

---
*3 missing, 4 extra, 0 URL issue(s)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Patroni versions 4.1.3 and 4.1.2 as available documentation sources
  * Added pgEdge ACE version 2.0.0 as an available documentation source

<!-- end of auto-generated comment: release notes by coderabbit.ai -->