### PR TITLE
package cells: native arm64 runners to avoid QEMU ldconfig segfault

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,7 +373,10 @@ jobs:
             needs.build-amd64.result == 'success' &&
             needs.build-arm64.result == 'success' &&
             needs.detect-matrix.outputs.has_rpm == 'true'
-        runs-on: ubuntu-latest
+        # arm64 cells run on native arm64 runners to avoid QEMU emulation
+        # (emulated glibc ldconfig segfaults during build-env setup); amd64
+        # stays on the standard x86_64 runner.
+        runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
         strategy:
             fail-fast: false
             matrix: ${{ fromJSON(needs.detect-matrix.outputs.rpm_matrix) }}
@@ -567,7 +570,10 @@ jobs:
             needs.build-amd64.result == 'success' &&
             needs.build-arm64.result == 'success' &&
             needs.detect-matrix.outputs.has_deb == 'true'
-        runs-on: ubuntu-latest
+        # arm64 cells run on native arm64 runners to avoid QEMU emulation
+        # (emulated glibc ldconfig segfaults during build-env setup); amd64
+        # stays on the standard x86_64 runner.
+        runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
         strategy:
             fail-fast: false
             matrix: ${{ fromJSON(needs.detect-matrix.outputs.deb_matrix) }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the RPM and DEB packaging build process for ARM64 systems by using native ARM64 build runners, improving overall build reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->