### PR TITLE
sync: fix kb-builder drift against SSOT

### DIFF
--- a/examples/pgedge-nla-kb-builder.yaml
+++ b/examples/pgedge-nla-kb-builder.yaml
@@ -199,6 +199,12 @@ sources:
       project_version: "5.0.4"
 
     - git_url: "https://github.com/pgEdge/control-plane.git"
+      tag: "v0.8.1"
+      doc_path: "docs"
+      project_name: "pgEdge Control Plane"
+      project_version: "0.8.1"
+
+    - git_url: "https://github.com/pgEdge/control-plane.git"
       tag: "v0.7.0"
       doc_path: "docs"
       project_name: "pgEdge Control Plane"


### PR DESCRIPTION
## Sources Drift Report — kb-builder

### Missing from consumer (in SSOT, absent here)

  - **MISSING** `pgedge-control-plane-080` (pgEdge Control Plane 0.8.1) — ref `v0.8.1`, doc_path `docs`

### Extra in consumer (not in SSOT — left as-is)

  - **EXTRA** `PostgreSQL` — ref `REL_18_3`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `PostgreSQL` — ref `REL_17_9`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `PostgreSQL` — ref `REL_16_13`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `PostgreSQL` — ref `REL_15_17`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `PostgreSQL` — ref `REL_14_22`, doc_path `doc/src/sgml` (not in SSOT, left as-is)
  - **EXTRA** `Spock` — ref `v5.0.7`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.5.0`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge ACE` — ref `v1.3.5`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge Radar` — ref `v0.2.1`, doc_path `docs` (not in SSOT, left as-is)
  - **EXTRA** `pgEdge Radar` — ref `v0.2.0`, doc_path `docs` (not in SSOT, left as-is)

### Policy-excluded versions present in consumer (informational)

  - **POLICY-EXCLUDED** `Spock` v5.0.4 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Control Plane` v0.6.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.8.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.7.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.6.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.5 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.4 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.3 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.5.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.1 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge ACE` v1.4.0 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.3 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.2.2 — beyond max_versions cutoff in SSOT
  - **POLICY-EXCLUDED** `pgEdge Radar` v0.1.0 — beyond max_versions cutoff in SSOT

---
*1 missing, 10 extra, 0 URL issue(s)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the knowledge base builder with an additional documentation source for a new version of control-plane.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/pgedge-postgres-mcp/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->