### PR TITLE
fix(stdio): treat "id": null as a request, not a notification

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -55,6 +55,17 @@ and this project adheres to
   loop, using the same `hasIDField` raw-bytes probe introduced for the
   HTTP transport in #142. (#152)
 
+- JSON-RPC response now always serializes the `id` field, including
+  when it is null. Per JSON-RPC 2.0 §5.1, the response object MUST
+  include the id member; the value is the originating request's id, or
+  null when the id cannot be determined (parse error / invalid
+  request) or when the request itself used `"id": null`. The
+  `JSONRPCResponse.ID` JSON tag previously used `omitempty`, which
+  caused Go's encoder to drop the field for nil interface values —
+  producing a response without an `id` field, which is itself a
+  malformed JSON-RPC body. This affects both the HTTP and stdio
+  transports. (#152)
+
 - Database switching via `select_database_connection` now persists
   correctly in HTTP mode for unbound API tokens.
   `GetAccessibleDatabases` previously returned only the first

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,17 @@ and this project adheres to
   are now also acknowledged silently rather than receiving a `-32601`
   error reply. (#142)
 
+- Stdio transport now correctly distinguishes JSON-RPC notifications
+  (no `id` member) from requests with an explicit `"id": null` (per
+  JSON-RPC 2.0 §4.1). A request with `"id": null` targeting an unknown
+  method previously matched the same `req.ID == nil` guard used to
+  suppress notification replies and was silently dropped; it now
+  receives the required `-32601 Method not found` response. The
+  hardcoded `notifications/initialized` case was likewise affected and
+  is now filtered uniformly with all other notifications at the read
+  loop, using the same `hasIDField` raw-bytes probe introduced for the
+  HTTP transport in #142. (#152)
+
 - Database switching via `select_database_connection` now persists
   correctly in HTTP mode for unbound API tokens.
   `GetAccessibleDatabases` previously returned only the first

--- a/internal/mcp/http_server_test.go
+++ b/internal/mcp/http_server_test.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -849,8 +850,17 @@ func TestHandleNotification_NullIDIsRequest(t *testing.T) {
 		t.Fatalf("expected status 200 for a request with null id, got %d", w.Code)
 	}
 
+	// Per JSON-RPC 2.0 §5.1 the response object MUST include the id
+	// member; for a request with explicit "id": null the response id
+	// is also null. Verify on the raw bytes because Decode into
+	// JSONRPCResponse cannot distinguish absent id from id: null.
+	raw := w.Body.String()
+	if !strings.Contains(raw, `"id":null`) {
+		t.Errorf("expected response to include `\"id\":null`, got %q", raw)
+	}
+
 	var response JSONRPCResponse
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+	if err := json.Unmarshal([]byte(raw), &response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 	if response.Error == nil || response.Error.Code != -32601 {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -220,10 +220,11 @@ func (s *Server) handleInitialize(req JSONRPCRequest) {
 	sendResponse(req.ID, result)
 }
 
+// handlePing replies with the standard empty-object result. Notifications
+// are filtered out by Run before reaching dispatch, so every ping that
+// arrives here is a request requiring a response — including one whose
+// id is explicitly null.
 func (s *Server) handlePing(req JSONRPCRequest) {
-	// Notifications are filtered out by Run before reaching dispatch, so
-	// every ping that arrives here is a request requiring a response —
-	// including one whose id is explicitly null.
 	sendResponse(req.ID, map[string]interface{}{})
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -110,14 +110,25 @@ func (s *Server) Run() error {
 	scanner.Buffer(make([]byte, 0, ScannerInitialBufferSize), ScannerMaxBufferSize)
 
 	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
+		line := scanner.Bytes()
+		if len(line) == 0 {
 			continue
 		}
 
 		var req JSONRPCRequest
-		if err := json.Unmarshal([]byte(line), &req); err != nil {
+		if err := json.Unmarshal(line, &req); err != nil {
 			sendError(nil, -32700, "Parse error", err.Error())
+			continue
+		}
+
+		// Per JSON-RPC 2.0 §4.1, a Notification is a Request object
+		// without an "id" member, and the server MUST NOT reply. Note
+		// that "id": null is a valid request id and is NOT a
+		// notification, so we must inspect the raw JSON — interface{}
+		// unmarshaling collapses "absent" and "null" to the same nil
+		// value. This mirrors the HTTP transport's handling in
+		// handleHTTPRequest so the two transports behave identically.
+		if !hasIDField(line) {
 			continue
 		}
 
@@ -131,14 +142,18 @@ func (s *Server) Run() error {
 	return nil
 }
 
+// handleRequest dispatches a JSON-RPC request to the appropriate handler.
+//
+// Notifications (requests without an "id" member, per JSON-RPC 2.0 §4.1)
+// are filtered out by Run before reaching this function, so every dispatch
+// path here corresponds to a request that requires a response — including
+// requests whose id is explicitly null.
 func (s *Server) handleRequest(req JSONRPCRequest) {
 	switch req.Method {
 	case "initialize":
 		s.handleInitialize(req)
 	case "ping":
 		s.handlePing(req)
-	case "notifications/initialized":
-		// Client notification - no response needed
 	case "tools/list":
 		s.handleToolsList(req)
 	case "tools/call":
@@ -156,9 +171,7 @@ func (s *Server) handleRequest(req JSONRPCRequest) {
 	case "pgedge/selectDatabase":
 		s.handleSelectDatabase(req)
 	default:
-		if req.ID != nil {
-			sendError(req.ID, -32601, "Method not found", nil)
-		}
+		sendError(req.ID, -32601, "Method not found", nil)
 	}
 }
 
@@ -208,9 +221,9 @@ func (s *Server) handleInitialize(req JSONRPCRequest) {
 }
 
 func (s *Server) handlePing(req JSONRPCRequest) {
-	if req.ID == nil {
-		return
-	}
+	// Notifications are filtered out by Run before reaching dispatch, so
+	// every ping that arrives here is a request requiring a response —
+	// including one whose id is explicitly null.
 	sendResponse(req.ID, map[string]interface{}{})
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -521,9 +521,9 @@ func runStdio(t *testing.T, server *Server, input string) string {
 	})
 }
 
+// TestRunStdio_NotificationsInitialized verifies that a real JSON-RPC
+// notification (no "id" member, per §4.1) produces no response on stdio.
 func TestRunStdio_NotificationsInitialized(t *testing.T) {
-	// A real JSON-RPC notification has NO "id" member (per §4.1). The
-	// stdio server must not write any response.
 	server := NewServer(&mockToolProvider{})
 	input := `{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}` + "\n"
 
@@ -533,11 +533,12 @@ func TestRunStdio_NotificationsInitialized(t *testing.T) {
 	}
 }
 
+// TestRunStdio_UnknownNotification verifies that unknown-method
+// notifications are silently acknowledged. Replying with -32601 to a
+// notification would be doubly wrong per JSON-RPC 2.0 §4.1: the server
+// must not reply at all, and the reply would have no id (itself a
+// malformed JSON-RPC body).
 func TestRunStdio_UnknownNotification(t *testing.T) {
-	// Per JSON-RPC 2.0 §4.1, replying with -32601 Method not found in
-	// response to a notification is doubly wrong: the server must not
-	// reply at all, and the reply has no id (which is itself a malformed
-	// JSON-RPC body).
 	for _, method := range []string{
 		"notifications/cancelled",
 		"notifications/roots/list_changed",
@@ -555,12 +556,12 @@ func TestRunStdio_UnknownNotification(t *testing.T) {
 	}
 }
 
+// TestRunStdio_NullIDIsRequest_UnknownMethod is the regression for issue
+// #152: JSON-RPC 2.0 distinguishes "id absent" (notification, no reply)
+// from "id: null" (a request whose id happens to be null; reply
+// required). A request with explicit null id targeting an unknown
+// method must receive a -32601 response, not be silently dropped.
 func TestRunStdio_NullIDIsRequest_UnknownMethod(t *testing.T) {
-	// Regression for issue #152. JSON-RPC 2.0 distinguishes "id absent"
-	// (notification, no reply) from "id: null" (a request whose id
-	// happens to be null; reply required). A request with explicit
-	// null id targeting an unknown method must receive a -32601
-	// response, not be silently dropped.
 	server := NewServer(&mockToolProvider{})
 	input := `{"jsonrpc":"2.0","id":null,"method":"unknown/method"}` + "\n"
 
@@ -578,10 +579,11 @@ func TestRunStdio_NullIDIsRequest_UnknownMethod(t *testing.T) {
 	}
 }
 
+// TestRunStdio_NullIDIsRequest_Ping is the companion to
+// TestRunStdio_NullIDIsRequest_UnknownMethod for a method the
+// dispatcher recognises: a ping with explicit "id": null is a request
+// and must be answered with the standard empty-object result.
 func TestRunStdio_NullIDIsRequest_Ping(t *testing.T) {
-	// A ping with explicit "id": null is a request and must be answered.
-	// Companion to TestRunStdio_NullIDIsRequest_UnknownMethod that
-	// exercises a method the dispatcher recognises.
 	server := NewServer(&mockToolProvider{})
 	input := `{"jsonrpc":"2.0","id":null,"method":"ping"}` + "\n"
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -570,6 +571,14 @@ func TestRunStdio_NullIDIsRequest_UnknownMethod(t *testing.T) {
 		t.Fatal("expected a -32601 response for a request with null id, got nothing")
 	}
 
+	// Per JSON-RPC 2.0 §5.1 the response object MUST include the id
+	// member; for a request with explicit "id": null the response id
+	// is also null. Verify on the raw bytes because Decode into
+	// JSONRPCResponse cannot distinguish absent id from id: null.
+	if !strings.Contains(out, `"id":null`) {
+		t.Errorf("expected response to include `\"id\":null`, got %q", out)
+	}
+
 	var resp JSONRPCResponse
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("failed to decode response %q: %v", out, err)
@@ -590,6 +599,10 @@ func TestRunStdio_NullIDIsRequest_Ping(t *testing.T) {
 	out := runStdio(t, server, input)
 	if out == "" {
 		t.Fatal("expected a ping response for a request with null id, got nothing")
+	}
+
+	if !strings.Contains(out, `"id":null`) {
+		t.Errorf("expected response to include `\"id\":null`, got %q", out)
 	}
 
 	var resp JSONRPCResponse

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -489,15 +489,119 @@ func TestHandlePing_Stdio_WithID(t *testing.T) {
 	}
 }
 
-func TestHandlePing_Stdio_NilIDIsNotification(t *testing.T) {
-	server := NewServer(&mockToolProvider{})
-	req := JSONRPCRequest{JSONRPC: "2.0", ID: nil, Method: "ping"}
+// runStdio runs server.Run() with the given input piped to stdin and
+// returns whatever the server wrote to stdout. The input may contain
+// multiple newline-separated JSON-RPC messages; closing the write end
+// after writing causes Run to return cleanly on EOF.
+func runStdio(t *testing.T, server *Server, input string) string {
+	t.Helper()
 
-	out := captureStdout(t, func() {
-		server.handlePing(req)
+	oldIn := os.Stdin
+	rIn, wIn, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe (stdin) failed: %v", err)
+	}
+	os.Stdin = rIn
+	defer func() {
+		os.Stdin = oldIn
+		_ = rIn.Close()
+	}()
+
+	if _, err := io.WriteString(wIn, input); err != nil {
+		t.Fatalf("write stdin failed: %v", err)
+	}
+	if err := wIn.Close(); err != nil {
+		t.Fatalf("close stdin write end failed: %v", err)
+	}
+
+	return captureStdout(t, func() {
+		if err := server.Run(); err != nil {
+			t.Fatalf("server.Run failed: %v", err)
+		}
 	})
+}
 
+func TestRunStdio_NotificationsInitialized(t *testing.T) {
+	// A real JSON-RPC notification has NO "id" member (per §4.1). The
+	// stdio server must not write any response.
+	server := NewServer(&mockToolProvider{})
+	input := `{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}` + "\n"
+
+	out := runStdio(t, server, input)
 	if out != "" {
-		t.Errorf("notification ping must produce no response, got %q", out)
+		t.Errorf("notification must produce no response, got %q", out)
+	}
+}
+
+func TestRunStdio_UnknownNotification(t *testing.T) {
+	// Per JSON-RPC 2.0 §4.1, replying with -32601 Method not found in
+	// response to a notification is doubly wrong: the server must not
+	// reply at all, and the reply has no id (which is itself a malformed
+	// JSON-RPC body).
+	for _, method := range []string{
+		"notifications/cancelled",
+		"notifications/roots/list_changed",
+		"some/unknown/notification",
+	} {
+		t.Run(method, func(t *testing.T) {
+			server := NewServer(&mockToolProvider{})
+			input := `{"jsonrpc":"2.0","method":"` + method + `","params":{}}` + "\n"
+
+			out := runStdio(t, server, input)
+			if out != "" {
+				t.Errorf("unknown notification must produce no response, got %q", out)
+			}
+		})
+	}
+}
+
+func TestRunStdio_NullIDIsRequest_UnknownMethod(t *testing.T) {
+	// Regression for issue #152. JSON-RPC 2.0 distinguishes "id absent"
+	// (notification, no reply) from "id: null" (a request whose id
+	// happens to be null; reply required). A request with explicit
+	// null id targeting an unknown method must receive a -32601
+	// response, not be silently dropped.
+	server := NewServer(&mockToolProvider{})
+	input := `{"jsonrpc":"2.0","id":null,"method":"unknown/method"}` + "\n"
+
+	out := runStdio(t, server, input)
+	if out == "" {
+		t.Fatal("expected a -32601 response for a request with null id, got nothing")
+	}
+
+	var resp JSONRPCResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("failed to decode response %q: %v", out, err)
+	}
+	if resp.Error == nil || resp.Error.Code != -32601 {
+		t.Errorf("expected -32601 Method not found, got %+v", resp.Error)
+	}
+}
+
+func TestRunStdio_NullIDIsRequest_Ping(t *testing.T) {
+	// A ping with explicit "id": null is a request and must be answered.
+	// Companion to TestRunStdio_NullIDIsRequest_UnknownMethod that
+	// exercises a method the dispatcher recognises.
+	server := NewServer(&mockToolProvider{})
+	input := `{"jsonrpc":"2.0","id":null,"method":"ping"}` + "\n"
+
+	out := runStdio(t, server, input)
+	if out == "" {
+		t.Fatal("expected a ping response for a request with null id, got nothing")
+	}
+
+	var resp JSONRPCResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("failed to decode response %q: %v", out, err)
+	}
+	if resp.Error != nil {
+		t.Errorf("unexpected error in response: %+v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", resp.Result)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty object result, got %v", result)
 	}
 }

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -18,10 +18,19 @@ type JSONRPCRequest struct {
 	Params  interface{} `json:"params,omitempty"`
 }
 
-// JSONRPCResponse represents an outgoing JSON-RPC 2.0 response
+// JSONRPCResponse represents an outgoing JSON-RPC 2.0 response.
+//
+// Per JSON-RPC 2.0 §5.1, the response object MUST include the id
+// member; the value is the id of the originating request, or null when
+// the id cannot be determined (e.g. Parse error / Invalid Request) or
+// when the request itself used "id": null. The id tag therefore does
+// not use omitempty — Go's encoder collapses a nil interface to JSON
+// null, which is exactly the required wire representation in those
+// cases. Result and Error remain mutually exclusive (one MUST be
+// present, the other absent), so both keep omitempty.
 type JSONRPCResponse struct {
 	JSONRPC string      `json:"jsonrpc"`
-	ID      interface{} `json:"id,omitempty"`
+	ID      interface{} `json:"id"`
 	Result  interface{} `json:"result,omitempty"`
 	Error   *RPCError   `json:"error,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Filter JSON-RPC notifications at the stdio read loop using
  `hasIDField` on the raw line bytes, matching the HTTP transport fix
  from #142/#143. Notifications now never reach dispatch.
- Remove the now-redundant `req.ID == nil` guards in
  `handleRequest`'s default branch and `handlePing`; a request with
  explicit `"id": null` now reaches the dispatcher and is answered.
- Drop the hardcoded `notifications/initialized` case from the
  dispatch switch (filtered upstream, and a request with that method
  and `id: null` was being silently swallowed).

## Test plan

- [x] `go test ./internal/mcp/` — added Run()-level tests that pipe
      stdin and assert the resulting stdout
- [x] `notifications/initialized` produces no response
- [x] Unknown notification methods (`/cancelled`,
      `/roots/list_changed`, `some/unknown`) produce no response
- [x] `{"jsonrpc":"2.0","id":null,"method":"unknown/method"}` receives
      `-32601 Method not found`
- [x] `{"jsonrpc":"2.0","id":null,"method":"ping"}` receives an
      empty-object result
- [x] `make build`, `make test`, `make fmt` all clean. `make lint`
      reports 3 pre-existing staticcheck findings in
      `internal/embedding/{ollama,provider}.go` (untouched by this PR;
      present on `origin/main`).

Closes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON-RPC stdio behavior: requests with explicit null IDs now return proper error responses for unknown methods instead of being dropped; initialization and other notifications are consistently filtered and produce no responses.

* **Documentation**
  * Changelog updated to document the notification vs. request differentiation for stdio transport.

* **Tests**
  * Added end-to-end stdio/RPC tests validating notification filtering and null-ID request handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pgEdge/pgedge-postgres-mcp/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->