### PR TITLE
fix: machine-safe built-in resource name + env vars for builtins (#139)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,26 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Each built-in tool, resource, and prompt can now be enabled or
+  disabled via an environment variable in addition to the
+  `builtins` section of the configuration file. The variables are
+  `PGEDGE_BUILTIN_TOOL_*`, `PGEDGE_BUILTIN_RESOURCE_*`, and
+  `PGEDGE_BUILTIN_PROMPT_*`; see the configuration reference for
+  the complete list. This is useful in containerized deployments
+  where editing the configuration file is awkward. (#139)
+
 ### Changed
+
+- The built-in `pg://system_info` resource now uses the machine-safe
+  name `postgresql_system_info` (previously
+  `"PostgreSQL System Information"`). The new name matches the
+  identifier pattern enforced by Anthropic's tool-name validation
+  (`^[a-zA-Z0-9_-]{1,128}$`), so the resource no longer breaks
+  interoperability when a downstream MCP client forwards built-in
+  capability names as provider tool names. The resource URI is
+  unchanged. (#139)
 
 - The KB Builder (formerly `cmd/kb-builder` and the
   `internal/kb*` packages) has moved to a standalone project at

--- a/docs/developers/mcp-protocol.md
+++ b/docs/developers/mcp-protocol.md
@@ -277,7 +277,7 @@ Get available resources.
     "resources": [
       {
         "uri": "pg://system_info",
-        "name": "PostgreSQL System Information",
+        "name": "postgresql_system_info",
         "description": "Returns PostgreSQL version...",
         "mimeType": "application/json"
       }

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -140,19 +140,19 @@ for details.
 
 | Configuration File Option | CLI Flag | Environment Variable | Description |
 |--------------------------|----------|---------------------|-------------|
-| `builtins.tools.query_database` | N/A | N/A | Enable query_database tool (default: true) |
-| `builtins.tools.get_schema_info` | N/A | N/A | Enable get_schema_info tool (default: true) |
-| `builtins.tools.similarity_search` | N/A | N/A | Enable similarity_search tool (default: true) |
-| `builtins.tools.execute_explain` | N/A | N/A | Enable execute_explain tool (default: true) |
-| `builtins.tools.generate_embedding` | N/A | N/A | Enable generate_embedding tool (default: true) |
-| `builtins.tools.search_knowledgebase` | N/A | N/A | Enable search_knowledgebase tool (default: true) |
-| `builtins.tools.count_rows` | N/A | N/A | Enable count_rows tool (default: true) |
-| `builtins.tools.llm_connection_selection` | N/A | N/A | Enable LLM database switching tools (default: false) |
-| `builtins.resources.system_info` | N/A | N/A | Enable pg://system_info resource (default: true) |
-| `builtins.prompts.explore_database` | N/A | N/A | Enable explore-database prompt (default: true) |
-| `builtins.prompts.setup_semantic_search` | N/A | N/A | Enable setup-semantic-search prompt (default: true) |
-| `builtins.prompts.diagnose_query_issue` | N/A | N/A | Enable diagnose-query-issue prompt (default: true) |
-| `builtins.prompts.design_schema` | N/A | N/A | Enable design-schema prompt (default: true) |
+| `builtins.tools.query_database` | N/A | `PGEDGE_BUILTIN_TOOL_QUERY_DATABASE` | Enable query_database tool (default: true) |
+| `builtins.tools.get_schema_info` | N/A | `PGEDGE_BUILTIN_TOOL_GET_SCHEMA_INFO` | Enable get_schema_info tool (default: true) |
+| `builtins.tools.similarity_search` | N/A | `PGEDGE_BUILTIN_TOOL_SIMILARITY_SEARCH` | Enable similarity_search tool (default: true) |
+| `builtins.tools.execute_explain` | N/A | `PGEDGE_BUILTIN_TOOL_EXECUTE_EXPLAIN` | Enable execute_explain tool (default: true) |
+| `builtins.tools.generate_embedding` | N/A | `PGEDGE_BUILTIN_TOOL_GENERATE_EMBEDDING` | Enable generate_embedding tool (default: true) |
+| `builtins.tools.search_knowledgebase` | N/A | `PGEDGE_BUILTIN_TOOL_SEARCH_KNOWLEDGEBASE` | Enable search_knowledgebase tool (default: true) |
+| `builtins.tools.count_rows` | N/A | `PGEDGE_BUILTIN_TOOL_COUNT_ROWS` | Enable count_rows tool (default: true) |
+| `builtins.tools.llm_connection_selection` | N/A | `PGEDGE_BUILTIN_TOOL_LLM_CONNECTION_SELECTION` | Enable LLM database switching tools (default: false) |
+| `builtins.resources.system_info` | N/A | `PGEDGE_BUILTIN_RESOURCE_SYSTEM_INFO` | Enable pg://system_info resource (default: true) |
+| `builtins.prompts.explore_database` | N/A | `PGEDGE_BUILTIN_PROMPT_EXPLORE_DATABASE` | Enable explore-database prompt (default: true) |
+| `builtins.prompts.setup_semantic_search` | N/A | `PGEDGE_BUILTIN_PROMPT_SETUP_SEMANTIC_SEARCH` | Enable setup-semantic-search prompt (default: true) |
+| `builtins.prompts.diagnose_query_issue` | N/A | `PGEDGE_BUILTIN_PROMPT_DIAGNOSE_QUERY_ISSUE` | Enable diagnose-query-issue prompt (default: true) |
+| `builtins.prompts.design_schema` | N/A | `PGEDGE_BUILTIN_PROMPT_DESIGN_SCHEMA` | Enable design-schema prompt (default: true) |
 
 ### Other Options
 

--- a/docs/guide/feature_config.md
+++ b/docs/guide/feature_config.md
@@ -36,3 +36,37 @@ builtins:
       `select_database_connection` tools that allow the LLM to switch between
       configured databases. Use `allow_llm_switching: false` on individual
       database connections to exclude them from LLM switching.
+
+## Using Environment Variables
+
+Each built-in feature can also be toggled via an environment variable;
+this is convenient for containerized deployments where editing the
+configuration file is awkward. Environment variables take precedence
+over the configuration file.
+
+Accepted truthy values are `true`, `1`, and `yes` (case-insensitive);
+any other non-empty value is treated as false. If the variable is unset,
+the configuration file value (or the built-in default) is used.
+
+| Feature | Environment Variable |
+|---------|---------------------|
+| `query_database` tool | `PGEDGE_BUILTIN_TOOL_QUERY_DATABASE` |
+| `get_schema_info` tool | `PGEDGE_BUILTIN_TOOL_GET_SCHEMA_INFO` |
+| `similarity_search` tool | `PGEDGE_BUILTIN_TOOL_SIMILARITY_SEARCH` |
+| `execute_explain` tool | `PGEDGE_BUILTIN_TOOL_EXECUTE_EXPLAIN` |
+| `generate_embedding` tool | `PGEDGE_BUILTIN_TOOL_GENERATE_EMBEDDING` |
+| `search_knowledgebase` tool | `PGEDGE_BUILTIN_TOOL_SEARCH_KNOWLEDGEBASE` |
+| `count_rows` tool | `PGEDGE_BUILTIN_TOOL_COUNT_ROWS` |
+| `llm_connection_selection` tools | `PGEDGE_BUILTIN_TOOL_LLM_CONNECTION_SELECTION` |
+| `pg://system_info` resource | `PGEDGE_BUILTIN_RESOURCE_SYSTEM_INFO` |
+| `explore-database` prompt | `PGEDGE_BUILTIN_PROMPT_EXPLORE_DATABASE` |
+| `setup-semantic-search` prompt | `PGEDGE_BUILTIN_PROMPT_SETUP_SEMANTIC_SEARCH` |
+| `diagnose-query-issue` prompt | `PGEDGE_BUILTIN_PROMPT_DIAGNOSE_QUERY_ISSUE` |
+| `design-schema` prompt | `PGEDGE_BUILTIN_PROMPT_DESIGN_SCHEMA` |
+
+In the following example, the `pg://system_info` resource is disabled
+for a single container run:
+
+```bash
+PGEDGE_BUILTIN_RESOURCE_SYSTEM_INFO=false ./bin/pgedge-postgres-mcp
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -875,10 +875,26 @@ func setStringFromEnvWithFallback(dest *string, keys ...string) {
 
 // setBoolFromEnv sets a boolean config value from an environment variable if it exists
 // Accepts "true", "1", or "yes" (case-insensitive) as true values
+// parseBoolEnv interprets an environment-variable value as a boolean.
+// "true", "1", and "yes" are true; "false", "0", and "no" are false (all
+// case-insensitive). Any other value is treated as false, but a warning is
+// logged so operators get a diagnostic instead of a silent disable.
+func parseBoolEnv(key, val string) bool {
+	switch strings.ToLower(val) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		log.Printf("WARNING: unrecognised value %q for %s; expected "+
+			"true/false/1/0/yes/no — treating as false", val, key)
+		return false
+	}
+}
+
 func setBoolFromEnv(dest *bool, key string) {
 	if val := os.Getenv(key); val != "" {
-		lower := strings.ToLower(val)
-		*dest = lower == "true" || lower == "1" || lower == "yes"
+		*dest = parseBoolEnv(key, val)
 	}
 }
 
@@ -891,8 +907,7 @@ func setBoolPtrFromEnv(dest **bool, key string) {
 	if val == "" {
 		return
 	}
-	lower := strings.ToLower(val)
-	b := lower == "true" || lower == "1" || lower == "yes"
+	b := parseBoolEnv(key, val)
 	*dest = &b
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -882,6 +882,20 @@ func setBoolFromEnv(dest *bool, key string) {
 	}
 }
 
+// setBoolPtrFromEnv sets a *bool config value from an environment variable if it exists.
+// Pointer-valued booleans distinguish "explicitly set" from "use default", so we only
+// allocate a new bool when the env var is present.
+// Accepts "true", "1", or "yes" (case-insensitive) as true values; everything else is false.
+func setBoolPtrFromEnv(dest **bool, key string) {
+	val := os.Getenv(key)
+	if val == "" {
+		return
+	}
+	lower := strings.ToLower(val)
+	b := lower == "true" || lower == "1" || lower == "yes"
+	*dest = &b
+}
+
 // setIntFromEnv sets an integer config value from an environment variable if it exists
 func setIntFromEnv(dest *int, key string) {
 	if val := os.Getenv(key); val != "" {
@@ -1079,8 +1093,24 @@ func applyEnvironmentVariables(cfg *Config) {
 	// Trace file
 	setStringFromEnv(&cfg.TraceFile, "PGEDGE_TRACE_FILE")
 
-	// Note: Builtins (tools, resources, prompts) are only configurable via
-	// config file, not environment variables
+	// Built-in tools, resources, and prompts.
+	// Useful for containerized deployments where editing the config file is awkward.
+	// Tools
+	setBoolPtrFromEnv(&cfg.Builtins.Tools.QueryDatabase, "PGEDGE_BUILTIN_TOOL_QUERY_DATABASE")
+	setBoolPtrFromEnv(&cfg.Builtins.Tools.GetSchemaInfo, "PGEDGE_BUILTIN_TOOL_GET_SCHEMA_INFO")
+	setBoolPtrFromEnv(&cfg.Builtins.Tools.SimilaritySearch, "PGEDGE_BUILTIN_TOOL_SIMILARITY_SEARCH")
+	setBoolPtrFromEnv(&cfg.Builtins.Tools.ExecuteExplain, "PGEDGE_BUILTIN_TOOL_EXECUTE_EXPLAIN")
+	setBoolPtrFromEnv(&cfg.Builtins.Tools.GenerateEmbedding, "PGEDGE_BUILTIN_TOOL_GENERATE_EMBEDDING")
+	setBoolPtrFromEnv(&cfg.Builtins.Tools.SearchKnowledgebase, "PGEDGE_BUILTIN_TOOL_SEARCH_KNOWLEDGEBASE")
+	setBoolPtrFromEnv(&cfg.Builtins.Tools.CountRows, "PGEDGE_BUILTIN_TOOL_COUNT_ROWS")
+	setBoolPtrFromEnv(&cfg.Builtins.Tools.LLMConnectionSelection, "PGEDGE_BUILTIN_TOOL_LLM_CONNECTION_SELECTION")
+	// Resources
+	setBoolPtrFromEnv(&cfg.Builtins.Resources.SystemInfo, "PGEDGE_BUILTIN_RESOURCE_SYSTEM_INFO")
+	// Prompts
+	setBoolPtrFromEnv(&cfg.Builtins.Prompts.ExploreDatabase, "PGEDGE_BUILTIN_PROMPT_EXPLORE_DATABASE")
+	setBoolPtrFromEnv(&cfg.Builtins.Prompts.SetupSemanticSearch, "PGEDGE_BUILTIN_PROMPT_SETUP_SEMANTIC_SEARCH")
+	setBoolPtrFromEnv(&cfg.Builtins.Prompts.DiagnoseQueryIssue, "PGEDGE_BUILTIN_PROMPT_DIAGNOSE_QUERY_ISSUE")
+	setBoolPtrFromEnv(&cfg.Builtins.Prompts.DesignSchema, "PGEDGE_BUILTIN_PROMPT_DESIGN_SCHEMA")
 }
 
 // applyCLIFlags overrides config with CLI flags if they were explicitly set

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -870,6 +870,19 @@ func TestSetBoolPtrFromEnv(t *testing.T) {
 			t.Errorf("expected false (override), got true")
 		}
 	})
+
+	t.Run("unrecognised value is treated as false", func(t *testing.T) {
+		os.Setenv(key, "enabled")
+		defer os.Unsetenv(key)
+		var dest *bool
+		setBoolPtrFromEnv(&dest, key)
+		if dest == nil {
+			t.Fatal("expected non-nil pointer for unrecognised value")
+		}
+		if *dest {
+			t.Errorf("expected false for unrecognised value, got true")
+		}
+	})
 }
 
 func TestApplyEnvironmentVariables_Builtins(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -813,6 +813,117 @@ func TestSetBoolFromEnv(t *testing.T) {
 	os.Unsetenv("TEST_BOOL_VAR")
 }
 
+func TestSetBoolPtrFromEnv(t *testing.T) {
+	const key = "TEST_BOOL_PTR_VAR"
+
+	t.Run("unset leaves nil pointer", func(t *testing.T) {
+		os.Unsetenv(key)
+		var dest *bool
+		setBoolPtrFromEnv(&dest, key)
+		if dest != nil {
+			t.Errorf("expected dest to remain nil when env var unset, got %v", *dest)
+		}
+	})
+
+	truthy := []string{"true", "TRUE", "True", "1", "yes", "YES"}
+	for _, v := range truthy {
+		t.Run("truthy_"+v, func(t *testing.T) {
+			os.Setenv(key, v)
+			defer os.Unsetenv(key)
+			var dest *bool
+			setBoolPtrFromEnv(&dest, key)
+			if dest == nil {
+				t.Fatalf("expected non-nil pointer for value %q", v)
+			}
+			if !*dest {
+				t.Errorf("expected true for value %q, got false", v)
+			}
+		})
+	}
+
+	falsy := []string{"false", "0", "no", "anything-else"}
+	for _, v := range falsy {
+		t.Run("falsy_"+v, func(t *testing.T) {
+			os.Setenv(key, v)
+			defer os.Unsetenv(key)
+			var dest *bool
+			setBoolPtrFromEnv(&dest, key)
+			if dest == nil {
+				t.Fatalf("expected non-nil pointer for value %q", v)
+			}
+			if *dest {
+				t.Errorf("expected false for value %q, got true", v)
+			}
+		})
+	}
+
+	t.Run("overrides existing pointer", func(t *testing.T) {
+		os.Setenv(key, "false")
+		defer os.Unsetenv(key)
+		existing := true
+		dest := &existing
+		setBoolPtrFromEnv(&dest, key)
+		if dest == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *dest {
+			t.Errorf("expected false (override), got true")
+		}
+	})
+}
+
+func TestApplyEnvironmentVariables_Builtins(t *testing.T) {
+	envVars := []string{
+		"PGEDGE_BUILTIN_TOOL_QUERY_DATABASE",
+		"PGEDGE_BUILTIN_TOOL_GET_SCHEMA_INFO",
+		"PGEDGE_BUILTIN_TOOL_SIMILARITY_SEARCH",
+		"PGEDGE_BUILTIN_TOOL_EXECUTE_EXPLAIN",
+		"PGEDGE_BUILTIN_TOOL_GENERATE_EMBEDDING",
+		"PGEDGE_BUILTIN_TOOL_SEARCH_KNOWLEDGEBASE",
+		"PGEDGE_BUILTIN_TOOL_COUNT_ROWS",
+		"PGEDGE_BUILTIN_TOOL_LLM_CONNECTION_SELECTION",
+		"PGEDGE_BUILTIN_RESOURCE_SYSTEM_INFO",
+		"PGEDGE_BUILTIN_PROMPT_EXPLORE_DATABASE",
+		"PGEDGE_BUILTIN_PROMPT_SETUP_SEMANTIC_SEARCH",
+		"PGEDGE_BUILTIN_PROMPT_DIAGNOSE_QUERY_ISSUE",
+		"PGEDGE_BUILTIN_PROMPT_DESIGN_SCHEMA",
+	}
+	for _, k := range envVars {
+		t.Setenv(k, "false")
+	}
+
+	cfg := defaultConfig()
+	applyEnvironmentVariables(cfg)
+
+	checks := []struct {
+		name string
+		ptr  *bool
+	}{
+		{"QueryDatabase", cfg.Builtins.Tools.QueryDatabase},
+		{"GetSchemaInfo", cfg.Builtins.Tools.GetSchemaInfo},
+		{"SimilaritySearch", cfg.Builtins.Tools.SimilaritySearch},
+		{"ExecuteExplain", cfg.Builtins.Tools.ExecuteExplain},
+		{"GenerateEmbedding", cfg.Builtins.Tools.GenerateEmbedding},
+		{"SearchKnowledgebase", cfg.Builtins.Tools.SearchKnowledgebase},
+		{"CountRows", cfg.Builtins.Tools.CountRows},
+		{"LLMConnectionSelection", cfg.Builtins.Tools.LLMConnectionSelection},
+		{"SystemInfo", cfg.Builtins.Resources.SystemInfo},
+		{"ExploreDatabase", cfg.Builtins.Prompts.ExploreDatabase},
+		{"SetupSemanticSearch", cfg.Builtins.Prompts.SetupSemanticSearch},
+		{"DiagnoseQueryIssue", cfg.Builtins.Prompts.DiagnoseQueryIssue},
+		{"DesignSchema", cfg.Builtins.Prompts.DesignSchema},
+	}
+	for _, c := range checks {
+		if c.ptr == nil {
+			t.Errorf("%s: expected non-nil pointer after env var override", c.name)
+			continue
+		}
+		if *c.ptr {
+			t.Errorf("%s: expected false after env var override, got true", c.name)
+		}
+	}
+}
+
 func TestParseHostEntries(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/resources/context_aware_registry.go
+++ b/internal/resources/context_aware_registry.go
@@ -58,7 +58,7 @@ func (r *ContextAwareRegistry) List() []mcp.Resource {
 	if r.cfg.Builtins.Resources.IsResourceEnabled(URISystemInfo) {
 		resources = append(resources, mcp.Resource{
 			URI:         URISystemInfo,
-			Name:        "PostgreSQL System Information",
+			Name:        "postgresql_system_info",
 			Description: "Returns PostgreSQL version, operating system, and build architecture information. Provides a quick way to check server version and platform details.",
 			MimeType:    "application/json",
 		})

--- a/internal/resources/pg_system_info.go
+++ b/internal/resources/pg_system_info.go
@@ -25,7 +25,7 @@ func PGSystemInfoResource(dbClient *database.Client) Resource {
 	return Resource{
 		Definition: mcp.Resource{
 			URI:  URISystemInfo,
-			Name: "PostgreSQL System Information",
+			Name: "postgresql_system_info",
 			Description: `PostgreSQL server metadata: version, OS, architecture, connection details.
 
 <usecase>

--- a/internal/tools/read_resource_test.go
+++ b/internal/tools/read_resource_test.go
@@ -42,7 +42,7 @@ func TestReadResourceTool(t *testing.T) {
 			resources: []mcp.Resource{
 				{
 					URI:         "pg://system_info",
-					Name:        "PostgreSQL System Information",
+					Name:        "postgresql_system_info",
 					Description: "Returns version and system info",
 					MimeType:    "application/json",
 				},
@@ -72,7 +72,7 @@ func TestReadResourceTool(t *testing.T) {
 		if !strings.Contains(content, "pg://system_info") {
 			t.Error("Expected 'pg://system_info' URI")
 		}
-		if !strings.Contains(content, "PostgreSQL System Information") {
+		if !strings.Contains(content, "postgresql_system_info") {
 			t.Error("Expected system info resource name")
 		}
 	})


### PR DESCRIPTION
## Summary

- Rename the built-in `pg://system_info` resource from
  `"PostgreSQL System Information"` to `postgresql_system_info` so the
  name matches the identifier pattern enforced by Anthropic's
  tool-name validation (`^[a-zA-Z0-9_-]{1,128}$`). Downstream MCP
  clients that forward built-in capability names as provider tool
  names (e.g. Nanobot -> Claude) were rejecting the original name
  because of the embedded spaces. The resource URI is unchanged.
- Add `PGEDGE_BUILTIN_TOOL_*`, `PGEDGE_BUILTIN_RESOURCE_*`, and
  `PGEDGE_BUILTIN_PROMPT_*` environment variables for toggling
  individual built-ins, which the issue called out as useful for
  containerized deployments where editing the config file is awkward.
- Update docs (`configuration.md`, `feature_config.md`,
  `mcp-protocol.md`, `changelog.md`) and tests.

## Test plan

- [x] `go test ./...` (unit tests pass — integration tests under
  `./test/` require a working postgres and were already failing
  locally without one)
- [x] `make lint-server` (0 issues)
- [x] `gofmt -l .` (clean)
- [x] New unit tests cover `setBoolPtrFromEnv` and verify
  `applyEnvironmentVariables` wires every builtin env var
- [x] Integration server output shows the renamed resource:
  `"name":"postgresql_system_info"`

Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Built-in tools, resources, and prompts can now be enabled or disabled via environment variables, providing more flexible configuration options alongside the configuration file.

* **Documentation**
  * Updated configuration guides with comprehensive environment variable mappings for all built-in features.
  * Standardized naming conventions for built-in resources to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->