### PR TITLE
fix: install SBOMs under /usr/share/<package>/ instead of flat /usr/share

### DIFF
--- a/pkg/deb/debian/rules
+++ b/pkg/deb/debian/rules
@@ -28,8 +28,8 @@ override_dh_auto_install:
 	install -D -m 644 debian/postgres-mcp.env debian/pgedge-postgres-mcp/etc/pgedge/postgres-mcp.env
 	install -D -m 644 server/LICENSE.md debian/pgedge-postgres-mcp/usr/share/doc/pgedge-postgres-mcp/LICENSE.md
 	install -D -m 644 server/README.md debian/pgedge-postgres-mcp/usr/share/doc/pgedge-postgres-mcp/README.md
-	install -D -m 644 debian/tmp/sbom/pgedge-postgres-mcp-sbom.json debian/pgedge-postgres-mcp/usr/share/pgedge-postgres-mcp-sbom.json
-	install -D -m 644 debian/tmp/sbom/pgedge-postgres-mcp-sbom.json.asc debian/pgedge-postgres-mcp/usr/share/pgedge-postgres-mcp-sbom.json.asc
+	install -D -m 644 debian/tmp/sbom/pgedge-postgres-mcp-sbom.json debian/pgedge-postgres-mcp/usr/share/pgedge-postgres-mcp/pgedge-postgres-mcp-sbom.json
+	install -D -m 644 debian/tmp/sbom/pgedge-postgres-mcp-sbom.json.asc debian/pgedge-postgres-mcp/usr/share/pgedge-postgres-mcp/pgedge-postgres-mcp-sbom.json.asc
 	install -d debian/pgedge-postgres-mcp/var/lib/pgedge/postgres-mcp
 	install -d debian/pgedge-postgres-mcp/var/log/pgedge/postgres-mcp
 	#CLI
@@ -42,8 +42,8 @@ override_dh_auto_install:
 	install -D -m 644 debian/nla-cli.yaml debian/pgedge-nla-cli/etc/pgedge/nla-cli.yaml
 	install -D -m 644 cli/LICENSE.md debian/pgedge-nla-cli/usr/share/doc/pgedge-nla-cli/LICENSE.md
 	install -D -m 644 cli/README.md debian/pgedge-nla-cli/usr/share/doc/pgedge-nla-cli/README.md
-	install -D -m 644 debian/tmp/sbom/pgedge-nla-cli-sbom.json debian/pgedge-nla-cli/usr/share/pgedge-nla-cli-sbom.json
-	install -D -m 644 debian/tmp/sbom/pgedge-nla-cli-sbom.json.asc debian/pgedge-nla-cli/usr/share/pgedge-nla-cli-sbom.json.asc
+	install -D -m 644 debian/tmp/sbom/pgedge-nla-cli-sbom.json debian/pgedge-nla-cli/usr/share/pgedge-nla-cli/pgedge-nla-cli-sbom.json
+	install -D -m 644 debian/tmp/sbom/pgedge-nla-cli-sbom.json.asc debian/pgedge-nla-cli/usr/share/pgedge-nla-cli/pgedge-nla-cli-sbom.json.asc
 	install -d debian/pgedge-nla-cli/etc/skel/.config/pgedge
 	# Web
 	syft dir:$(CURDIR)/web -o cyclonedx-json > debian/tmp/sbom/pgedge-nla-web-sbom.json || exit 1
@@ -57,8 +57,8 @@ override_dh_auto_install:
 	install -D -m 644 web/LICENSE.md debian/pgedge-nla-web/usr/share/doc/pgedge-nla-web/LICENSE.md
 	install -D -m 644 web/README.md debian/pgedge-nla-web/usr/share/doc/pgedge-nla-web/README.md
 	install -d debian/pgedge-nla-web/var/log/pgedge/nla-web
-	install -D -m 644 debian/tmp/sbom/pgedge-nla-web-sbom.json debian/pgedge-nla-web/usr/share/pgedge-nla-web-sbom.json
-	install -D -m 644 debian/tmp/sbom/pgedge-nla-web-sbom.json.asc debian/pgedge-nla-web/usr/share/pgedge-nla-web-sbom.json.asc
+	install -D -m 644 debian/tmp/sbom/pgedge-nla-web-sbom.json debian/pgedge-nla-web/usr/share/pgedge-nla-web/pgedge-nla-web-sbom.json
+	install -D -m 644 debian/tmp/sbom/pgedge-nla-web-sbom.json.asc debian/pgedge-nla-web/usr/share/pgedge-nla-web/pgedge-nla-web-sbom.json.asc
 	# Note: the kb.db knowledgebase and the kb-builder tool are no longer shipped
 	# here. They now live in the standalone pgedge-ai-kb project.
 	rm -rf debian/tmp/sbom

--- a/pkg/rpm/pgedge-nla.spec
+++ b/pkg/rpm/pgedge-nla.spec
@@ -106,9 +106,8 @@ install -m 755 %{_builddir}/server/pgedge-postgres-mcp %{buildroot}%{_bindir}/
 install -m 644 %{_builddir}/server/LICENSE.md %{buildroot}%{_defaultdocdir}/pgedge-postgres-mcp/
 install -m 644 %{_builddir}/server/README.md %{buildroot}%{_defaultdocdir}/pgedge-postgres-mcp/
 
-mkdir -p %{buildroot}%{_datadir}
-install -p -m 0644 %{_builddir}/pgedge-postgres-mcp-sbom.json %{buildroot}%{_datadir}/pgedge-postgres-mcp-sbom.json
-install -p -m 0644 %{_builddir}/pgedge-postgres-mcp-sbom.json.asc %{buildroot}%{_datadir}/pgedge-postgres-mcp-sbom.json.asc
+install -Dp -m 0644 %{_builddir}/pgedge-postgres-mcp-sbom.json %{buildroot}%{_datadir}/pgedge-postgres-mcp/pgedge-postgres-mcp-sbom.json
+install -Dp -m 0644 %{_builddir}/pgedge-postgres-mcp-sbom.json.asc %{buildroot}%{_datadir}/pgedge-postgres-mcp/pgedge-postgres-mcp-sbom.json.asc
 
 # Install systemd service
 install -d %{buildroot}%{_unitdir}
@@ -124,8 +123,8 @@ install -m 644 %{SOURCE6} %{buildroot}%{_sysconfdir}/pgedge/postgres-mcp.env
 install -m 755 %{_builddir}/cli/pgedge-nla-cli %{buildroot}%{_bindir}/
 install -m 644 %{_builddir}/cli/LICENSE.md %{buildroot}%{_defaultdocdir}/pgedge-nla-cli/
 install -m 644 %{_builddir}/cli/README.md %{buildroot}%{_defaultdocdir}/pgedge-nla-cli/
-install -p -m 0644 %{_builddir}/%{sname}-cli-sbom.json %{buildroot}%{_datadir}/%{sname}-cli-sbom.json
-install -p -m 0644 %{_builddir}/%{sname}-cli-sbom.json.asc %{buildroot}%{_datadir}/%{sname}-cli-sbom.json.asc
+install -Dp -m 0644 %{_builddir}/%{sname}-cli-sbom.json %{buildroot}%{_datadir}/pgedge-nla-cli/%{sname}-cli-sbom.json
+install -Dp -m 0644 %{_builddir}/%{sname}-cli-sbom.json.asc %{buildroot}%{_datadir}/pgedge-nla-cli/%{sname}-cli-sbom.json.asc
 install -m 644 %{SOURCE7} %{buildroot}%{_sysconfdir}/pgedge/nla-cli.yaml
 install -d -m 0755 %{buildroot}/etc/skel/.config/pgedge
 
@@ -137,8 +136,8 @@ install -d %{buildroot}/var/log/pgedge/nla-web
 cp -r %{_builddir}/web/dist/* %{buildroot}%{_datadir}/pgedge/nla-web/
 install -d %{buildroot}/etc/nginx/conf.d
 install -m 644 %{SOURCE8} %{buildroot}/etc/nginx/conf.d/pgedge-nla-web.conf
-install -p -m 0644 %{_builddir}/%{sname}-web-sbom.json %{buildroot}%{_datadir}/%{sname}-web-sbom.json
-install -p -m 0644 %{_builddir}/%{sname}-web-sbom.json.asc %{buildroot}%{_datadir}/%{sname}-web-sbom.json.asc
+install -Dp -m 0644 %{_builddir}/%{sname}-web-sbom.json %{buildroot}%{_datadir}/pgedge-nla-web/%{sname}-web-sbom.json
+install -Dp -m 0644 %{_builddir}/%{sname}-web-sbom.json.asc %{buildroot}%{_datadir}/pgedge-nla-web/%{sname}-web-sbom.json.asc
 
 # Note: the kb.db knowledgebase and the kb-builder tool are no longer shipped
 # here. The knowledgebase ships in the standalone pgedge-ai-kb package, and the
@@ -150,8 +149,9 @@ install -p -m 0644 %{_builddir}/%{sname}-web-sbom.json.asc %{buildroot}%{_datadi
 %{_bindir}/pgedge-postgres-mcp
 %config(noreplace) %{_sysconfdir}/pgedge/postgres-mcp.yaml
 %config(noreplace) %{_sysconfdir}/pgedge/postgres-mcp.env
-%{_datadir}/pgedge-postgres-mcp-sbom.json
-%{_datadir}/pgedge-postgres-mcp-sbom.json.asc
+%dir %{_datadir}/pgedge-postgres-mcp
+%{_datadir}/pgedge-postgres-mcp/pgedge-postgres-mcp-sbom.json
+%{_datadir}/pgedge-postgres-mcp/pgedge-postgres-mcp-sbom.json.asc
 %{_unitdir}/pgedge-postgres-mcp.service
 %dir %attr(0755,pgedge,pgedge) /var/lib/pgedge
 %dir %attr(0755,pgedge,pgedge) /var/lib/pgedge/postgres-mcp
@@ -165,8 +165,9 @@ install -p -m 0644 %{_builddir}/%{sname}-web-sbom.json.asc %{buildroot}%{_datadi
 %config(noreplace) %{_sysconfdir}/pgedge/nla-cli.yaml
 %dir %attr(0755,root,root) /etc/skel/.config
 %dir %attr(0755,root,root) /etc/skel/.config/pgedge
-%{_datadir}/%{sname}-cli-sbom.json
-%{_datadir}/%{sname}-cli-sbom.json.asc
+%dir %{_datadir}/pgedge-nla-cli
+%{_datadir}/pgedge-nla-cli/%{sname}-cli-sbom.json
+%{_datadir}/pgedge-nla-cli/%{sname}-cli-sbom.json.asc
 
 %files web
 %license %{_defaultdocdir}/pgedge-nla-web/LICENSE.md
@@ -175,8 +176,9 @@ install -p -m 0644 %{_builddir}/%{sname}-web-sbom.json.asc %{buildroot}%{_datadi
 %dir %attr(0755,pgedge,pgedge) /var/log/pgedge/nla-web
 %{_datadir}/pgedge/nla-web
 %config(noreplace) /etc/nginx/conf.d/pgedge-nla-web.conf
-%{_datadir}/%{sname}-web-sbom.json
-%{_datadir}/%{sname}-web-sbom.json.asc
+%dir %{_datadir}/pgedge-nla-web
+%{_datadir}/pgedge-nla-web/%{sname}-web-sbom.json
+%{_datadir}/pgedge-nla-web/%{sname}-web-sbom.json.asc
 
 %post -n pgedge-postgres-mcp
 %systemd_post pgedge-postgres-mcp.service


### PR DESCRIPTION
Fixes SBOM install paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Software Bill of Materials (SBOM) files and their GPG signatures are now packaged in dedicated directories for the server, CLI, and web components.
  - Debian and RPM packages consistently place these security and compliance artifacts alongside their respective components.
  - Updated package contents make SBOM files easier to locate and help prevent conflicts between component artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->