### PR TITLE
fix(installer): resolve latest stable v* release, not GitHub "latest"

### DIFF
--- a/examples/claude-try-it/README.md
+++ b/examples/claude-try-it/README.md
@@ -73,6 +73,7 @@ The following table lists the flags for `install.sh`:
 | `--db-name=DB` | Set the database name. |
 | `--db-user=USER` | Set the database username. |
 | `--db-pass=PASS` | Set the database password. |
+| `--version=VERSION` | Install a specific release tag (for example, `v1.0.0`) instead of resolving the latest. See [Pinning a Version](#pinning-a-version). |
 
 In the following example, the `--demo` flag starts a demo
 database without prompting:
@@ -103,6 +104,7 @@ The following table lists the flags for `install.ps1`:
 | `-DbName` | Set the database name. |
 | `-DbUser` | Set the database username. |
 | `-DbPass` | Set the database password. |
+| `-Version` | Install a specific release tag (for example, `v1.0.0`) instead of resolving the latest. See [Pinning a Version](#pinning-a-version). |
 
 In the following example, the `-Demo` flag starts a demo
 database without prompting:
@@ -117,6 +119,42 @@ to an instance on a non-default port:
 ```powershell
 .\install.ps1 -Detect -DbPort 5433
 ```
+
+## Pinning a Version
+
+By default, the installer resolves the latest stable release
+(a `v*` tag that ships a binary for your platform). To install
+a specific version instead, pin it with the `--version` flag
+(`-Version` on Windows) or the `PGEDGE_MCP_VERSION` environment
+variable. The flag takes precedence over the environment variable.
+
+Pinning skips the latest-release lookup entirely, so it is also a
+reliable fallback if release resolution ever fails.
+
+On macOS and Linux:
+
+```bash
+# Flag — note it prefixes `bash`, after `-s --`:
+curl -fsSL https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/claude-try-it/install.sh | bash -s -- --version=v1.0.0
+
+# Environment variable — must prefix `bash`, not `curl`:
+curl -fsSL https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/claude-try-it/install.sh | PGEDGE_MCP_VERSION=v1.0.0 bash
+```
+
+On Windows (PowerShell):
+
+```powershell
+# Flag (script saved locally):
+.\install.ps1 -Version v1.0.0
+
+# Environment variable (piped install):
+$env:PGEDGE_MCP_VERSION = "v1.0.0"
+irm https://raw.githubusercontent.com/pgEdge/pgedge-postgres-mcp/main/examples/claude-try-it/install.ps1 | iex
+```
+
+The value matches the GitHub release tag (for example, `v1.0.0`).
+A leading `v` is optional. Browse available tags on the
+[releases page](https://github.com/pgEdge/pgedge-postgres-mcp/releases).
 
 ## PostgreSQL Detection
 

--- a/examples/claude-try-it/install.ps1
+++ b/examples/claude-try-it/install.ps1
@@ -102,16 +102,19 @@ function Get-Platform {
 # --- Get latest release version -------------------------------------------
 
 # Does the server binary asset exist for a given tag on this platform?
-# Rejects only on a definitive 404 — any other failure (transient network, a
-# proxy that blocks HEAD) is treated as "present" so we don't wrongly skip a
-# good release and strand every Windows user.
+# Uses a 0-byte ranged GET (Range: bytes=0-0), matching install.sh: HEAD is
+# unreliable against GitHub's asset redirect to S3, which can reject it. Rejects
+# only on a definitive 404 — any other failure (transient network, a proxy
+# quirk) is treated as "present" so we don't wrongly skip a good release and
+# strand every Windows user.
 function Test-AssetExists {
     param([string]$Tag)
     $num = $Tag.TrimStart('v')
     $asset = "pgedge-postgres-mcp-server_${num}_$($script:OS)_$($script:Arch).$($script:Ext)"
     $url = "https://github.com/$Repo/releases/download/$Tag/$asset"
     try {
-        Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -ErrorAction Stop | Out-Null
+        Invoke-WebRequest -Uri $url -Headers @{ Range = "bytes=0-0" } `
+            -UseBasicParsing -ErrorAction Stop | Out-Null
         return $true
     } catch {
         if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 404) {
@@ -151,8 +154,14 @@ function Get-LatestVersion {
     # Stable v* releases only, ordered by semantic version (highest first).
     # GitHub lists releases by date, not version, so a hotfix cut on an older
     # line after a newer release would otherwise be picked ahead of it.
+    #
+    # Filter structurally on the tag, matching install.sh: reject any tag with a
+    # "-" (v1.0.0-beta3, -rc1…) rather than trusting GitHub's prerelease flag.
+    # This repo does not set that flag reliably — its beta/alpha tags are all
+    # published with prerelease=false — so the flag alone would let an RC slip
+    # through whenever a release line has no stable counterpart yet.
     $candidates = @($releases |
-        Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -match '^v\d' } |
+        Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -match '^v\d' -and $_.tag_name -notmatch '-' } |
         ForEach-Object { $_.tag_name } |
         Sort-Object { try { [version]($_.TrimStart('v')) } catch { [version]'0.0' } } -Descending)
 

--- a/examples/claude-try-it/install.ps1
+++ b/examples/claude-try-it/install.ps1
@@ -12,6 +12,10 @@
 #   .\install.ps1 -Detect -DbPort 5433
 #   .\install.ps1 -OwnDb -DbHost localhost -DbPort 5432 -DbName mydb -DbUser me -DbPass secret
 #
+# Pin a specific version (escape hatch — skips the latest-release lookup):
+#   .\install.ps1 -Version v1.0.0
+#   $env:PGEDGE_MCP_VERSION = "v1.0.0"; irm .../install.ps1 | iex   # env var equivalent
+#
 # What it does:
 #   1. Downloads the pgEdge MCP Server binary for Windows (x86_64)
 #   2. Helps you connect to a database (your own or a demo with sample data)
@@ -26,7 +30,8 @@ param(
     [string]$DbPort,
     [string]$DbName,
     [string]$DbUser,
-    [string]$DbPass
+    [string]$DbPass,
+    [string]$Version
 )
 
 $ErrorActionPreference = 'Stop'
@@ -44,6 +49,8 @@ $DemoPort   = 5432
 
 $script:Version      = ""
 $script:VersionNum   = ""
+# Pinned version: -Version flag wins, else PGEDGE_MCP_VERSION env var, else empty.
+$script:PinVersion   = if ($Version) { $Version } elseif ($env:PGEDGE_MCP_VERSION) { $env:PGEDGE_MCP_VERSION } else { "" }
 $script:DbHost       = $DbHost
 $script:DbPort       = $DbPort
 $script:DbName       = $DbName
@@ -94,17 +101,74 @@ function Get-Platform {
 
 # --- Get latest release version -------------------------------------------
 
-function Get-LatestVersion {
+# Does the server binary asset exist for a given tag on this platform?
+# Rejects only on a definitive 404 — any other failure (transient network, a
+# proxy that blocks HEAD) is treated as "present" so we don't wrongly skip a
+# good release and strand every Windows user.
+function Test-AssetExists {
+    param([string]$Tag)
+    $num = $Tag.TrimStart('v')
+    $asset = "pgedge-postgres-mcp-server_${num}_$($script:OS)_$($script:Arch).$($script:Ext)"
+    $url = "https://github.com/$Repo/releases/download/$Tag/$asset"
     try {
-        $release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest"
-        $script:Version = $release.tag_name
+        Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -ErrorAction Stop | Out-Null
+        return $true
     } catch {
-        Write-Fail "Could not determine latest release version: $_"
+        if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 404) {
+            return $false
+        }
+        return $true
     }
-    if (-not $script:Version) {
-        Write-Fail "Could not determine latest release version"
+}
+
+# Resolve the version to install.
+#
+# We deliberately do NOT trust GitHub's /releases/latest: this repo also
+# publishes knowledge-base releases (tagged kb-YYYY-MM-DD) that carry only a
+# kb.db asset and no platform binaries. Those are not flagged as prereleases,
+# so /releases/latest can return one and the binary download 404s.
+#
+# Instead, walk the releases list newest-first and pick the first STABLE
+# software release (v<digit>…, not draft, not prerelease) that actually has a
+# server binary for this platform. A pinned version (-Version flag or
+# PGEDGE_MCP_VERSION env var) overrides everything as an escape hatch.
+function Get-LatestVersion {
+    if ($script:PinVersion) {
+        # Normalize to a v-prefixed tag so -Version 1.0.0 and -Version v1.0.0
+        # both resolve to the v1.0.0 release tag (the leading v is optional).
+        $script:VersionNum = $script:PinVersion.Trim().TrimStart('v', 'V')
+        $script:Version = "v$($script:VersionNum)"
+        Write-Info "Using pinned version $($script:Version)"
+        return
     }
-    $script:VersionNum = $script:Version.TrimStart('v')
+
+    try {
+        $releases = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases?per_page=30"
+    } catch {
+        Write-Fail "Could not fetch releases from GitHub: $_"
+    }
+
+    # Stable v* releases only, ordered by semantic version (highest first).
+    # GitHub lists releases by date, not version, so a hotfix cut on an older
+    # line after a newer release would otherwise be picked ahead of it.
+    $candidates = @($releases |
+        Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -match '^v\d' } |
+        ForEach-Object { $_.tag_name } |
+        Sort-Object { try { [version]($_.TrimStart('v')) } catch { [version]'0.0' } } -Descending)
+
+    if ($candidates.Count -eq 0) {
+        Write-Fail "No stable release (v*) found in the latest 30 releases"
+    }
+
+    foreach ($tag in $candidates) {
+        if (Test-AssetExists -Tag $tag) {
+            $script:Version = $tag
+            $script:VersionNum = $tag.TrimStart('v')
+            return
+        }
+    }
+
+    Write-Fail "No stable release with a $($script:OS)/$($script:Arch) binary was found (checked: $($candidates -join ', '))"
 }
 
 # --- Download and install binary ------------------------------------------
@@ -120,7 +184,17 @@ function Install-Binary {
     try {
         Invoke-WebRequest -Uri $url -OutFile (Join-Path $tmpDir $assetName) -UseBasicParsing
     } catch {
-        Write-Fail "Download failed. Check your internet connection."
+        $code = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+        # Write-Fail exits, so clean up the temp dir here before it does.
+        Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+        if ($code -eq 403 -or $code -eq 429) {
+            Write-Fail "Download failed (HTTP $code): GitHub rate limit reached. Wait a few minutes and retry, or pin a version with -Version $($script:Version)."
+        } elseif ($code -eq 404) {
+            Write-Fail "Download failed (HTTP 404): no $($script:OS)/$($script:Arch) binary for $($script:Version) at $url"
+        } else {
+            $suffix = if ($code) { " (HTTP $code)" } else { "" }
+            Write-Fail "Download failed$suffix. Check your internet connection."
+        }
     }
 
     New-Item -ItemType Directory -Path $BinDir -Force | Out-Null

--- a/examples/claude-try-it/install.sh
+++ b/examples/claude-try-it/install.sh
@@ -9,6 +9,10 @@
 #   curl -fsSL .../install.sh | bash -s -- --detect
 #   curl -fsSL .../install.sh | bash -s -- --db-host=localhost --db-port=5432 --db-name=mydb --db-user=me --db-pass=secret
 #
+# Pin a specific version (escape hatch — skips the latest-release lookup):
+#   curl -fsSL .../install.sh | bash -s -- --version=v1.0.0
+#   curl -fsSL .../install.sh | PGEDGE_MCP_VERSION=v1.0.0 bash   # env var equivalent
+#
 # What it does:
 #   1. Downloads the pgEdge MCP Server binary for your platform
 #   2. Helps you connect to a database (your own or a demo with sample data)
@@ -28,6 +32,8 @@ DEMO_PORT=5432
 
 MODE=""
 DB_HOST="" DB_PORT="" DB_NAME="" DB_USER="" DB_PASS=""
+# Pinned version: --version=… flag wins, else PGEDGE_MCP_VERSION env var, else empty.
+PIN_VERSION="${PGEDGE_MCP_VERSION:-}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -39,6 +45,7 @@ for arg in "$@"; do
     --db-name=*)     DB_NAME="${arg#*=}" ;;
     --db-user=*)     DB_USER="${arg#*=}" ;;
     --db-pass=*)     DB_PASS="${arg#*=}" ;;
+    --version=*)     PIN_VERSION="${arg#*=}" ;;
     --install-docker) MODE="install-docker" ;;
   esac
 done
@@ -99,13 +106,80 @@ detect_platform() {
 
 # ─── Get latest release version ─────────────────────────────────────────────
 
+# Does the server binary asset exist for a given tag on this platform?
+# Uses a 0-byte ranged GET (more reliable than HEAD against GitHub's asset
+# redirect to S3, which can reject HEAD requests). Rejects only on a definitive
+# 404 — any other outcome (a transient error, a proxy quirk) is treated as
+# "present" so we don't wrongly skip a good release.
+asset_exists_for_version() {
+  local tag="$1" num="${1#v}"
+  local asset="pgedge-postgres-mcp-server_${num}_${OS}_${ARCH}.${EXT}"
+  local url="https://github.com/$REPO/releases/download/$tag/$asset"
+  local code
+  code=$(curl -sSL -r 0-0 -o /dev/null -w '%{http_code}' "$url" 2>/dev/null) || code=""
+  [ "$code" != "404" ]
+}
+
+# Resolve the version to install.
+#
+# We deliberately do NOT trust GitHub's /releases/latest: this repo also
+# publishes knowledge-base releases (tagged kb-YYYY-MM-DD) that carry only a
+# kb.db asset and no platform binaries. Those are not flagged as prereleases,
+# so /releases/latest can return one and the binary download 404s.
+#
+# Instead, walk the releases list newest-first and pick the first STABLE
+# software release (tag matches v<digit>… with no prerelease "-" suffix) that
+# actually has a server binary for this platform. A pinned version (--version=
+# flag or PGEDGE_MCP_VERSION env var) overrides everything as an escape hatch
+# (e.g. --version=v1.0.0).
 get_latest_version() {
+  if [ -n "$PIN_VERSION" ]; then
+    # Normalize to a v-prefixed tag so --version=1.0.0 and --version=v1.0.0
+    # both resolve to the v1.0.0 release tag (the leading v is optional).
+    VERSION_NUM="${PIN_VERSION#[vV]}"
+    VERSION="v${VERSION_NUM}"
+    info "Using pinned version $VERSION"
+    return
+  fi
+
   local response
-  response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest") \
-    || fail "Could not fetch latest release from GitHub (network error or rate limit)"
-  VERSION=$(echo "$response" | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4) || true
-  [ -z "$VERSION" ] && fail "Could not determine latest release version"
-  VERSION_NUM="${VERSION#v}"
+  response=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30") \
+    || fail "Could not fetch releases from GitHub (network error or rate limit)"
+
+  # Collect stable v* tags, newest first (GitHub returns newest first).
+  local -a candidates=()
+  local tag
+  while IFS= read -r tag; do
+    [ -z "$tag" ] && continue
+    case "$tag" in *-*) continue ;; esac   # skip prereleases (v1.0.0-beta3, -test1…)
+    candidates+=("$tag")
+  done <<< "$(echo "$response" | grep -oE '"tag_name": *"v[0-9][^"]*"' | cut -d'"' -f4)"
+
+  [ ${#candidates[@]} -eq 0 ] \
+    && fail "No stable release (v*) found in the latest 30 releases"
+
+  # Order by semantic version, highest first. GitHub lists releases by date,
+  # not version, so a hotfix cut on an older line after a newer release would
+  # otherwise be picked ahead of it. Falls back to list (date) order if this
+  # platform's sort lacks -V.
+  if echo | sort -V >/dev/null 2>&1; then
+    local -a sorted=()
+    while IFS= read -r tag; do
+      [ -n "$tag" ] && sorted+=("$tag")
+    done <<< "$(printf '%s\n' "${candidates[@]}" | sort -V -r)"
+    candidates=("${sorted[@]}")
+  fi
+
+  # Pick the highest version that actually ships a binary for this platform.
+  for tag in "${candidates[@]}"; do
+    if asset_exists_for_version "$tag"; then
+      VERSION="$tag"
+      VERSION_NUM="${VERSION#v}"
+      return
+    fi
+  done
+
+  fail "No stable release with a ${OS}/${ARCH} binary was found (checked: ${candidates[*]})"
 }
 
 # ─── Download and install binary ────────────────────────────────────────────
@@ -118,8 +192,18 @@ download_binary() {
 
   info "Downloading pgEdge MCP Server $VERSION ($OS/$ARCH)..."
 
-  curl -fsSL -o "$tmp_dir/$asset_name" "$url" \
-    || fail "Download failed. Check your internet connection."
+  local http_code
+  http_code=$(curl -sSL -o "$tmp_dir/$asset_name" -w '%{http_code}' "$url" 2>/dev/null) \
+    || http_code="000"
+  case "$http_code" in
+    2??) : ;;  # success
+    403|429) rm -rf "$tmp_dir"
+             fail "Download failed (HTTP $http_code): GitHub rate limit reached. Wait a few minutes and retry, or pin a version with --version=$VERSION." ;;
+    404)     rm -rf "$tmp_dir"
+             fail "Download failed (HTTP 404): no $OS/$ARCH binary for $VERSION at $url" ;;
+    *)       rm -rf "$tmp_dir"
+             fail "Download failed (HTTP ${http_code:-000}). Check your internet connection." ;;
+  esac
 
   mkdir -p "$BIN_DIR"
 


### PR DESCRIPTION
## Problem

The `examples/claude-try-it` install scripts trusted GitHub's `/releases/latest` and used its `tag_name` verbatim to build the binary download URL.

This repo also publishes **knowledge-base releases** (`kb-YYYY-MM-DD`) via `docker-publish.yml` that ship only a `kb.db` asset — no platform binaries. They are **not** flagged as prereleases, so `/releases/latest` returns them and the binary download 404s.

**Impact:** install/update has been broken for every user since **2026-04-22**, when the first `kb-*` release became "latest" (`v1.0.0`, the last release with binaries, shipped 2026-03-27).

```
ℹ  Downloading pgEdge MCP Server kb-2026-04-27 (darwin/arm64)...
curl: (56) The requested URL returned error: 404
✗  Download failed. Check your internet connection.
```

## Fix (client side)

- Fetch the releases **list** instead of `/releases/latest`.
- Keep stable `v*` releases only (drop `kb-*` and prerelease `-` tags).
- Order by **semantic version** (not GitHub's date order) so a hotfix on an older line can't be picked ahead of a newer release.
- Install the highest version that **actually ships a binary** for the current platform; reject a candidate only on a definitive **404** so a transient error / HEAD-blocking proxy can't strand users.
- Download failures now report the **HTTP status**: 403/429 explain the GitHub rate limit (and suggest pinning), 404 names the missing asset.
- New **version pin** escape hatch: `--version=` flag (`-Version` on Windows), precedence over the existing `PGEDGE_MCP_VERSION` env var. Documented in the example README.

Mirrored in `install.sh` and `install.ps1`.

## Testing

- `bash -n` clean; functional tests resolve `v1.0.0` against the live API; `kb-2026-04-27` correctly rejected (404).
- Semver sort verified (`v1.10.0` > `v1.9.0` regardless of list order).
- `--version=` flag + env-var precedence verified end-to-end.
- 404 download path verified to emit the new message and exit non-zero.
- PowerShell logic mirrors bash but was **not** run locally (no `pwsh` available) — worth a quick check on Windows before merge.

## Follow-ups (not in this PR)

- **Layer 2 (defense in depth):** mark `kb-*` releases as `prerelease: true` / `make_latest: false` in `docker-publish.yml` so `/releases/latest` is correct too.
- Cosmetic: `ask()` errors `"/dev/tty: Device not configured"` in non-TTY/CI contexts; make the TTY probe check readability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--version` (macOS/Linux) and `-Version` (Windows) options to pin the pgEdge MCP Server release during installation.
  * Version pinning now takes precedence over `PGEDGE_MCP_VERSION` and avoids “latest” discovery.
* **Bug Fixes**
  * Improved download/version resolution with better validation of platform-specific binaries.
  * Enhanced error handling and cleanup, including clearer messages for rate limits and missing binaries.
* **Documentation**
  * Added a “Pinning a Version” section with bash and PowerShell examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->