### PR TITLE
Relocate Save/Delete conversation actions to status banner menu

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -147,7 +147,19 @@ and this project adheres to
   library's expected shape. The on-disk JSON written by this and
   later versions uses the typed content-block format directly.
 
+- The web client now groups the conversation-level Save and Delete
+  actions in a new menu in the status banner header, alongside the
+  database switcher and connection details, rather than placing them
+  next to the message input. This keeps the destructive Delete action
+  away from the Send button and clarifies that the actions affect the
+  whole conversation. Deleting a conversation now requires confirmation
+  via a dialog instead of a browser prompt. (#73)
+
 ### Fixed
+
+- The edit and delete icons in the conversation history list no longer
+  overlap the conversation title; the list item now reserves enough
+  space for both controls so long titles ellipsize cleanly. (#73)
 
 - Metadata loader now tolerates tables with zero columns
   (e.g. `CREATE TABLE foo()`). The query LEFT JOINs against the

--- a/web/src/components/ChatInterface.jsx
+++ b/web/src/components/ChatInterface.jsx
@@ -13,6 +13,7 @@ import { Box, Paper, useTheme } from '@mui/material';
 import { useAuth } from '../contexts/AuthContext';
 import { useLLMProcessing } from '../contexts/LLMProcessingContext';
 import { useDatabaseContext } from '../contexts/DatabaseContext';
+import { useConversationActions } from '../contexts/ConversationActionsContext';
 import { useLocalStorageBoolean } from '../hooks/useLocalStorage';
 import { useQueryHistory } from '../hooks/useQueryHistory';
 import { useMCPClient } from '../hooks/useMCPClient';
@@ -24,6 +25,7 @@ import PromptPopover from './PromptPopover';
 import WriteQueryConfirmDialog from './WriteQueryConfirmDialog';
 import { isWriteQuery } from '../utils/queryClassify';
 import { sseChat } from '../utils/sseChat';
+import { conversationToMarkdown, downloadMarkdown } from '../lib/conversationExport';
 
 const MAX_AGENTIC_LOOPS = 50;
 // Compact if estimated tokens exceed this threshold.
@@ -444,6 +446,7 @@ const compactMessages = async (messages, sessionToken, maxTokens = 100000, recen
 const ChatInterface = ({ conversations }) => {
     const { sessionToken, forceLogout } = useAuth();
     const { setIsProcessing } = useLLMProcessing();
+    const { registerActions } = useConversationActions();
     const theme = useTheme();
     const isDark = theme.palette.mode === 'dark';
 
@@ -1173,10 +1176,10 @@ const ChatInterface = ({ conversations }) => {
         }
     }, [queryHistory]);
 
-    // Handle clear conversation
+    // Handle clear conversation. Confirmation is handled by the caller
+    // (the StatusBanner header menu shows a confirmation dialog), so this
+    // performs the clearing unconditionally.
     const handleClear = useCallback(() => {
-        if (!window.confirm('Clear conversation and start new?')) return;
-
         // Clear local state
         isLoadingRef.current = true;
         setMessages([]);
@@ -1190,6 +1193,24 @@ const ChatInterface = ({ conversations }) => {
         // Reset loading flag after state update
         setTimeout(() => { isLoadingRef.current = false; }, 100);
     }, [queryHistory, conversations]);
+
+    // Export the current conversation to a Markdown file. No-op when there
+    // are no messages to export.
+    const handleSaveConversation = useCallback(() => {
+        if (messages.length === 0) return;
+        const markdown = conversationToMarkdown(messages, { showActivity, debug });
+        const filename = `chat-history-${new Date().toISOString().slice(0, 10)}.md`;
+        downloadMarkdown(markdown, filename);
+    }, [messages, showActivity, debug]);
+
+    // Publish conversation-level actions to the StatusBanner header menu.
+    useEffect(() => {
+        registerActions({
+            hasMessages: messages.length > 0,
+            onSave: handleSaveConversation,
+            onClear: handleClear,
+        });
+    }, [messages.length, handleSaveConversation, handleClear, registerActions]);
 
     // Handle prompt selection
     const handlePromptClick = useCallback((event) => {
@@ -1660,9 +1681,6 @@ const ChatInterface = ({ conversations }) => {
                     isLoading={loading}
                     onPromptClick={handlePromptClick}
                     hasPrompts={prompts && prompts.length > 0}
-                    messages={messages}
-                    showActivity={showActivity}
-                    debug={debug}
                 />
 
                 <ProviderSelector
@@ -1680,8 +1698,6 @@ const ChatInterface = ({ conversations }) => {
                     onDebugChange={setDebug}
                     disabled={loading}
                     loadingModels={llmProviders.loadingModels}
-                    onClear={handleClear}
-                    hasMessages={messages.length > 0}
                 />
             </Paper>
 

--- a/web/src/components/ConversationPanel.jsx
+++ b/web/src/components/ConversationPanel.jsx
@@ -352,7 +352,7 @@ const ConversationPanel = ({
                                             }}
                                             disabled={disabled}
                                             sx={{
-                                                pr: 13,
+                                                pr: 21,
                                                 '&:hover': {
                                                     bgcolor: isDark ? alpha('#22B8CF', 0.08) : alpha('#15AABF', 0.06),
                                                 },
@@ -366,8 +366,9 @@ const ConversationPanel = ({
                                             }}
                                         >
                                             <ListItemText
+                                                sx={{ minWidth: 0 }}
                                                 primary={
-                                                    <Box>
+                                                    <Box sx={{ minWidth: 0, overflow: 'hidden' }}>
                                                         {conversation.connection && (
                                                             <Typography
                                                                 variant="caption"
@@ -387,6 +388,8 @@ const ConversationPanel = ({
                                                             sx={{
                                                                 fontWeight: conversation.id === currentConversationId ? 600 : 400,
                                                                 color: isDark ? '#F1F5F9' : '#1F2937',
+                                                                // Hard cap so long titles don't run under the rename/delete icons.
+                                                                maxWidth: '190px',
                                                             }}
                                                         >
                                                             {conversation.title}
@@ -528,6 +531,9 @@ const ConversationPanel = ({
                         onChange={(e) => setNewTitle(e.target.value)}
                         onKeyDown={(e) => {
                             if (e.key === 'Enter' && newTitle.trim()) {
+                                // Prevents the dialog's focus-restore-on-close from re-triggering
+                                // the rename icon's click via the browser's native Enter handling.
+                                e.preventDefault();
                                 handleConfirmRename();
                             }
                         }}

--- a/web/src/components/ConversationPanel.jsx
+++ b/web/src/components/ConversationPanel.jsx
@@ -352,7 +352,7 @@ const ConversationPanel = ({
                                             }}
                                             disabled={disabled}
                                             sx={{
-                                                pr: 10,
+                                                pr: 13,
                                                 '&:hover': {
                                                     bgcolor: isDark ? alpha('#22B8CF', 0.08) : alpha('#15AABF', 0.06),
                                                 },

--- a/web/src/components/Login.jsx
+++ b/web/src/components/Login.jsx
@@ -64,7 +64,18 @@ const Login = () => {
     const [error, setError] = useState('');
     const [warning, setWarning] = useState('');
     const [loading, setLoading] = useState(false);
+    const [usernameAutofilled, setUsernameAutofilled] = useState(false);
+    const [passwordAutofilled, setPasswordAutofilled] = useState(false);
     const { login } = useAuth();
+
+    // Browser autofill bypasses onChange, so detect it via MUI's mui-auto-fill animation instead.
+    const handleAutofillDetect = (setAutofilled) => (e) => {
+        if (e.animationName === 'mui-auto-fill') {
+            setAutofilled(true);
+        } else if (e.animationName === 'mui-auto-fill-cancel') {
+            setAutofilled(false);
+        }
+    };
 
     // Check for disconnect message on mount
     useEffect(() => {
@@ -350,8 +361,10 @@ const Login = () => {
                                 required
                                 autoFocus
                                 disabled={loading}
+                                InputLabelProps={{ shrink: usernameAutofilled || Boolean(username) }}
                                 inputProps={{
                                     autoComplete: 'off',
+                                    onAnimationStart: handleAutofillDetect(setUsernameAutofilled),
                                 }}
                                 sx={{
                                     '& .MuiOutlinedInput-root': {
@@ -380,8 +393,10 @@ const Login = () => {
                                 margin="normal"
                                 required
                                 disabled={loading}
+                                InputLabelProps={{ shrink: passwordAutofilled || Boolean(password) }}
                                 inputProps={{
                                     autoComplete: 'current-password',
+                                    onAnimationStart: handleAutofillDetect(setPasswordAutofilled),
                                 }}
                                 sx={{
                                     '& .MuiOutlinedInput-root': {
@@ -447,7 +462,7 @@ const Login = () => {
                         color: 'rgba(255, 255, 255, 0.6)',
                     }}
                 >
-                    &copy; 2025 pgEdge, Inc.
+                    &copy; 2025 - 2026, pgEdge, Inc.
                 </Typography>
             </Container>
         </Box>

--- a/web/src/components/MainContent.jsx
+++ b/web/src/components/MainContent.jsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { LLMProcessingProvider } from '../contexts/LLMProcessingContext';
 import { DatabaseProvider } from '../contexts/DatabaseContext';
+import { ConversationActionsProvider } from '../contexts/ConversationActionsContext';
 import StatusBanner from './StatusBanner';
 import ChatInterface from './ChatInterface';
 
@@ -19,10 +20,12 @@ const MainContent = ({ conversations }) => {
     return (
         <DatabaseProvider>
             <LLMProcessingProvider>
-                <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-                    <StatusBanner />
-                    <ChatInterface conversations={conversations} />
-                </Box>
+                <ConversationActionsProvider>
+                    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+                        <StatusBanner />
+                        <ChatInterface conversations={conversations} />
+                    </Box>
+                </ConversationActionsProvider>
             </LLMProcessingProvider>
         </DatabaseProvider>
     );

--- a/web/src/components/MessageInput.jsx
+++ b/web/src/components/MessageInput.jsx
@@ -10,10 +10,10 @@
  *-------------------------------------------------------------------------
  */
 
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Box, TextField, IconButton, Tooltip, useTheme, alpha } from '@mui/material';
-import { Send as SendIcon, Stop as StopIcon, Psychology as PsychologyIcon, SaveAlt as SaveIcon } from '@mui/icons-material';
+import { Send as SendIcon, Stop as StopIcon, Psychology as PsychologyIcon } from '@mui/icons-material';
 
 const MessageInput = React.memo(({
     value,
@@ -25,9 +25,6 @@ const MessageInput = React.memo(({
     isLoading = false,
     onPromptClick,
     hasPrompts = false,
-    messages = [],
-    showActivity = false,
-    debug = false,
 }) => {
     const inputRef = useRef(null);
     const theme = useTheme();
@@ -43,99 +40,6 @@ const MessageInput = React.memo(({
             return () => clearTimeout(timer);
         }
     }, [disabled]);
-
-    // Convert messages to Markdown format
-    const convertToMarkdown = useCallback(() => {
-        const lines = [];
-        lines.push('# Chat History');
-        lines.push('');
-        lines.push(`*Exported: ${new Date().toLocaleString()}*`);
-        lines.push('');
-        lines.push('---');
-        lines.push('');
-
-        for (const msg of messages) {
-            // Skip system messages unless debug is enabled
-            if (msg.role === 'system' && !debug) {
-                continue;
-            }
-
-            const timestamp = msg.timestamp
-                ? new Date(msg.timestamp).toLocaleString()
-                : '';
-
-            if (msg.role === 'user') {
-                lines.push('## User');
-                if (timestamp) lines.push(`*${timestamp}*`);
-                lines.push('');
-                lines.push(msg.content);
-                lines.push('');
-            } else if (msg.role === 'assistant') {
-                lines.push('## Assistant');
-                if (timestamp) lines.push(`*${timestamp}*`);
-                if (msg.provider && msg.model) {
-                    lines.push(`*${msg.provider}: ${msg.model}*`);
-                }
-                lines.push('');
-
-                // Include activity/tool calls if showActivity is enabled
-                if (showActivity && msg.activity && msg.activity.length > 0) {
-                    lines.push('### Activity');
-                    lines.push('');
-                    for (const act of msg.activity) {
-                        if (act.type === 'tool') {
-                            const tokenInfo = act.tokens ? ` (~${act.tokens} tokens)` : '';
-                            const errorInfo = act.isError ? ' [ERROR]' : '';
-                            if (act.name === 'read_resource' && act.uri) {
-                                lines.push(`- **${act.name}**: \`${act.uri}\`${tokenInfo}${errorInfo}`);
-                            } else {
-                                lines.push(`- **${act.name}**${tokenInfo}${errorInfo}`);
-                            }
-                        } else if (act.type === 'compaction') {
-                            lines.push(`- *Compacted: ${act.originalCount} → ${act.compactedCount} messages*`);
-                        } else if (act.type === 'rate_limit_pause') {
-                            lines.push(`- *Rate limit pause: ${act.message}*`);
-                        }
-                    }
-                    lines.push('');
-                }
-
-                lines.push(msg.content);
-                lines.push('');
-            } else if (msg.role === 'system' && debug) {
-                lines.push('## System');
-                if (timestamp) lines.push(`*${timestamp}*`);
-                lines.push('');
-                lines.push(`> ${msg.content}`);
-                lines.push('');
-            }
-
-            lines.push('---');
-            lines.push('');
-        }
-
-        return lines.join('\n');
-    }, [messages, showActivity, debug]);
-
-    // Handle save button click
-    const handleSave = useCallback(() => {
-        if (messages.length === 0) return;
-
-        const markdown = convertToMarkdown();
-        const blob = new Blob([markdown], { type: 'text/markdown' });
-        const url = URL.createObjectURL(blob);
-
-        // Create a temporary link and trigger download
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = `chat-history-${new Date().toISOString().slice(0, 10)}.md`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-
-        // Clean up the URL object
-        URL.revokeObjectURL(url);
-    }, [messages, convertToMarkdown]);
 
     return (
         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 2 }}>
@@ -175,23 +79,6 @@ const MessageInput = React.memo(({
                     },
                 }}
             />
-            {messages.length > 0 && (
-                <Tooltip title="Save Chat History">
-                    <IconButton
-                        onClick={handleSave}
-                        size="small"
-                        sx={{
-                            color: isDark ? '#94A3B8' : '#6B7280',
-                            '&:hover': {
-                                bgcolor: isDark ? alpha('#22B8CF', 0.08) : alpha('#15AABF', 0.04),
-                                color: '#15AABF',
-                            },
-                        }}
-                    >
-                        <SaveIcon />
-                    </IconButton>
-                </Tooltip>
-            )}
             {hasPrompts && (
                 <Tooltip title="Execute Prompt">
                     <IconButton
@@ -252,9 +139,6 @@ MessageInput.propTypes = {
     isLoading: PropTypes.bool,
     onPromptClick: PropTypes.func,
     hasPrompts: PropTypes.bool,
-    messages: PropTypes.arrayOf(PropTypes.object),
-    showActivity: PropTypes.bool,
-    debug: PropTypes.bool,
 };
 
 export default MessageInput;

--- a/web/src/components/ProviderSelector.jsx
+++ b/web/src/components/ProviderSelector.jsx
@@ -25,7 +25,6 @@ import {
 } from '@mui/material';
 import {
     Settings as SettingsIcon,
-    Delete as DeleteIcon,
 } from '@mui/icons-material';
 import PreferencesPopover from './PreferencesPopover';
 
@@ -44,8 +43,6 @@ const ProviderSelector = React.memo(({
     onDebugChange,
     disabled,
     loadingModels,
-    onClear,
-    hasMessages = false,
 }) => {
     const [preferencesAnchor, setPreferencesAnchor] = useState(null);
     const theme = useTheme();
@@ -221,26 +218,6 @@ const ProviderSelector = React.memo(({
                 debug={debug}
                 onDebugChange={onDebugChange}
             />
-
-            {/* Clear Button */}
-            {hasMessages && (
-                <Tooltip title="Clear Conversation">
-                    <IconButton
-                        onClick={onClear}
-                        disabled={disabled}
-                        size="small"
-                        sx={{
-                            ...iconButtonStyles,
-                            '&:hover': {
-                                bgcolor: isDark ? alpha('#EF4444', 0.08) : alpha('#EF4444', 0.04),
-                                color: '#EF4444',
-                            },
-                        }}
-                    >
-                        <DeleteIcon />
-                    </IconButton>
-                </Tooltip>
-            )}
         </Box>
     );
 });
@@ -268,8 +245,6 @@ ProviderSelector.propTypes = {
     onDebugChange: PropTypes.func.isRequired,
     disabled: PropTypes.bool.isRequired,
     loadingModels: PropTypes.bool.isRequired,
-    onClear: PropTypes.func,
-    hasMessages: PropTypes.bool,
 };
 
 export default ProviderSelector;

--- a/web/src/components/StatusBanner.jsx
+++ b/web/src/components/StatusBanner.jsx
@@ -22,6 +22,16 @@ import {
     useTheme,
     Tooltip,
     alpha,
+    Menu,
+    MenuItem,
+    ListItemIcon,
+    ListItemText,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogContentText,
+    DialogActions,
+    Button,
 } from '@mui/material';
 import {
     CheckCircle as CheckCircleIcon,
@@ -30,10 +40,14 @@ import {
     ExpandLess as ExpandLessIcon,
     Storage as StorageIcon,
     Warning as WarningIcon,
+    MoreVert as MoreVertIcon,
+    SaveAlt as SaveIcon,
+    Delete as DeleteIcon,
 } from '@mui/icons-material';
 import { useAuth } from '../contexts/AuthContext';
 import { useLLMProcessing } from '../contexts/LLMProcessingContext';
 import { useDatabaseContext } from '../contexts/DatabaseContext';
+import { useConversationActions } from '../contexts/ConversationActionsContext';
 import { MCPClient } from '../lib/mcp-client';
 import DatabaseSelectorPopover from './DatabaseSelectorPopover';
 
@@ -46,14 +60,54 @@ const RETRY_DELAY_MS = 500;
 const StatusBanner = () => {
     const { sessionToken, forceLogout } = useAuth();
     const { isProcessing } = useLLMProcessing();
+    const { hasMessages, onSave, onClear } = useConversationActions();
     const theme = useTheme();
     const [systemInfo, setSystemInfo] = useState(null);
     const [expanded, setExpanded] = useState(false);
     const [error, setError] = useState('');
     const [dbPopoverAnchor, setDbPopoverAnchor] = useState(null);
     const [isSwitchingDatabase, setIsSwitchingDatabase] = useState(false);
+    const [actionsMenuAnchor, setActionsMenuAnchor] = useState(null);
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
     const isDark = theme.palette.mode === 'dark';
+
+    // Conversation actions menu handlers
+    const handleActionsMenuOpen = (event) => {
+        setActionsMenuAnchor(event.currentTarget);
+    };
+
+    const handleActionsMenuClose = () => {
+        setActionsMenuAnchor(null);
+    };
+
+    const handleSaveClick = () => {
+        handleActionsMenuClose();
+        onSave?.();
+    };
+
+    const handleDeleteClick = () => {
+        handleActionsMenuClose();
+        setDeleteDialogOpen(true);
+    };
+
+    const handleConfirmDelete = () => {
+        onClear?.();
+        setDeleteDialogOpen(false);
+    };
+
+    const handleCancelDelete = () => {
+        setDeleteDialogOpen(false);
+    };
+
+    const dialogPaperProps = {
+        sx: {
+            bgcolor: isDark ? '#1E293B' : '#FFFFFF',
+            border: '1px solid',
+            borderColor: isDark ? '#334155' : '#E5E7EB',
+            borderRadius: 1,
+        },
+    };
 
     // Database management (shared context)
     const {
@@ -379,6 +433,74 @@ const StatusBanner = () => {
                             </span>
                         </Tooltip>
                     )}
+                    <Tooltip title="Conversation actions">
+                        <IconButton
+                            size="small"
+                            onClick={handleActionsMenuOpen}
+                            aria-label="Conversation actions"
+                            sx={{
+                                color: isDark ? '#94A3B8' : '#6B7280',
+                                mr: 0.5,
+                                '&:hover': {
+                                    bgcolor: isDark ? alpha('#22B8CF', 0.08) : alpha('#15AABF', 0.04),
+                                    color: '#15AABF',
+                                },
+                            }}
+                        >
+                            <MoreVertIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                    <Menu
+                        anchorEl={actionsMenuAnchor}
+                        open={Boolean(actionsMenuAnchor)}
+                        onClose={handleActionsMenuClose}
+                        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                        slotProps={{
+                            paper: {
+                                sx: {
+                                    bgcolor: isDark ? '#1E293B' : '#FFFFFF',
+                                    border: '1px solid',
+                                    borderColor: isDark ? '#334155' : '#E5E7EB',
+                                    borderRadius: 1,
+                                    boxShadow: isDark
+                                        ? '0 10px 15px -3px rgba(0, 0, 0, 0.3)'
+                                        : '0 10px 15px -3px rgba(0, 0, 0, 0.1)',
+                                },
+                            },
+                        }}
+                    >
+                        <MenuItem
+                            onClick={handleSaveClick}
+                            disabled={!hasMessages || !onSave}
+                            sx={{
+                                color: isDark ? '#F1F5F9' : '#1F2937',
+                                '&:hover': {
+                                    bgcolor: isDark ? alpha('#22B8CF', 0.08) : alpha('#15AABF', 0.04),
+                                },
+                            }}
+                        >
+                            <ListItemIcon sx={{ color: 'inherit', minWidth: 36 }}>
+                                <SaveIcon fontSize="small" />
+                            </ListItemIcon>
+                            <ListItemText primary="Save conversation" />
+                        </MenuItem>
+                        <MenuItem
+                            onClick={handleDeleteClick}
+                            disabled={!hasMessages || !onClear}
+                            sx={{
+                                color: isDark ? '#F87171' : '#DC2626',
+                                '&:hover': {
+                                    bgcolor: isDark ? alpha('#EF4444', 0.08) : alpha('#EF4444', 0.04),
+                                },
+                            }}
+                        >
+                            <ListItemIcon sx={{ color: 'inherit', minWidth: 36 }}>
+                                <DeleteIcon fontSize="small" />
+                            </ListItemIcon>
+                            <ListItemText primary="Delete conversation" />
+                        </MenuItem>
+                    </Menu>
                     <IconButton
                         size="small"
                         onClick={() => setExpanded(!expanded)}
@@ -664,6 +786,48 @@ const StatusBanner = () => {
                 loading={dbLoading}
                 error={dbError}
             />
+
+            {/* Delete Conversation Confirmation Dialog */}
+            <Dialog
+                open={deleteDialogOpen}
+                onClose={handleCancelDelete}
+                PaperProps={dialogPaperProps}
+            >
+                <DialogTitle sx={{ color: isDark ? '#F1F5F9' : '#1F2937' }}>
+                    Delete conversation
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText sx={{ color: isDark ? '#94A3B8' : '#6B7280' }}>
+                        This clears the entire current conversation and starts a
+                        new one. This action cannot be undone.
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions sx={{ p: 2, pt: 0 }}>
+                    <Button
+                        onClick={handleCancelDelete}
+                        sx={{
+                            color: isDark ? '#94A3B8' : '#6B7280',
+                            textTransform: 'none',
+                        }}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={handleConfirmDelete}
+                        variant="contained"
+                        sx={{
+                            bgcolor: '#EF4444',
+                            color: '#FFFFFF',
+                            textTransform: 'none',
+                            '&:hover': {
+                                bgcolor: '#DC2626',
+                            },
+                        }}
+                    >
+                        Delete
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </Paper>
     );
 };

--- a/web/src/components/__tests__/StatusBanner.test.jsx
+++ b/web/src/components/__tests__/StatusBanner.test.jsx
@@ -1,0 +1,117 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - StatusBanner Conversation Actions Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import StatusBanner from '../StatusBanner';
+import {
+    ConversationActionsProvider,
+    useConversationActions,
+} from '../../contexts/ConversationActionsContext';
+
+// Mock the contexts StatusBanner depends on so we avoid all MCP network
+// machinery. sessionToken is null so the mount effect does not fetch.
+vi.mock('../../contexts/AuthContext', () => ({
+    useAuth: () => ({ sessionToken: null, forceLogout: vi.fn() }),
+}));
+
+vi.mock('../../contexts/LLMProcessingContext', () => ({
+    useLLMProcessing: () => ({ isProcessing: false }),
+}));
+
+vi.mock('../../contexts/DatabaseContext', () => ({
+    useDatabaseContext: () => ({
+        databases: [],
+        currentDatabase: null,
+        loading: false,
+        error: null,
+        fetchDatabases: vi.fn(),
+        selectDatabase: vi.fn(),
+    }),
+}));
+
+vi.mock('../../lib/mcp-client', () => ({
+    MCPClient: vi.fn(),
+}));
+
+// Mock the popover to keep the tree light.
+vi.mock('../DatabaseSelectorPopover', () => ({
+    default: () => null,
+}));
+
+// Helper that registers conversation actions into the provider so the
+// menu items are enabled, mirroring what ChatInterface does at runtime.
+const ActionRegistrar = ({ onSave, onClear }) => {
+    const { registerActions } = useConversationActions();
+    React.useEffect(() => {
+        registerActions({ hasMessages: true, onSave, onClear });
+    }, [registerActions, onSave, onClear]);
+    return null;
+};
+
+const renderBanner = ({ onSave = vi.fn(), onClear = vi.fn() } = {}) => {
+    render(
+        <ConversationActionsProvider>
+            <ActionRegistrar onSave={onSave} onClear={onClear} />
+            <StatusBanner />
+        </ConversationActionsProvider>
+    );
+    return { onSave, onClear };
+};
+
+describe('StatusBanner conversation actions', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the kebab actions button', () => {
+        renderBanner();
+        expect(
+            screen.getByRole('button', { name: /conversation actions/i })
+        ).toBeInTheDocument();
+    });
+
+    it('opens the menu with Save and Delete items', () => {
+        renderBanner();
+        fireEvent.click(
+            screen.getByRole('button', { name: /conversation actions/i })
+        );
+        expect(screen.getByText('Save conversation')).toBeInTheDocument();
+        expect(screen.getByText('Delete conversation')).toBeInTheDocument();
+    });
+
+    it('calls onSave when Save is clicked', () => {
+        const { onSave } = renderBanner();
+        fireEvent.click(
+            screen.getByRole('button', { name: /conversation actions/i })
+        );
+        fireEvent.click(screen.getByText('Save conversation'));
+        expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens the confirm dialog and calls onClear on confirm', () => {
+        const { onClear } = renderBanner();
+        fireEvent.click(
+            screen.getByRole('button', { name: /conversation actions/i })
+        );
+        fireEvent.click(screen.getByText('Delete conversation'));
+
+        // Confirmation dialog appears.
+        expect(
+            screen.getByText(/clears the entire current conversation/i)
+        ).toBeInTheDocument();
+        expect(onClear).not.toHaveBeenCalled();
+
+        // Confirm the delete.
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        expect(onClear).toHaveBeenCalledTimes(1);
+    });
+});

--- a/web/src/contexts/ConversationActionsContext.jsx
+++ b/web/src/contexts/ConversationActionsContext.jsx
@@ -1,0 +1,65 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - Conversation Actions Context
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ * Lightweight context that lets ChatInterface publish its
+ * conversation-level actions (save/clear) up to sibling components
+ * such as StatusBanner without lifting the large messages state.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+const ConversationActionsContext = createContext(null);
+
+export const ConversationActionsProvider = ({ children }) => {
+    const [actions, setActions] = useState({
+        hasMessages: false,
+        onSave: null,
+        onClear: null,
+    });
+
+    // Stable callback (empty deps + functional setState) so consumers
+    // can safely call it from an effect without triggering update loops.
+    const registerActions = useCallback((next) => {
+        setActions((prev) => ({
+            hasMessages: next.hasMessages,
+            onSave: next.onSave,
+            onClear: next.onClear,
+        }));
+    }, []);
+
+    const value = useMemo(() => ({
+        hasMessages: actions.hasMessages,
+        onSave: actions.onSave,
+        onClear: actions.onClear,
+        registerActions,
+    }), [actions, registerActions]);
+
+    return (
+        <ConversationActionsContext.Provider value={value}>
+            {children}
+        </ConversationActionsContext.Provider>
+    );
+};
+
+ConversationActionsProvider.propTypes = {
+    children: PropTypes.node.isRequired,
+};
+
+export const useConversationActions = () => {
+    const context = useContext(ConversationActionsContext);
+    if (!context) {
+        throw new Error(
+            'useConversationActions must be used within a ConversationActionsProvider'
+        );
+    }
+    return context;
+};
+
+export default ConversationActionsContext;

--- a/web/src/contexts/__tests__/ConversationActionsContext.test.jsx
+++ b/web/src/contexts/__tests__/ConversationActionsContext.test.jsx
@@ -1,0 +1,65 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - Conversation Actions Context Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+    ConversationActionsProvider,
+    useConversationActions,
+} from '../ConversationActionsContext';
+
+const wrapper = ({ children }) => (
+    <ConversationActionsProvider>{children}</ConversationActionsProvider>
+);
+
+describe('ConversationActionsContext', () => {
+    it('provides default values', () => {
+        const { result } = renderHook(() => useConversationActions(), { wrapper });
+
+        expect(result.current.hasMessages).toBe(false);
+        expect(result.current.onSave).toBeNull();
+        expect(result.current.onClear).toBeNull();
+        expect(typeof result.current.registerActions).toBe('function');
+    });
+
+    it('updates consumed values when registerActions is called', () => {
+        const { result } = renderHook(() => useConversationActions(), { wrapper });
+
+        const onSave = () => {};
+        const onClear = () => {};
+
+        act(() => {
+            result.current.registerActions({ hasMessages: true, onSave, onClear });
+        });
+
+        expect(result.current.hasMessages).toBe(true);
+        expect(result.current.onSave).toBe(onSave);
+        expect(result.current.onClear).toBe(onClear);
+    });
+
+    it('keeps registerActions identity stable across renders', () => {
+        const { result, rerender } = renderHook(() => useConversationActions(), { wrapper });
+
+        const firstRegister = result.current.registerActions;
+
+        act(() => {
+            result.current.registerActions({ hasMessages: true, onSave: null, onClear: null });
+        });
+        rerender();
+
+        expect(result.current.registerActions).toBe(firstRegister);
+    });
+
+    it('throws when used outside the provider', () => {
+        expect(() => renderHook(() => useConversationActions())).toThrow(
+            /must be used within a ConversationActionsProvider/
+        );
+    });
+});

--- a/web/src/lib/__tests__/conversationExport.test.js
+++ b/web/src/lib/__tests__/conversationExport.test.js
@@ -1,0 +1,74 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - Conversation Export Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { conversationToMarkdown } from '../conversationExport';
+
+// All data below is synthetic and made up for testing only.
+const messages = [
+    { role: 'user', content: 'Hello from Test User' },
+    {
+        role: 'assistant',
+        content: 'Hello back from the example assistant',
+        provider: 'example-provider',
+        model: 'example-model',
+        activity: [
+            { type: 'tool', name: 'run_query', tokens: 42 },
+        ],
+    },
+    { role: 'system', content: 'example system note' },
+];
+
+describe('conversationToMarkdown', () => {
+    it('includes a top-level Chat History heading', () => {
+        const md = conversationToMarkdown(messages);
+        expect(md).toContain('# Chat History');
+    });
+
+    it('produces headings for user and assistant messages', () => {
+        const md = conversationToMarkdown(messages);
+        expect(md).toContain('## User');
+        expect(md).toContain('Hello from Test User');
+        expect(md).toContain('## Assistant');
+        expect(md).toContain('Hello back from the example assistant');
+        expect(md).toContain('*example-provider: example-model*');
+    });
+
+    it('omits system messages when debug is false', () => {
+        const md = conversationToMarkdown(messages, { debug: false });
+        expect(md).not.toContain('## System');
+        expect(md).not.toContain('example system note');
+    });
+
+    it('includes system messages when debug is true', () => {
+        const md = conversationToMarkdown(messages, { debug: true });
+        expect(md).toContain('## System');
+        expect(md).toContain('> example system note');
+    });
+
+    it('omits activity detail when showActivity is false', () => {
+        const md = conversationToMarkdown(messages, { showActivity: false });
+        expect(md).not.toContain('### Activity');
+        expect(md).not.toContain('run_query');
+    });
+
+    it('includes activity detail when showActivity is true', () => {
+        const md = conversationToMarkdown(messages, { showActivity: true });
+        expect(md).toContain('### Activity');
+        expect(md).toContain('**run_query**');
+        expect(md).toContain('(~42 tokens)');
+    });
+
+    it('returns header-only output for an empty conversation', () => {
+        const md = conversationToMarkdown([]);
+        expect(md).toContain('# Chat History');
+        expect(md).not.toContain('## User');
+    });
+});

--- a/web/src/lib/conversationExport.js
+++ b/web/src/lib/conversationExport.js
@@ -1,0 +1,133 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - Conversation Export Utilities
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ * Pure helpers for exporting a conversation to Markdown and triggering
+ * a client-side download. Extracted from MessageInput so the export can
+ * be driven from the StatusBanner header menu.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Format a message timestamp as a locale string, or '' when absent.
+const formatTimestamp = (msg) =>
+    msg.timestamp ? new Date(msg.timestamp).toLocaleString() : '';
+
+// Render a single activity entry as a Markdown bullet, or null when the
+// activity type is not one we export.
+const formatActivityItem = (act) => {
+    if (act.type === 'tool') {
+        const tokenInfo = act.tokens ? ` (~${act.tokens} tokens)` : '';
+        const errorInfo = act.isError ? ' [ERROR]' : '';
+        if (act.name === 'read_resource' && act.uri) {
+            return `- **${act.name}**: \`${act.uri}\`${tokenInfo}${errorInfo}`;
+        }
+        return `- **${act.name}**${tokenInfo}${errorInfo}`;
+    }
+    if (act.type === 'compaction') {
+        return `- *Compacted: ${act.originalCount} → ${act.compactedCount} messages*`;
+    }
+    if (act.type === 'rate_limit_pause') {
+        return `- *Rate limit pause: ${act.message}*`;
+    }
+    return null;
+};
+
+// Render the "### Activity" block for an assistant message; returns an
+// empty array when there is nothing to show.
+const formatActivityBlock = (activity) => {
+    const items = activity.map(formatActivityItem).filter((line) => line !== null);
+    if (items.length === 0) return [];
+    return ['### Activity', '', ...items, ''];
+};
+
+const formatUserMessage = (msg, timestamp) => {
+    const lines = ['## User'];
+    if (timestamp) lines.push(`*${timestamp}*`);
+    lines.push('', msg.content, '');
+    return lines;
+};
+
+const formatAssistantMessage = (msg, timestamp, showActivity) => {
+    const lines = ['## Assistant'];
+    if (timestamp) lines.push(`*${timestamp}*`);
+    if (msg.provider && msg.model) lines.push(`*${msg.provider}: ${msg.model}*`);
+    lines.push('');
+    if (showActivity && msg.activity && msg.activity.length > 0) {
+        lines.push(...formatActivityBlock(msg.activity));
+    }
+    lines.push(msg.content, '');
+    return lines;
+};
+
+const formatSystemMessage = (msg, timestamp) => {
+    const lines = ['## System'];
+    if (timestamp) lines.push(`*${timestamp}*`);
+    lines.push('', `> ${msg.content}`, '');
+    return lines;
+};
+
+// Render one message to its Markdown lines, or null when it should be
+// skipped (e.g. a system message while debug is disabled).
+const formatMessage = (msg, { showActivity, debug }) => {
+    const timestamp = formatTimestamp(msg);
+    if (msg.role === 'user') return formatUserMessage(msg, timestamp);
+    if (msg.role === 'assistant') return formatAssistantMessage(msg, timestamp, showActivity);
+    if (msg.role === 'system' && debug) return formatSystemMessage(msg, timestamp);
+    return null;
+};
+
+/**
+ * Convert an array of chat messages to a Markdown document.
+ *
+ * @param {Array<Object>} messages - Chat messages to export.
+ * @param {Object} [options] - Export options.
+ * @param {boolean} [options.showActivity=false] - Include tool/activity
+ *     detail for assistant messages when true.
+ * @param {boolean} [options.debug=false] - Include system messages when
+ *     true; otherwise they are skipped.
+ * @returns {string} The Markdown document.
+ */
+export const conversationToMarkdown = (messages = [], { showActivity = false, debug = false } = {}) => {
+    const lines = [
+        '# Chat History',
+        '',
+        `*Exported: ${new Date().toLocaleString()}*`,
+        '',
+        '---',
+        '',
+    ];
+
+    for (const msg of messages) {
+        const messageLines = formatMessage(msg, { showActivity, debug });
+        if (messageLines === null) continue;
+        lines.push(...messageLines, '---', '');
+    }
+
+    return lines.join('\n');
+};
+
+/**
+ * Trigger a client-side download of a Markdown string as a file.
+ *
+ * @param {string} markdown - The Markdown content to download.
+ * @param {string} filename - The download filename.
+ */
+export const downloadMarkdown = (markdown, filename) => {
+    const blob = new Blob([markdown], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+
+    // Create a temporary link and trigger download
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    // Clean up the URL object
+    URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Summary

- Move the conversation-level **Save** and **Delete** actions out of the message input area into a new overflow (kebab) menu in the status banner header, alongside the database switcher and connection details. This keeps the destructive Delete action away from the Send button, groups the session-level actions, and declutters the input row.
- **Delete** now opens a confirmation dialog (replacing the old `window.confirm`), reducing the risk of accidental data loss.
- A new lightweight `ConversationActionsContext` lets `ChatInterface` publish its save/clear handlers up to the sibling `StatusBanner` without lifting the large `messages` state; the Markdown export logic moves into a reusable `conversationExport` helper (factored into small per-message-type formatters to stay within complexity limits).
- Fix the edit/delete icons in the conversation history list overlapping the conversation title by reserving enough space for both controls so long titles ellipsize cleanly.

The existing database switcher and connection-details expand controls are unchanged; the menu is additive.

## Test plan

- [x] `npm run build` (web client) succeeds.
- [x] `npm test` (web client) passes: 13 files, 111 tests, including new tests for `ConversationActionsContext`, the `conversationExport` helper, and the StatusBanner menu/confirm-dialog behaviour.
- [x] `make test` (Go suite, incl. database tests) passes with no failures.
- [ ] Manual: confirm the kebab menu shows Save/Delete (disabled with no messages), Save downloads the Markdown history, Delete prompts for confirmation before clearing, and long conversation titles no longer sit under the edit icon.

## Notes

Implements #73. The issue is intentionally **not** auto-closed on merge (`Implements` rather than `Closes`) so it can be reassigned to QA for verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a conversation actions menu to the chat header with **Save conversation** and **Delete conversation**.
  * **Save conversation** downloads a Markdown transcript; **Delete conversation** uses a confirmation dialog.
* **Bug Fixes**
  * Conversation history titles no longer overlap edit/delete controls and truncate cleanly.
  * Rename dialog Enter key no longer re-triggers actions.
* **Changes**
  * Removed the inline save/export control from the message input; save/clear are now in the header menu.
* **Documentation**
  * Updated the changelog under **[Unreleased] → Fixed**.
* **Tests**
  * Added coverage for the menu UI, confirmation flow, conversation actions context, and Markdown export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->