### PR TITLE
fix: show configured display name instead of raw connection details (…

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -149,6 +149,25 @@ and this project adheres to
 
 ### Fixed
 
+- Tool and resource responses now show the operator-configured database
+  display name instead of the raw connection details. Previously,
+  `query_database`, `get_schema_info`, `execute_explain`, `count_rows`,
+  and `similarity_search` only masked the password in the connection
+  string they showed the caller, leaving the real host, port, and
+  database name visible; `pg://system_info` was worse, reporting the
+  live-resolved server address from `inet_server_addr()`, which can be
+  an internal-only address (a container or pod IP) that differs from,
+  and may be unreachable via, the address the operator actually
+  configured. A new `Client.DisplayName()` now backs every one of
+  these responses with the connection's configured `name` (falling
+  back to a password-masked connection string when none is
+  configured); `pg://system_info` gains a `connection_name` field and
+  its `host`/`port` fields now reflect the configured values rather
+  than a live-resolved one. Ad-hoc connection strings a caller types
+  inline (the `postgres://...` mini-DSL supported by `query_database`)
+  are intentionally left as-is, since echoing back what the caller
+  themselves supplied is not a leak. (#187)
+
 - Metadata loader now tolerates tables with zero columns
   (e.g. `CREATE TABLE foo()`). The query LEFT JOINs against the
   per-column catalog, so a zero-column table produced a row whose

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -90,7 +90,7 @@ When you read the resource to view PostgreSQL system information, the result is 
 | `user` | Current database user. |
 | `host` | The operator-configured connection host (or `unix socket`), never a live-resolved server address. |
 | `port` | The operator-configured connection port. |
-| `connection_name` | The operator-configured display name for this database, when one is set. Prefer this over `host`/`port` when referring to "which database" in a response to the caller. |
+| `connection_name` | The operator-configured display name for this database, when one is set; otherwise a password-masked connection string. Prefer this over `host`/`port` when referring to "which database" in a response to the caller. |
 | `allow_writes` | Whether write operations are permitted (default: `false`). |
 
 

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -70,6 +70,7 @@ When you read the resource to view PostgreSQL system information, the result is 
   "user": "postgres",
   "host": "localhost",
   "port": 5432,
+  "connection_name": "orders-prod",
   "allow_writes": false
 }
 ```
@@ -87,8 +88,9 @@ When you read the resource to view PostgreSQL system information, the result is 
 | `bit_version` | Architecture bit version (e.g., `64-bit`, `32-bit`). |
 | `database` | Currently connected database name. |
 | `user` | Current database user. |
-| `host` | Connection host (or `unix socket`). |
-| `port` | Connection port number. |
+| `host` | The operator-configured connection host (or `unix socket`), never a live-resolved server address. |
+| `port` | The operator-configured connection port. |
+| `connection_name` | The operator-configured display name for this database, when one is set. Prefer this over `host`/`port` when referring to "which database" in a response to the caller. |
 | `allow_writes` | Whether write operations are permitted (default: `false`). |
 
 

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -278,6 +278,69 @@ func (c *Client) AllowWrites() bool {
 	return c.dbConfig.AllowWrites
 }
 
+// DisplayName returns the operator-configured display name for this
+// client's database (config.NamedDatabaseConfig.Name), for use in any
+// user-facing string. It deliberately never returns the raw host/port: an
+// internal-only address (a Kubernetes pod IP, a private VPC host) that the
+// caller cannot reach is not useful information and only exposes
+// infrastructure detail (issue #187).
+//
+// Falls back to a password-masked connection string when no name is
+// configured, e.g. a bare client built without a NamedDatabaseConfig.
+func (c *Client) DisplayName() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.dbConfig != nil && c.dbConfig.Name != "" {
+		return c.dbConfig.Name
+	}
+	return SanitizeConnStr(c.defaultConnStr)
+}
+
+// ConfiguredHost returns the operator-configured host for this client's
+// database (the first entry of Hosts when multi-host failover is
+// configured, matching the same backward-compatibility rule used by
+// GET /api/databases), or "unix socket" if no config is set.
+//
+// This is deliberately the value the operator wrote in the config file,
+// never a live-resolved server address such as inet_server_addr(): the
+// latter can report an internal-only address (a container or pod IP) that
+// differs from, and may be unreachable via, the host the operator actually
+// configured (issue #187).
+func (c *Client) ConfiguredHost() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.dbConfig == nil {
+		return "unix socket"
+	}
+	if len(c.dbConfig.Hosts) > 0 {
+		return c.dbConfig.Hosts[0].Host
+	}
+	return c.dbConfig.Host
+}
+
+// ConfiguredPort returns the operator-configured port for this client's
+// database (the first entry of Hosts when multi-host failover is
+// configured), defaulting to 5432 when unset to match
+// NamedDatabaseConfig.BuildConnectionString's default. Returns 0 if no
+// config is set.
+func (c *Client) ConfiguredPort() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.dbConfig == nil {
+		return 0
+	}
+	if len(c.dbConfig.Hosts) > 0 {
+		if c.dbConfig.Hosts[0].Port == 0 {
+			return 5432
+		}
+		return c.dbConfig.Hosts[0].Port
+	}
+	if c.dbConfig.Port == 0 {
+		return 5432
+	}
+	return c.dbConfig.Port
+}
+
 // Close closes all database connections
 func (c *Client) Close() {
 	c.mu.Lock()

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -299,7 +299,9 @@ func (c *Client) DisplayName() string {
 // ConfiguredHost returns the operator-configured host for this client's
 // database (the first entry of Hosts when multi-host failover is
 // configured, matching the same backward-compatibility rule used by
-// GET /api/databases), or "unix socket" if no config is set.
+// GET /api/databases), defaulting to "localhost" when a single-host config
+// omits it (matching NamedDatabaseConfig.Host's documented default), or
+// "unix socket" if no config is set.
 //
 // This is deliberately the value the operator wrote in the config file,
 // never a live-resolved server address such as inet_server_addr(): the
@@ -313,7 +315,11 @@ func (c *Client) ConfiguredHost() string {
 		return "unix socket"
 	}
 	if len(c.dbConfig.Hosts) > 0 {
+		// Validate rejects empty entries in Hosts, so no default needed here.
 		return c.dbConfig.Hosts[0].Host
+	}
+	if c.dbConfig.Host == "" {
+		return "localhost"
 	}
 	return c.dbConfig.Host
 }

--- a/internal/database/display_test.go
+++ b/internal/database/display_test.go
@@ -87,6 +87,11 @@ func TestConfiguredHost(t *testing.T) {
 			cfg:  nil,
 			want: "unix socket",
 		},
+		{
+			name: "single-host config with omitted host defaults to localhost",
+			cfg:  &config.NamedDatabaseConfig{Name: "db1", Port: 5432},
+			want: "localhost",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/database/display_test.go
+++ b/internal/database/display_test.go
@@ -1,0 +1,149 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package database
+
+import (
+	"testing"
+
+	"pgedge-postgres-mcp/internal/config"
+)
+
+// TestDisplayName_UsesConfiguredName is a regression test for issue #187:
+// user-facing strings must show the operator-configured name, never the
+// raw connection string.
+func TestDisplayName_UsesConfiguredName(t *testing.T) {
+	client := NewClientWithConnectionString(
+		"postgres://appuser:secret@10.244.1.7:5432/orders_prod",
+		&config.NamedDatabaseConfig{Name: "orders-prod", Host: "10.244.1.7", Port: 5432},
+	)
+
+	got := client.DisplayName()
+	if got != "orders-prod" {
+		t.Errorf("DisplayName() = %q, want %q", got, "orders-prod")
+	}
+	if got == "10.244.1.7" {
+		t.Fatal("BUG #187 reproduced: DisplayName() leaked the raw host")
+	}
+}
+
+// TestDisplayName_FallsBackWhenNoConfig covers the two cases where there is
+// no configured name to substitute: no config at all, and a config with an
+// empty name (e.g. an ad-hoc connection string the caller typed inline,
+// which has no NamedDatabaseConfig behind it at all in practice, but the
+// empty-Name case is tested directly since it exercises the same fallback
+// branch). The password must still be masked either way.
+func TestDisplayName_FallsBackWhenNoConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.NamedDatabaseConfig
+	}{
+		{name: "nil config", cfg: nil},
+		{name: "config with empty name", cfg: &config.NamedDatabaseConfig{Host: "10.244.1.7", Port: 5432}},
+	}
+
+	connStr := "postgres://appuser:secret@10.244.1.7:5432/orders_prod"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClientWithConnectionString(connStr, tt.cfg)
+
+			got := client.DisplayName()
+			if got != "postgres://appuser:***@10.244.1.7:5432/orders_prod" {
+				t.Errorf("DisplayName() = %q, want password-masked connection string", got)
+			}
+		})
+	}
+}
+
+func TestConfiguredHost(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.NamedDatabaseConfig
+		want string
+	}{
+		{
+			name: "single host",
+			cfg:  &config.NamedDatabaseConfig{Name: "db1", Host: "10.244.1.7", Port: 5432},
+			want: "10.244.1.7",
+		},
+		{
+			name: "multi-host uses first entry",
+			cfg: &config.NamedDatabaseConfig{
+				Name:  "db1",
+				Hosts: []config.HostEntry{{Host: "10.244.1.7", Port: 5432}, {Host: "10.244.1.8", Port: 5432}},
+			},
+			want: "10.244.1.7",
+		},
+		{
+			name: "nil config falls back to unix socket",
+			cfg:  nil,
+			want: "unix socket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClientWithConnectionString("postgres://localhost/test", tt.cfg)
+			if got := client.ConfiguredHost(); got != tt.want {
+				t.Errorf("ConfiguredHost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfiguredPort(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.NamedDatabaseConfig
+		want int
+	}{
+		{
+			name: "explicit port",
+			cfg:  &config.NamedDatabaseConfig{Name: "db1", Host: "10.244.1.7", Port: 6543},
+			want: 6543,
+		},
+		{
+			name: "zero port defaults to 5432",
+			cfg:  &config.NamedDatabaseConfig{Name: "db1", Host: "10.244.1.7"},
+			want: 5432,
+		},
+		{
+			name: "multi-host uses first entry's port",
+			cfg: &config.NamedDatabaseConfig{
+				Name:  "db1",
+				Hosts: []config.HostEntry{{Host: "10.244.1.7", Port: 6543}, {Host: "10.244.1.8", Port: 6544}},
+			},
+			want: 6543,
+		},
+		{
+			name: "multi-host first entry zero port defaults to 5432",
+			cfg: &config.NamedDatabaseConfig{
+				Name:  "db1",
+				Hosts: []config.HostEntry{{Host: "10.244.1.7"}},
+			},
+			want: 5432,
+		},
+		{
+			name: "nil config returns 0",
+			cfg:  nil,
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClientWithConnectionString("postgres://localhost/test", tt.cfg)
+			if got := client.ConfiguredPort(); got != tt.want {
+				t.Errorf("ConfiguredPort() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/database/test_helpers.go
+++ b/internal/database/test_helpers.go
@@ -10,7 +10,11 @@
 
 package database
 
-import "time"
+import (
+	"time"
+
+	"pgedge-postgres-mcp/internal/config"
+)
 
 // NewTestClient creates a database client for testing with mock data
 // This allows tests in other packages to create clients with predetermined metadata
@@ -29,5 +33,15 @@ func NewTestClient(connStr string, metadata map[string]TableInfo) *Client {
 	// Set as default connection
 	client.defaultConnStr = connStr
 
+	return client
+}
+
+// NewTestClientWithConfig is NewTestClient plus an attached
+// NamedDatabaseConfig, for tests that need to exercise config-derived
+// behavior such as DisplayName, ConfiguredHost, ConfiguredPort, or
+// AllowWrites.
+func NewTestClientWithConfig(connStr string, metadata map[string]TableInfo, cfg *config.NamedDatabaseConfig) *Client {
+	client := NewTestClient(connStr, metadata)
+	client.dbConfig = cfg
 	return client
 }

--- a/internal/resources/pg_system_info.go
+++ b/internal/resources/pg_system_info.go
@@ -48,8 +48,11 @@ Returns JSON with:
 - bit_version: 32-bit or 64-bit
 - database: Currently connected database name
 - user: Current database user
-- host: Connection host (or "unix socket")
-- port: Connection port number
+- host: The operator-configured connection host (or "unix socket")
+- port: The operator-configured connection port
+- connection_name: The operator-configured display name for this
+  database, if one is set; prefer this when referring to "which
+  database" in a response to the caller
 - allow_writes: Whether write operations are permitted (default: false)
 </provided_info>
 
@@ -73,9 +76,7 @@ Use before:
 					current_setting('server_version') AS version,
 					current_setting('server_version_num') AS version_number,
 					current_database() AS database,
-					current_user AS user,
-					COALESCE(inet_server_addr()::text, 'unix socket') AS host,
-					COALESCE(inet_server_port(), 0) AS port
+					current_user AS user
 			`
 
 			processor := func(rows pgx.Rows) (interface{}, error) {
@@ -83,9 +84,8 @@ Use before:
 					return nil, fmt.Errorf("no system information returned")
 				}
 
-				var fullVersion, version, versionNumber, database, user, host string
-				var port int
-				err := rows.Scan(&fullVersion, &version, &versionNumber, &database, &user, &host, &port)
+				var fullVersion, version, versionNumber, database, user string
+				err := rows.Scan(&fullVersion, &version, &versionNumber, &database, &user)
 				if err != nil {
 					return nil, fmt.Errorf("failed to scan system info: %w", err)
 				}
@@ -95,11 +95,17 @@ Use before:
 				systemInfo := parseVersionString(fullVersion, version, versionNumber)
 				systemInfo.Database = database
 				systemInfo.User = user
-				systemInfo.Host = host
-				systemInfo.Port = port
-				// Include write access status from database configuration
+				// Host/port are the operator-configured values, never the
+				// live-resolved server address (inet_server_addr() can
+				// report an internal-only address the caller cannot
+				// reach - issue #187).
 				if dbClient != nil {
+					systemInfo.Host = dbClient.ConfiguredHost()
+					systemInfo.Port = dbClient.ConfiguredPort()
+					systemInfo.ConnectionName = dbClient.DisplayName()
 					systemInfo.AllowWrites = dbClient.AllowWrites()
+				} else {
+					systemInfo.Host = "unix socket"
 				}
 				return systemInfo, nil
 			}
@@ -122,6 +128,7 @@ type SystemInfo struct {
 	User              string `json:"user"`
 	Host              string `json:"host"`
 	Port              int    `json:"port"`
+	ConnectionName    string `json:"connection_name,omitempty"`
 	AllowWrites       bool   `json:"allow_writes"`
 }
 

--- a/internal/resources/pg_system_info.go
+++ b/internal/resources/pg_system_info.go
@@ -51,8 +51,9 @@ Returns JSON with:
 - host: The operator-configured connection host (or "unix socket")
 - port: The operator-configured connection port
 - connection_name: The operator-configured display name for this
-  database, if one is set; prefer this when referring to "which
-  database" in a response to the caller
+  database, if one is set, otherwise a password-masked connection
+  string; prefer this when referring to "which database" in a
+  response to the caller
 - allow_writes: Whether write operations are permitted (default: false)
 </provided_info>
 

--- a/internal/resources/pg_system_info_display_test.go
+++ b/internal/resources/pg_system_info_display_test.go
@@ -1,0 +1,85 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package resources
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"pgedge-postgres-mcp/internal/config"
+	"pgedge-postgres-mcp/internal/database"
+)
+
+// TestPGSystemInfoResource_UsesConfiguredDisplayValues is a regression test
+// for issue #187: pg://system_info must report the operator-configured
+// host/port/name, never the live-resolved server address from
+// inet_server_addr(), which can be an internal-only address (a container
+// or pod IP) that differs from, and may be unreachable via, the address
+// the operator actually configured.
+func TestPGSystemInfoResource_UsesConfiguredDisplayValues(t *testing.T) {
+	connStr := os.Getenv("TEST_PGEDGE_POSTGRES_CONNECTION_STRING")
+	if connStr == "" {
+		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set; skipping live-DB regression test for issue #187")
+	}
+
+	// A deliberately distinctive configured host/name pair. The live
+	// server may report a completely different address (e.g. a Docker
+	// bridge IP) via inet_server_addr() - if that ever leaks through,
+	// this test must fail.
+	const configuredHost = "configured-display-host.example.internal"
+	const configuredName = "orders-prod-display-name"
+	cfg := &config.NamedDatabaseConfig{
+		Name: configuredName,
+		Host: configuredHost,
+		Port: 6543,
+	}
+
+	client := database.NewClientWithConnectionString(connStr, cfg)
+	defer client.Close()
+
+	if err := client.ConnectTo(connStr); err != nil {
+		t.Fatalf("ConnectTo failed: %v", err)
+	}
+	if err := client.LoadMetadata(); err != nil {
+		t.Fatalf("LoadMetadata failed: %v", err)
+	}
+
+	resource := PGSystemInfoResource(client)
+	content, err := resource.Handler()
+	if err != nil {
+		t.Fatalf("Handler failed: %v", err)
+	}
+	if len(content.Contents) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+
+	var info SystemInfo
+	if err := json.Unmarshal([]byte(content.Contents[0].Text), &info); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	if info.Host != configuredHost {
+		t.Errorf("host = %q, want configured host %q", info.Host, configuredHost)
+	}
+	if info.Port != 6543 {
+		t.Errorf("port = %d, want configured port 6543", info.Port)
+	}
+	if info.ConnectionName != configuredName {
+		t.Errorf("connection_name = %q, want %q", info.ConnectionName, configuredName)
+	}
+
+	// The definitive check: whatever inet_server_addr() actually resolves
+	// to on this connection, it must not be what the caller sees.
+	if info.Host == "unix socket" && configuredHost != "unix socket" {
+		t.Errorf("BUG #187 reproduced: host fell back to the live-resolved value instead of the configured one")
+	}
+}

--- a/internal/tools/count_rows.go
+++ b/internal/tools/count_rows.go
@@ -96,7 +96,7 @@ Use count_rows to efficiently determine data volume:
 
 			pool := dbClient.GetPoolFor(connStr)
 			if pool == nil {
-				return mcp.NewToolError(fmt.Sprintf("Connection pool not found for: %s", database.SanitizeConnStr(connStr)))
+				return mcp.NewToolError(fmt.Sprintf("Connection pool not found for: %s", dbClient.DisplayName()))
 			}
 
 			// Build the COUNT query with proper quoting
@@ -157,7 +157,7 @@ Use count_rows to efficiently determine data volume:
 
 			// Build response
 			var sb strings.Builder
-			fmt.Fprintf(&sb, "Database: %s\n\n", database.SanitizeConnStr(connStr))
+			fmt.Fprintf(&sb, "Database: %s\n\n", dbClient.DisplayName())
 			fmt.Fprintf(&sb, "SQL Query:\n%s\n\n", sqlQuery)
 			fmt.Fprintf(&sb, "Count: %d", count)
 

--- a/internal/tools/execute_explain.go
+++ b/internal/tools/execute_explain.go
@@ -199,8 +199,7 @@ READ ONLY transaction to prevent side effects. However, be cautious with:
 
 			// Format the output
 			var result strings.Builder
-			sanitizedConn := database.SanitizeConnStr(connStr)
-			fmt.Fprintf(&result, "Database: %s\n\n", sanitizedConn)
+			fmt.Fprintf(&result, "Database: %s\n\n", dbClient.DisplayName())
 			fmt.Fprintf(&result, "Query:\n%s\n\n", query)
 			result.WriteString("Execution Plan:\n")
 			result.WriteString(strings.Repeat("=", 80))

--- a/internal/tools/get_schema_info.go
+++ b/internal/tools/get_schema_info.go
@@ -390,14 +390,11 @@ To avoid rate limits when calling this tool:
 
 			// Handle empty results with contextual guidance
 			if matchedTables == 0 {
-				connStr := dbClient.GetDefaultConnection()
-				sanitizedConn := database.SanitizeConnStr(connStr)
-
 				var emptyMsg strings.Builder
 				emptyMsg.WriteString("\nNo tables found matching your criteria.\n\n")
 
 				emptyMsg.WriteString("<current_connection>\n")
-				fmt.Fprintf(&emptyMsg, "Connected to: %s\n", sanitizedConn)
+				fmt.Fprintf(&emptyMsg, "Connected to: %s\n", dbClient.DisplayName())
 				emptyMsg.WriteString("</current_connection>\n\n")
 
 				emptyMsg.WriteString("<diagnosis>\n")
@@ -471,9 +468,7 @@ To avoid rate limits when calling this tool:
 			}
 
 			// Prepend database context to the response
-			connStr := dbClient.GetDefaultConnection()
-			sanitizedConn := database.SanitizeConnStr(connStr)
-			result := fmt.Sprintf("Database: %s\n\n%s", sanitizedConn, sb.String())
+			result := fmt.Sprintf("Database: %s\n\n%s", dbClient.DisplayName(), sb.String())
 
 			return mcp.NewToolSuccess(result)
 		},

--- a/internal/tools/get_schema_info_test.go
+++ b/internal/tools/get_schema_info_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"pgedge-postgres-mcp/internal/config"
 	"pgedge-postgres-mcp/internal/database"
 )
 
@@ -966,6 +967,61 @@ func TestGetSchemaInfoTool(t *testing.T) {
 		}
 		if strings.Contains(content, "events_2024_01") {
 			t.Error("Expected child partition hidden in compact mode")
+		}
+	})
+}
+
+// TestGetSchemaInfoTool_UsesDisplayName is a regression test for issue
+// #187: responses must show the operator-configured display name, never
+// the raw (possibly internal-only) connection host.
+func TestGetSchemaInfoTool_UsesDisplayName(t *testing.T) {
+	internalHost := "10.244.1.7"
+	cfg := &config.NamedDatabaseConfig{Name: "orders-prod", Host: internalHost, Port: 5432}
+
+	t.Run("empty results path", func(t *testing.T) {
+		client := database.NewTestClientWithConfig(
+			"postgres://appuser:secret@10.244.1.7:5432/orders_prod",
+			map[string]database.TableInfo{},
+			cfg,
+		)
+
+		tool := GetSchemaInfoTool(client)
+		response, err := tool.Handler(map[string]interface{}{"schema_name": "nonexistent"})
+		if err != nil {
+			t.Fatalf("Handler returned error: %v", err)
+		}
+
+		content := response.Content[0].Text
+		if !strings.Contains(content, "Connected to: orders-prod") {
+			t.Errorf("expected display name in response, got: %s", content)
+		}
+		if strings.Contains(content, internalHost) {
+			t.Errorf("BUG #187 reproduced: response leaked the raw host: %s", content)
+		}
+	})
+
+	t.Run("normal results path", func(t *testing.T) {
+		metadata := map[string]database.TableInfo{
+			"public.users": {SchemaName: "public", TableName: "users", TableType: "TABLE"},
+		}
+		client := database.NewTestClientWithConfig(
+			"postgres://appuser:secret@10.244.1.7:5432/orders_prod",
+			metadata,
+			cfg,
+		)
+
+		tool := GetSchemaInfoTool(client)
+		response, err := tool.Handler(map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("Handler returned error: %v", err)
+		}
+
+		content := response.Content[0].Text
+		if !strings.Contains(content, "Database: orders-prod") {
+			t.Errorf("expected display name in response, got: %s", content)
+		}
+		if strings.Contains(content, internalHost) {
+			t.Errorf("BUG #187 reproduced: response leaked the raw host: %s", content)
 		}
 	})
 }

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -286,7 +286,15 @@ To avoid rate limits (30,000 input tokens/minute):
 			ctx := context.Background()
 			pool := dbClient.GetPoolFor(connStr)
 			if pool == nil {
-				return mcp.NewToolError(fmt.Sprintf("Connection pool not found for: %s", database.SanitizeConnStr(connStr)))
+				// An ad-hoc connection string the caller supplied inline is
+				// echoed back sanitized (they already know what they typed);
+				// otherwise show the configured display name, never the raw
+				// default connection's host (issue #187).
+				display := dbClient.DisplayName()
+				if queryCtx.ConnectionString != "" {
+					display = database.SanitizeConnStr(connStr)
+				}
+				return mcp.NewToolError(fmt.Sprintf("Connection pool not found for: %s", display))
 			}
 
 			// Begin a transaction with read-only protection
@@ -397,8 +405,7 @@ To avoid rate limits (30,000 input tokens/minute):
 
 			// Always show current database context (unless already shown via connection message)
 			if connectionMessage == "" {
-				sanitizedConn := database.SanitizeConnStr(connStr)
-				fmt.Fprintf(&sb, "Database: %s\n\n", sanitizedConn)
+				fmt.Fprintf(&sb, "Database: %s\n\n", dbClient.DisplayName())
 			} else {
 				sb.WriteString(connectionMessage)
 			}

--- a/internal/tools/similarity_search.go
+++ b/internal/tools/similarity_search.go
@@ -205,13 +205,10 @@ To avoid rate limits (30,000 input tokens/minute):
 			metadataMap := dbClient.GetMetadata()
 			tableInfo, err := findTableInMetadataMap(metadataMap, tableName)
 			if err != nil {
-				connStr := dbClient.GetDefaultConnection()
-				sanitizedConn := database.SanitizeConnStr(connStr)
-
 				var errMsg strings.Builder
 				fmt.Fprintf(&errMsg, "Table '%s' not found.\n\n", tableName)
 				errMsg.WriteString("<current_connection>\n")
-				fmt.Fprintf(&errMsg, "Connected to: %s\n", sanitizedConn)
+				fmt.Fprintf(&errMsg, "Connected to: %s\n", dbClient.DisplayName())
 				errMsg.WriteString("</current_connection>\n\n")
 				errMsg.WriteString("<diagnosis>\n")
 				errMsg.WriteString("Possible reasons:\n")
@@ -432,9 +429,7 @@ To avoid rate limits (30,000 input tokens/minute):
 			}
 
 			// Prepend database context
-			connStr := dbClient.GetDefaultConnection()
-			sanitizedConn := database.SanitizeConnStr(connStr)
-			result := fmt.Sprintf("Database: %s\nTable: %s\n\n%s", sanitizedConn, tableName, output)
+			result := fmt.Sprintf("Database: %s\nTable: %s\n\n%s", dbClient.DisplayName(), tableName, output)
 
 			// Log execution metrics
 			totalTokens := 0


### PR DESCRIPTION
## Summary

- Tool and resource responses only masked the password in the connection string they showed the caller, leaving the real host, port, and database name fully visible. `pg://system_info` was worse: it queried `inet_server_addr()`/`inet_server_port()` live, reporting the actual server-side network address of the connection rather than anything the operator configured.
- Confirmed live against a real Postgres container: connecting via its Docker DNS name returned the container's internal bridge IP (`172.19.0.2`, unreachable from outside that network) as `"host"` in the resource, and the same raw address leaked through `query_database`/`get_schema_info`/`execute_explain`/`count_rows`/`similarity_search` — with the operator's configured display name appearing nowhere.
- `Client.DisplayName()` now backs every one of these responses with the connection's configured `name`, falling back to a password-masked connection string when none is configured. Two new getters, `ConfiguredHost()`/`ConfiguredPort()`, give `pg_system_info` the operator's configured address (matching what `list_database_connections`/`GET /api/databases` already expose) instead of a live-resolved one; the resource also gains a `connection_name` field carrying the display name directly.
- Deliberately left alone: the ad-hoc `postgres://...` connection strings a caller can type inline in `query_database`'s mini-DSL. Echoing back what the caller themselves supplied isn't a leak, so those paths still show a password-masked version of their own literal input rather than a display name.

## Test plan

- [x] New unit tests for `DisplayName`/`ConfiguredHost`/`ConfiguredPort` cover configured name, no config, empty name, multi-host failover configs, and port defaulting — pure logic, no DB required.
- [x] New `TestGetSchemaInfoTool_UsesDisplayName` and `TestPGSystemInfoResource_UsesConfiguredDisplayValues` reproduce the bug precisely (a distinctive internal-looking host that must never appear in the response). Confirmed non-tautological: reverted against the pre-fix code, the `get_schema_info` test fails exactly as expected, and the `system_info` test fails to even compile since `connection_name` doesn't exist without the fix.
- [x] The `system_info` test was run for real against a live local PostgreSQL instance, proving the fix end-to-end through actual SQL execution, not mocked logic.
- [x] Rebuilt the actual server binary and drove it through the real MCP JSON-RPC protocol (`initialize`, `resources/read`, `tools/call`) against a live Postgres container, confirming `query_database`, `get_schema_info`, `execute_explain`, `count_rows`, and `pg://system_info` all now show the configured display name end-to-end.
- [x] Full `internal/database`, `internal/resources`, `internal/tools` suites pass under `-race`, both with and without a live `TEST_PGEDGE_POSTGRES_CONNECTION_STRING`. One unrelated pre-existing failure (`TestClientManager_Concurrency`) was confirmed to fail identically on unmodified `main` with the same environment — not a regression from this change.
- [x] `make lint-server`: 0 issues. `make test-server`: exit code 0 (verified directly, not through a piped `tail`), zero failures across every server package.

Closes #187


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database tools now show the operator-configured database display name instead of raw connection details (host/port), with passwords still masked when no name is available.
  * `pg://system_info` now reports configured host/port values and includes an optional `connection_name`.
* **Documentation**
  * Updated the changelog and system information reference to document the revised connection details and the new `connection_name` field.
* **Tests**
  * Added regression tests covering display name, configured host/port selection, and `pg://system_info` output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->