### PR TITLE
Aggregate multiple foreign-key references per column in metadata loader

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -158,6 +158,7 @@ and this project adheres to
   per column, and `ColumnInfo.ForeignKeyRefs` is a `[]string` so all
   references are surfaced (comma-separated in the `fk_ref` output
   column) rather than silently discarding all but one. (#171)
+
 - Metadata loader now tolerates tables with zero columns
   (e.g. `CREATE TABLE foo()`). The query LEFT JOINs against the
   per-column catalog, so a zero-column table produced a row whose

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -149,6 +149,15 @@ and this project adheres to
 
 ### Fixed
 
+- Metadata loader no longer emits duplicate column entries for a
+  column that participates in more than one foreign-key constraint.
+  The `fk_columns` CTE produced one row per foreign key, so the
+  downstream LEFT JOIN multiplied the per-column rows; `get_schema_info`
+  consequently listed the affected column once per foreign key. The CTE
+  now aggregates every reference into one ordered, de-duplicated array
+  per column, and `ColumnInfo.ForeignKeyRefs` is a `[]string` so all
+  references are surfaced (comma-separated in the `fk_ref` output
+  column) rather than silently discarding all but one. (#171)
 - Metadata loader now tolerates tables with zero columns
   (e.g. `CREATE TABLE foo()`). The query LEFT JOINs against the
   per-column catalog, so a zero-column table produced a row whose

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -460,7 +460,7 @@ efficiency. The columns are:
 | `col_desc` | Column description. |
 | `is_pk` | true if part of primary key. |
 | `is_unique` | true if has unique constraint (excluding PK). |
-| `fk_ref` | Foreign key reference in format "schema.table.column" if FK. |
+| `fk_ref` | FK reference(s), "schema.table.column", comma-separated. |
 | `is_indexed` | true if column is part of any index. |
 | `identity` | "a" for GENERATED ALWAYS, "d" for BY DEFAULT, empty otherwise. |
 | `default` | Default value expression if any. |

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"database/sql"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -536,6 +537,92 @@ func TestLoadMetadata_TableWithNoColumns(t *testing.T) {
 	}
 	if len(tableInfo.Columns) != 0 {
 		t.Errorf("expected empty-columns table to have 0 columns, got %d", len(tableInfo.Columns))
+	}
+}
+
+// TestLoadMetadata_ColumnWithMultipleFKs is a regression test for issue
+// #171. A single column can participate in more than one foreign-key
+// constraint; before the fix the fk_columns CTE emitted one row per FK,
+// and the downstream LEFT JOIN multiplied the per-column rows, producing
+// duplicate ColumnInfo entries for that column.
+//
+// This test creates a child column referenced by two different parent
+// tables, loads metadata, and asserts that the column appears exactly
+// once and that ForeignKeyRefs carries both references in deterministic
+// (sorted) order. It is gated on TEST_PGEDGE_POSTGRES_CONNECTION_STRING,
+// matching the convention used by the other live-DB regression tests.
+func TestLoadMetadata_ColumnWithMultipleFKs(t *testing.T) {
+	connStr := os.Getenv("TEST_PGEDGE_POSTGRES_CONNECTION_STRING")
+	if connStr == "" {
+		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set; skipping live-DB regression test for issue #171")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	setupPool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("failed to open setup pool: %v", err)
+	}
+	defer setupPool.Close()
+
+	const dropStmt = "DROP TABLE IF EXISTS public.pgedge_mcp_issue171_child, " +
+		"public.pgedge_mcp_issue171_parent_a, public.pgedge_mcp_issue171_parent_b CASCADE"
+	if _, err := setupPool.Exec(ctx, dropStmt); err != nil {
+		t.Fatalf("failed to drop preexisting fixture tables: %v", err)
+	}
+	defer func() {
+		_, _ = setupPool.Exec(context.Background(), dropStmt)
+	}()
+
+	setup := []string{
+		"CREATE TABLE public.pgedge_mcp_issue171_parent_a (id integer PRIMARY KEY)",
+		"CREATE TABLE public.pgedge_mcp_issue171_parent_b (id integer PRIMARY KEY)",
+		"CREATE TABLE public.pgedge_mcp_issue171_child (" +
+			"ref integer, " +
+			"CONSTRAINT fk_a FOREIGN KEY (ref) REFERENCES public.pgedge_mcp_issue171_parent_a(id), " +
+			"CONSTRAINT fk_b FOREIGN KEY (ref) REFERENCES public.pgedge_mcp_issue171_parent_b(id))",
+	}
+	for _, stmt := range setup {
+		if _, err := setupPool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("failed to create fixture (%q): %v", stmt, err)
+		}
+	}
+
+	client := NewClientWithConnectionString(connStr, nil)
+	defer client.Close()
+
+	if err := client.ConnectTo(connStr); err != nil {
+		t.Fatalf("ConnectTo failed: %v", err)
+	}
+	if err := client.LoadMetadataFor(connStr); err != nil {
+		t.Fatalf("LoadMetadataFor returned error: %v", err)
+	}
+
+	meta := client.GetMetadataFor(connStr)
+	key := "public.pgedge_mcp_issue171_child"
+	tableInfo, ok := meta[key]
+	if !ok {
+		t.Fatalf("expected metadata to contain %q, got keys: %v", key, mapKeys(meta))
+	}
+
+	var refCols []ColumnInfo
+	for _, col := range tableInfo.Columns {
+		if col.ColumnName == "ref" {
+			refCols = append(refCols, col)
+		}
+	}
+	if len(refCols) != 1 {
+		t.Fatalf("expected column %q to appear exactly once, got %d (issue #171 duplicate rows)", "ref", len(refCols))
+	}
+
+	want := []string{
+		"public.pgedge_mcp_issue171_parent_a.id",
+		"public.pgedge_mcp_issue171_parent_b.id",
+	}
+	if !reflect.DeepEqual(refCols[0].ForeignKeyRefs, want) {
+		t.Errorf("expected both FK references in sorted order:\n got:  %v\n want: %v",
+			refCols[0].ForeignKeyRefs, want)
 	}
 }
 

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -557,37 +557,8 @@ func TestLoadMetadata_ColumnWithMultipleFKs(t *testing.T) {
 		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set; skipping live-DB regression test for issue #171")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	setupPool, err := pgxpool.New(ctx, connStr)
-	if err != nil {
-		t.Fatalf("failed to open setup pool: %v", err)
-	}
-	defer setupPool.Close()
-
-	const dropStmt = "DROP TABLE IF EXISTS public.pgedge_mcp_issue171_child, " +
-		"public.pgedge_mcp_issue171_parent_a, public.pgedge_mcp_issue171_parent_b CASCADE"
-	if _, err := setupPool.Exec(ctx, dropStmt); err != nil {
-		t.Fatalf("failed to drop preexisting fixture tables: %v", err)
-	}
-	defer func() {
-		_, _ = setupPool.Exec(context.Background(), dropStmt)
-	}()
-
-	setup := []string{
-		"CREATE TABLE public.pgedge_mcp_issue171_parent_a (id integer PRIMARY KEY)",
-		"CREATE TABLE public.pgedge_mcp_issue171_parent_b (id integer PRIMARY KEY)",
-		"CREATE TABLE public.pgedge_mcp_issue171_child (" +
-			"ref integer, " +
-			"CONSTRAINT fk_a FOREIGN KEY (ref) REFERENCES public.pgedge_mcp_issue171_parent_a(id), " +
-			"CONSTRAINT fk_b FOREIGN KEY (ref) REFERENCES public.pgedge_mcp_issue171_parent_b(id))",
-	}
-	for _, stmt := range setup {
-		if _, err := setupPool.Exec(ctx, stmt); err != nil {
-			t.Fatalf("failed to create fixture (%q): %v", stmt, err)
-		}
-	}
+	cleanup := setupMultiFKFixture(t, connStr)
+	defer cleanup()
 
 	client := NewClientWithConnectionString(connStr, nil)
 	defer client.Close()
@@ -606,12 +577,7 @@ func TestLoadMetadata_ColumnWithMultipleFKs(t *testing.T) {
 		t.Fatalf("expected metadata to contain %q, got keys: %v", key, mapKeys(meta))
 	}
 
-	var refCols []ColumnInfo
-	for _, col := range tableInfo.Columns {
-		if col.ColumnName == "ref" {
-			refCols = append(refCols, col)
-		}
-	}
+	refCols := columnsNamed(tableInfo.Columns, "ref")
 	if len(refCols) != 1 {
 		t.Fatalf("expected column %q to appear exactly once, got %d (issue #171 duplicate rows)", "ref", len(refCols))
 	}
@@ -624,6 +590,57 @@ func TestLoadMetadata_ColumnWithMultipleFKs(t *testing.T) {
 		t.Errorf("expected both FK references in sorted order:\n got:  %v\n want: %v",
 			refCols[0].ForeignKeyRefs, want)
 	}
+}
+
+// setupMultiFKFixture creates a child table whose `ref` column is
+// referenced by two different parent tables (the issue #171 fixture) and
+// returns a cleanup function that drops the fixture and closes the pool.
+// It fails the test if any setup statement errors.
+func setupMultiFKFixture(t *testing.T, connStr string) func() {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to open setup pool: %v", err)
+	}
+
+	const dropStmt = "DROP TABLE IF EXISTS public.pgedge_mcp_issue171_child, " +
+		"public.pgedge_mcp_issue171_parent_a, public.pgedge_mcp_issue171_parent_b CASCADE"
+	stmts := []string{
+		dropStmt,
+		"CREATE TABLE public.pgedge_mcp_issue171_parent_a (id integer PRIMARY KEY)",
+		"CREATE TABLE public.pgedge_mcp_issue171_parent_b (id integer PRIMARY KEY)",
+		"CREATE TABLE public.pgedge_mcp_issue171_child (" +
+			"ref integer, " +
+			"CONSTRAINT fk_a FOREIGN KEY (ref) REFERENCES public.pgedge_mcp_issue171_parent_a(id), " +
+			"CONSTRAINT fk_b FOREIGN KEY (ref) REFERENCES public.pgedge_mcp_issue171_parent_b(id))",
+	}
+	for _, stmt := range stmts {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			pool.Close()
+			cancel()
+			t.Fatalf("failed to set up fixture (%q): %v", stmt, err)
+		}
+	}
+
+	return func() {
+		_, _ = pool.Exec(context.Background(), dropStmt)
+		pool.Close()
+		cancel()
+	}
+}
+
+// columnsNamed returns the columns in cols whose name equals name.
+func columnsNamed(cols []ColumnInfo, name string) []ColumnInfo {
+	var out []ColumnInfo
+	for _, c := range cols {
+		if c.ColumnName == name {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func mapKeys(m map[string]TableInfo) []string {

--- a/internal/database/load_metadata.sql
+++ b/internal/database/load_metadata.sql
@@ -70,12 +70,20 @@ unique_columns AS (
     JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(con.conkey)
     WHERE con.contype = 'u'
 ),
+-- A single column can participate in more than one foreign-key
+-- constraint (e.g. the same column referenced by two different parent
+-- tables), so aggregate every reference for a column into one ordered,
+-- de-duplicated array. This yields exactly one row per
+-- (schema, table, column); without the GROUP BY the downstream LEFT
+-- JOIN would multiply the per-column rows and emit duplicate columns
+-- (issue #171).
 fk_columns AS (
     SELECT
         n.nspname AS schema_name,
         c.relname AS table_name,
         a.attname AS column_name,
-        fn.nspname || '.' || fc.relname || '.' || fa.attname AS fk_reference
+        array_agg(DISTINCT fn.nspname || '.' || fc.relname || '.' || fa.attname
+                  ORDER BY fn.nspname || '.' || fc.relname || '.' || fa.attname) AS fk_references
     FROM pg_constraint con
     JOIN pg_class c ON c.oid = con.conrelid
     JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -85,6 +93,7 @@ fk_columns AS (
     JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = cols.col_num
     JOIN pg_attribute fa ON fa.attrelid = fc.oid AND fa.attnum = cols.ref_num
     WHERE con.contype = 'f'
+    GROUP BY n.nspname, c.relname, a.attname
 ),
 indexed_columns AS (
     SELECT DISTINCT
@@ -125,7 +134,7 @@ SELECT
     ci.type_modifier,
     CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END AS is_primary_key,
     CASE WHEN uq.column_name IS NOT NULL THEN true ELSE false END AS is_unique,
-    COALESCE(fk.fk_reference, '') AS fk_reference,
+    COALESCE(fk.fk_references, ARRAY[]::text[]) AS fk_references,
     CASE WHEN ix.column_name IS NOT NULL THEN true ELSE false END AS is_indexed,
     COALESCE(ci.identity_type, '') AS identity_type,
     COALESCE(cd.default_value, '') AS default_value

--- a/internal/database/metadata.go
+++ b/internal/database/metadata.go
@@ -50,10 +50,12 @@ type metadataRow struct {
 	TypeModifier  sql.NullInt32
 	IsPrimaryKey  bool
 	IsUnique      bool
-	FKReference   string
-	IsIndexed     bool
-	IdentityType  string
-	DefaultValue  string
+	// FKReferences is the text[] of "schema.table.column" references the
+	// column participates in (COALESCEd to an empty array, never NULL).
+	FKReferences []string
+	IsIndexed    bool
+	IdentityType string
+	DefaultValue string
 }
 
 // scanMetadataRow scans one row of loadMetadataSQL into a metadataRow.
@@ -76,7 +78,7 @@ func scanMetadataRow(rows pgx.Rows) (metadataRow, error) {
 		&r.TypeModifier,
 		&r.IsPrimaryKey,
 		&r.IsUnique,
-		&r.FKReference,
+		&r.FKReferences,
 		&r.IsIndexed,
 		&r.IdentityType,
 		&r.DefaultValue,
@@ -120,7 +122,7 @@ func columnInfoFromRow(r metadataRow) ColumnInfo {
 		Description:      r.ColumnDesc,
 		IsPrimaryKey:     r.IsPrimaryKey,
 		IsUnique:         r.IsUnique,
-		ForeignKeyRef:    r.FKReference,
+		ForeignKeyRefs:   r.FKReferences,
 		IsIndexed:        r.IsIndexed,
 		IsIdentity:       r.IdentityType,
 		DefaultValue:     r.DefaultValue,

--- a/internal/database/metadata_test.go
+++ b/internal/database/metadata_test.go
@@ -12,6 +12,7 @@ package database
 
 import (
 	"database/sql"
+	"reflect"
 	"testing"
 )
 
@@ -246,7 +247,7 @@ func TestBuildTableInfo_PreservesAllColumnAttributes(t *testing.T) {
 		TypeModifier: sql.NullInt32{Int32: -1, Valid: true},
 		IsPrimaryKey: true,
 		IsUnique:     true,
-		FKReference:  "auth.tokens.user_id",
+		FKReferences: []string{"auth.tokens.user_id"},
 		IsIndexed:    true,
 		IdentityType: "a",
 		DefaultValue: "nextval('users_id_seq'::regclass)",
@@ -258,7 +259,7 @@ func TestBuildTableInfo_PreservesAllColumnAttributes(t *testing.T) {
 		Description:      "primary identifier",
 		IsPrimaryKey:     true,
 		IsUnique:         true,
-		ForeignKeyRef:    "auth.tokens.user_id",
+		ForeignKeyRefs:   []string{"auth.tokens.user_id"},
 		IsIndexed:        true,
 		IsIdentity:       "a",
 		DefaultValue:     "nextval('users_id_seq'::regclass)",
@@ -269,8 +270,31 @@ func TestBuildTableInfo_PreservesAllColumnAttributes(t *testing.T) {
 	metadata, _, _ := buildTableInfo([]metadataRow{row})
 	got := metadata["public.users"].Columns[0]
 
-	if got != want {
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("column attributes not preserved:\n got:  %+v\n want: %+v", got, want)
+	}
+}
+
+// TestBuildTableInfo_PreservesMultipleFKReferences verifies that a
+// column participating in more than one foreign key (issue #171) keeps
+// every reference, in the order the loader produced them, rather than
+// collapsing to a single value or duplicating the column.
+func TestBuildTableInfo_PreservesMultipleFKReferences(t *testing.T) {
+	row := validColumn("public", "child", "ref", "integer", "int4")
+	row.FKReferences = []string{"public.parent_a.id", "public.parent_b.id"}
+
+	metadata, _, columnCount := buildTableInfo([]metadataRow{row})
+
+	cols := metadata["public.child"].Columns
+	if len(cols) != 1 {
+		t.Fatalf("expected exactly 1 column for a multi-FK column, got %d", len(cols))
+	}
+	if columnCount != 1 {
+		t.Errorf("expected columnCount == 1, got %d", columnCount)
+	}
+	want := []string{"public.parent_a.id", "public.parent_b.id"}
+	if !reflect.DeepEqual(cols[0].ForeignKeyRefs, want) {
+		t.Errorf("FK references not preserved:\n got:  %v\n want: %v", cols[0].ForeignKeyRefs, want)
 	}
 }
 

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -27,13 +27,13 @@ type ColumnInfo struct {
 	DataType         string
 	IsNullable       string
 	Description      string
-	IsPrimaryKey     bool   // True if this column is part of the primary key
-	IsUnique         bool   // True if this column has a unique constraint (excluding PK)
-	ForeignKeyRef    string // Reference in format "schema.table.column" if FK, empty otherwise
-	IsIndexed        bool   // True if this column is part of any index
-	IsIdentity       string // Identity generation: "" (none), "a" (ALWAYS), "d" (BY DEFAULT)
-	DefaultValue     string // Default value expression if any, empty otherwise
-	IsVectorColumn   bool   // True if this is a pgvector column
-	VectorDimensions int    // Number of dimensions for vector columns (0 if not a vector)
-	VectorType       string // Underlying vector type: "vector", "halfvec", or "" if not a vector column
+	IsPrimaryKey     bool     // True if this column is part of the primary key
+	IsUnique         bool     // True if this column has a unique constraint (excluding PK)
+	ForeignKeyRefs   []string // References in format "schema.table.column"; one entry per FK the column participates in, empty if none
+	IsIndexed        bool     // True if this column is part of any index
+	IsIdentity       string   // Identity generation: "" (none), "a" (ALWAYS), "d" (BY DEFAULT)
+	DefaultValue     string   // Default value expression if any, empty otherwise
+	IsVectorColumn   bool     // True if this is a pgvector column
+	VectorDimensions int      // Number of dimensions for vector columns (0 if not a vector)
+	VectorType       string   // Underlying vector type: "vector", "halfvec", or "" if not a vector column
 }

--- a/internal/tools/get_schema_info.go
+++ b/internal/tools/get_schema_info.go
@@ -50,7 +50,8 @@ Returns comprehensive information in TSV format (one row per column):
 - All tables and views in the database
 - Column names, data types, nullable status
 - Primary key (is_pk) and unique constraint (is_unique) indicators
-- Foreign key references (fk_ref) in format "schema.table.column"
+- Foreign key references (fk_ref) in format "schema.table.column"; a
+  column in multiple foreign keys lists each reference, comma-separated
 - Index membership (is_indexed) for query optimization hints
 - Identity columns (identity): "a" for ALWAYS, "d" for BY DEFAULT, empty if not identity
 - Default values for columns (default)
@@ -373,7 +374,7 @@ To avoid rate limits when calling this tool:
 								col.Description,
 								fmt.Sprintf("%t", col.IsPrimaryKey),
 								fmt.Sprintf("%t", col.IsUnique),
-								col.ForeignKeyRef,
+								strings.Join(col.ForeignKeyRefs, ", "),
 								fmt.Sprintf("%t", col.IsIndexed),
 								col.IsIdentity,
 								col.DefaultValue,


### PR DESCRIPTION
## Summary

- The `fk_columns` CTE in `internal/database/load_metadata.sql` emitted one row per foreign-key constraint a column participates in, so the downstream `LEFT JOIN` keyed on `(schema, table, column)` multiplied the per-column rows and produced duplicate `ColumnInfo` entries; `get_schema_info` then listed the affected column once per FK.
- The CTE now aggregates every reference into a single ordered, de-duplicated `text[]` per column (one row per column), and `ColumnInfo.ForeignKeyRef` becomes `ForeignKeyRefs []string` so **all** references are surfaced rather than silently discarding all but one (shape (1) from the issue, the "most defensible long-term answer").
- The `fk_ref` TSV cell from `get_schema_info` now joins the references comma-separated; the tool description documents this.

## Test plan

- [x] `make test-server` — all `internal/...` Go tests pass.
- [x] `make lint` — 0 issues. `make fmt` clean.
- [x] New pure unit test `TestBuildTableInfo_PreservesMultipleFKReferences` (no DB).
- [x] New live-DB regression test `TestLoadMetadata_ColumnWithMultipleFKs` (gated on `TEST_PGEDGE_POSTGRES_CONNECTION_STRING`), run locally against a real Postgres with a column referenced by two parent tables: the column appears exactly once with both references in sorted order.
- [x] Verified the rewritten `load_metadata.sql` directly against a live Postgres with the two-FK fixture.

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema metadata so columns with multiple foreign key relationships are listed once, with all references preserved.
  * Improved `fk_ref` output to show multiple foreign key targets as a comma-separated list instead of only one reference.
  * Updated metadata handling so foreign key details are kept in deterministic order.
* **Tests**
  * Added regression coverage for columns involved in multiple foreign keys to prevent duplicate metadata entries.
  * Updated and extended metadata tests to validate multiple foreign key references end-to-end.
* **Documentation**
  * Updated the changelog and `get_schema_info` tool docs to reflect multi-reference `fk_ref` output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->