### PR TITLE
ci: use latest=auto so only GA release tags get the  Docker tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,7 +63,10 @@ jobs:
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=sha
-                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+                  # latest=auto tags GA releases (vX.Y.Z) as `latest`; semver
+                  # pre-releases (e.g. v1.0.0-rc1) are excluded automatically.
+                  flavor: |
+                      latest=auto
 
             - name: Build and push server image
               id: build
@@ -128,14 +131,16 @@ jobs:
               uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_SERVER }}
+                  # latest=auto with onlatest=true tags GA releases as
+                  # `latest-with-kb`; semver pre-releases are excluded.
                   flavor: |
+                      latest=auto
                       suffix=-with-kb,onlatest=true
                   tags: |
                       type=ref,event=branch,suffix=-with-kb
                       type=semver,pattern={{version}},suffix=-with-kb
                       type=semver,pattern={{major}}.{{minor}},suffix=-with-kb
                       type=sha,suffix=-with-kb
-                      type=raw,value=latest-with-kb,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
             - name: Build and push KB image
               uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
@@ -185,7 +190,9 @@ jobs:
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=sha
-                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+                  # latest=auto tags GA releases as `latest`; pre-releases skip.
+                  flavor: |
+                      latest=auto
 
             - name: Build and push web image
               uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
@@ -234,7 +241,9 @@ jobs:
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=sha
-                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+                  # latest=auto tags GA releases as `latest`; pre-releases skip.
+                  flavor: |
+                      latest=auto
 
             - name: Build and push CLI image
               uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5


### PR DESCRIPTION
- use latest=auto so only GA release tags get the latest docker image tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image tagging for GA releases.
  * Automatically applies the `latest` tag to stable images while excluding pre-releases.
  * Updated knowledge-base image tags to use a consistent `-with-kb` suffix across release and build tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->