### PR TITLE
docs: fix typo in help guide

### DIFF
--- a/docs/guide/help.md
+++ b/docs/guide/help.md
@@ -1,6 +1,6 @@
 # Using Online Help
 
-You can include the `-help` keyword at the command line to retreive an online list of command options:
+You can include the `-help` keyword at the command line to retrieve an online list of command options:
 
 ```bash
 bin/pgedge-postgres-mcp -help


### PR DESCRIPTION
Fixes a small typo in the help guide: `retreive` → `retrieve`.

This is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo and improved clarity in the help documentation for command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->