### PR TITLE
sync: fix kb-builder drift against SSOT

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -15,7 +15,19 @@ sources:
       project_version: "18"
 
     - git_url: "https://github.com/postgres/postgres.git"
+      tag: "REL_18_4"
+      doc_path: "doc/src/sgml"
+      project_name: "PostgreSQL"
+      project_version: "18"
+
+    - git_url: "https://github.com/postgres/postgres.git"
       tag: "REL_17_9"
+      doc_path: "doc/src/sgml"
+      project_name: "PostgreSQL"
+      project_version: "17"
+
+    - git_url: "https://github.com/postgres/postgres.git"
+      tag: "REL_17_10"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "17"
@@ -27,7 +39,19 @@ sources:
       project_version: "16"
 
     - git_url: "https://github.com/postgres/postgres.git"
+      tag: "REL_16_14"
+      doc_path: "doc/src/sgml"
+      project_name: "PostgreSQL"
+      project_version: "16"
+
+    - git_url: "https://github.com/postgres/postgres.git"
       tag: "REL_15_17"
+      doc_path: "doc/src/sgml"
+      project_name: "PostgreSQL"
+      project_version: "15"
+
+    - git_url: "https://github.com/postgres/postgres.git"
+      tag: "REL_15_18"
       doc_path: "doc/src/sgml"
       project_name: "PostgreSQL"
       project_version: "15"
@@ -38,6 +62,12 @@ sources:
       project_name: "PostgreSQL"
       project_version: "14"
 
+
+    - git_url: "https://github.com/postgres/postgres.git"
+      tag: "REL_14_23"
+      doc_path: "doc/src/sgml"
+      project_name: "PostgreSQL"
+      project_version: "14"
     - git_url: "https://github.com/pgEdge/3rd-party-docs.git"
       branch: "pgadmin913"
       doc_path: "docs"


### PR DESCRIPTION
## Sources Drift Report — kb-builder

### Missing from consumer (in SSOT, absent here)

  - **MISSING** `postgresql-18` (PostgreSQL 18) — ref `REL_18_4`, doc_path `doc/src/sgml`
  - **MISSING** `postgresql-17` (PostgreSQL 17) — ref `REL_17_10`, doc_path `doc/src/sgml`
  - **MISSING** `postgresql-16` (PostgreSQL 16) — ref `REL_16_14`, doc_path `doc/src/sgml`
  - **MISSING** `postgresql-15` (PostgreSQL 15) — ref `REL_15_18`, doc_path `doc/src/sgml`
  - **MISSING** `postgresql-14` (PostgreSQL 14) — ref `REL_14_23`, doc_path `doc/src/sgml`

### Extra in consumer (not in SSOT — left as-is)

  - **EXTRA** `PostgreSQL` — ref `REL_18_3`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `PostgreSQL` — ref `REL_17_9`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `PostgreSQL` — ref `REL_16_13`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `PostgreSQL` — ref `REL_15_17`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `PostgreSQL` — ref `REL_14_22`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.0`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.3.5`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge Radar` — ref `v0.2.1`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge Radar` — ref `v0.2.0`, doc_path `docs` (not in SSOT, left as-is)

### Policy-excluded versions present in consumer (informational)

  - **POLICY-EXCLUDED** `Spock` v5.0.4 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.8.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.6.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.5 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.4 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.3 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.3 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.1.0 — beyond max_versions cutoff in SSOT

---
*5 missing, 9 extra, 0 URL issue(s)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example configuration to include PostgreSQL documentation sources for additional release versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/pgedge-postgres-mcp/pull/156)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->