### PR TITLE
Return consistent JSON error responses on every HTTP path

### DIFF
--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -34,6 +34,7 @@ import (
 	"pgedge-postgres-mcp/internal/conversations"
 	"pgedge-postgres-mcp/internal/database"
 	"pgedge-postgres-mcp/internal/definitions"
+	"pgedge-postgres-mcp/internal/httperror"
 	"pgedge-postgres-mcp/internal/llmtracing"
 	"pgedge-postgres-mcp/internal/mcp"
 	"pgedge-postgres-mcp/internal/openapi"
@@ -791,16 +792,16 @@ func main() {
 					// Extract token from Authorization header
 					authHeader := r.Header.Get("Authorization")
 					if authHeader == "" {
-						http.Error(w, "Missing Authorization header",
-							http.StatusUnauthorized)
+						httperror.Write(w, http.StatusUnauthorized,
+							"Missing Authorization header")
 						return
 					}
 
 					// Extract Bearer token
 					token := strings.TrimPrefix(authHeader, "Bearer ")
 					if token == authHeader {
-						http.Error(w, "Invalid Authorization header format",
-							http.StatusUnauthorized)
+						httperror.Write(w, http.StatusUnauthorized,
+							"Invalid Authorization header format")
 						return
 					}
 
@@ -809,13 +810,13 @@ func main() {
 						// Try session token if user auth is enabled
 						if userStore != nil {
 							if _, err := userStore.ValidateSessionToken(token); err != nil {
-								http.Error(w, "Invalid or expired token",
-									http.StatusUnauthorized)
+								httperror.Write(w, http.StatusUnauthorized,
+									"Invalid or expired token")
 								return
 							}
 						} else {
-							http.Error(w, "Invalid or expired token",
-								http.StatusUnauthorized)
+							httperror.Write(w, http.StatusUnauthorized,
+								"Invalid or expired token")
 							return
 						}
 					}
@@ -945,7 +946,7 @@ func main() {
 			}
 			mux.HandleFunc("/api/openapi.json", func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodGet {
-					http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+					httperror.Write(w, http.StatusMethodNotAllowed, "Method not allowed")
 					return
 				}
 				w.Header().Set("Content-Type", "application/json")

--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -946,6 +946,7 @@ func main() {
 			}
 			mux.HandleFunc("/api/openapi.json", func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodGet {
+					w.Header().Set("Allow", http.MethodGet)
 					httperror.Write(w, http.StatusMethodNotAllowed, "Method not allowed")
 					return
 				}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -166,7 +166,14 @@ and this project adheres to
   HTTP server now sets `ReadHeaderTimeout`, `ReadTimeout`, and
   `IdleTimeout` to guard against slow-header and slow-body attacks;
   these fire before a request reaches a handler, so (unlike the cases
-  above) there is no response body to produce. (#189)
+  above) there is no response body to produce. Every 405 response now
+  also sets the `Allow` header naming the supported method(s), per
+  RFC 7231 §6.5.5. `GET /api/databases`'s 405 uses the shared
+  `internal/httperror` writer; `POST /api/databases/select`'s 405 uses
+  the endpoint's own documented `{"success": false, "error": "..."}`
+  shape instead, matching its other error responses (400, 404, 403)
+  rather than the bare `{"error": "..."}` it previously returned only
+  for that one status code. (#189)
 
 - Metadata loader now tolerates tables with zero columns
   (e.g. `CREATE TABLE foo()`). The query LEFT JOINs against the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -149,6 +149,25 @@ and this project adheres to
 
 ### Fixed
 
+- Every HTTP error response is now a consistent JSON object
+  (`{"error": "..."}`) with an appropriate status code, including
+  framework-level cases that previously bypassed the normal handlers
+  and returned a plaintext or empty body: an unknown route (404), a
+  method mismatch (405), an oversized request body (413, distinguished
+  from other body-read failures), and a panic inside a handler (500;
+  previously the connection was simply closed with no response at
+  all). A shared `internal/httperror` helper backs the new panic
+  recovery and 404 catch-all middleware, as well as the handlers that
+  previously wrote plaintext errors via `http.Error`
+  (`/mcp/v1`, `/api/chat/compact`, `/api/openapi.json`, and the
+  session-auth wrapper). Request bodies on `/api/chat/compact`,
+  `/api/databases/select`, and the `/api/conversations*` endpoints are
+  now also capped at 10MB, matching the existing `/mcp/v1` limit. The
+  HTTP server now sets `ReadHeaderTimeout`, `ReadTimeout`, and
+  `IdleTimeout` to guard against slow-header and slow-body attacks;
+  these fire before a request reaches a handler, so (unlike the cases
+  above) there is no response body to produce. (#189)
+
 - Metadata loader now tolerates tables with zero columns
   (e.g. `CREATE TABLE foo()`). The query LEFT JOINs against the
   per-column catalog, so a zero-column table produced a row whose

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -27,6 +27,7 @@ returns.
 | 403    | Forbidden            | The user lacks permission. |
 | 404    | Not Found            | The resource does not exist. |
 | 405    | Method Not Allowed   | The HTTP method is wrong.  |
+| 413    | Payload Too Large    | The request body exceeds the 10MB limit. |
 | 429    | Too Many Requests    | The rate limit is exceeded. |
 | 500    | Internal Server Error| A server-side error occurred. |
 

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -97,6 +97,7 @@ func NewDatabaseHandler(
 func (h *DatabaseHandler) HandleListDatabases(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Allow", http.MethodGet)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		//nolint:errcheck // Error would only occur if connection is closed
 		json.NewEncoder(w).Encode(map[string]string{"error": "Method not allowed"})
@@ -165,6 +166,7 @@ func (h *DatabaseHandler) HandleListDatabases(w http.ResponseWriter, r *http.Req
 func (h *DatabaseHandler) HandleSelectDatabase(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Allow", http.MethodPost)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		//nolint:errcheck // Error would only occur if connection is closed
 		json.NewEncoder(w).Encode(map[string]string{"error": "Method not allowed"})

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -12,12 +12,17 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"pgedge-postgres-mcp/internal/auth"
 	"pgedge-postgres-mcp/internal/config"
 	"pgedge-postgres-mcp/internal/database"
 )
+
+// maxRequestBodySize is the maximum allowed size for a request body
+// (10MB), preventing memory exhaustion from an oversized request.
+const maxRequestBodySize = 10 * 1024 * 1024
 
 // HostInfo represents a single host:port pair in the API response
 type HostInfo struct {
@@ -169,15 +174,25 @@ func (h *DatabaseHandler) HandleSelectDatabase(w http.ResponseWriter, r *http.Re
 	ctx := r.Context()
 	tokenHash := auth.GetTokenHashFromContext(ctx)
 
+	// Limit request body size to prevent memory exhaustion attacks
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
 	// Parse request body
 	var req SelectDatabaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		status := http.StatusBadRequest
+		errMsg := "Invalid request body"
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			status = http.StatusRequestEntityTooLarge
+			errMsg = "Request body too large"
+		}
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(status)
 		//nolint:errcheck // Error would only occur if connection is closed
 		json.NewEncoder(w).Encode(SelectDatabaseResponse{
 			Success: false,
-			Error:   "Invalid request body",
+			Error:   errMsg,
 		})
 		return
 	}

--- a/internal/api/databases.go
+++ b/internal/api/databases.go
@@ -18,6 +18,7 @@ import (
 	"pgedge-postgres-mcp/internal/auth"
 	"pgedge-postgres-mcp/internal/config"
 	"pgedge-postgres-mcp/internal/database"
+	"pgedge-postgres-mcp/internal/httperror"
 )
 
 // maxRequestBodySize is the maximum allowed size for a request body
@@ -96,11 +97,8 @@ func NewDatabaseHandler(
 // HandleListDatabases handles GET /api/databases
 func (h *DatabaseHandler) HandleListDatabases(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Allow", http.MethodGet)
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		//nolint:errcheck // Error would only occur if connection is closed
-		json.NewEncoder(w).Encode(map[string]string{"error": "Method not allowed"})
+		httperror.Write(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
 
@@ -169,7 +167,10 @@ func (h *DatabaseHandler) HandleSelectDatabase(w http.ResponseWriter, r *http.Re
 		w.Header().Set("Allow", http.MethodPost)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		//nolint:errcheck // Error would only occur if connection is closed
-		json.NewEncoder(w).Encode(map[string]string{"error": "Method not allowed"})
+		json.NewEncoder(w).Encode(SelectDatabaseResponse{
+			Success: false,
+			Error:   "Method not allowed",
+		})
 		return
 	}
 

--- a/internal/api/databases_test.go
+++ b/internal/api/databases_test.go
@@ -111,6 +111,16 @@ func TestHandleListDatabases_MethodNotAllowed(t *testing.T) {
 	if allow := w.Header().Get("Allow"); allow != http.MethodGet {
 		t.Errorf("expected Allow header %q, got %q", http.MethodGet, allow)
 	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if body["error"] != "Method not allowed" {
+		t.Errorf("expected error 'Method not allowed', got %q", body["error"])
+	}
 }
 
 func TestHandleListDatabases_WithTokenHash(t *testing.T) {
@@ -209,6 +219,32 @@ func TestHandleSelectDatabase_MethodNotAllowed(t *testing.T) {
 	}
 	if allow := w.Header().Get("Allow"); allow != http.MethodPost {
 		t.Errorf("expected Allow header %q, got %q", http.MethodPost, allow)
+	}
+
+	bodyBytes := w.Body.Bytes()
+
+	// Confirm the "success" key is actually present in the raw JSON (not
+	// just its Go zero-value default), so this test can't pass against a
+	// bare {"error": "..."} shape that omits the field entirely -
+	// matching the documented SelectDatabaseResponse contract for every
+	// other error on this endpoint (400, 404, 403).
+	var raw map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &raw); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if _, ok := raw["success"]; !ok {
+		t.Fatal("expected response to include a \"success\" field, matching SelectDatabaseResponse")
+	}
+
+	var response SelectDatabaseResponse
+	if err := json.Unmarshal(bodyBytes, &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Success {
+		t.Error("expected success=false")
+	}
+	if response.Error != "Method not allowed" {
+		t.Errorf("expected error 'Method not allowed', got %q", response.Error)
 	}
 }
 

--- a/internal/api/databases_test.go
+++ b/internal/api/databases_test.go
@@ -234,6 +234,38 @@ func TestHandleSelectDatabase_InvalidBody(t *testing.T) {
 	}
 }
 
+func TestHandleSelectDatabase_OversizedBody(t *testing.T) {
+	cm := createTestClientManager()
+	handler := NewDatabaseHandler(cm, nil, false, false)
+
+	// Must be syntactically valid JSON so json.Decoder keeps reading
+	// (buffering the string token) until it exceeds the body-size cap,
+	// rather than failing fast on a syntax error before the cap is hit.
+	huge := bytes.Repeat([]byte("x"), maxRequestBodySize+1)
+	oversized := append(append([]byte(`{"name":"`), huge...), []byte(`"}`)...)
+	req := httptest.NewRequest(http.MethodPost, "/api/databases/select",
+		bytes.NewReader(oversized))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	handler.HandleSelectDatabase(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected status 413, got %d", w.Code)
+	}
+
+	var response SelectDatabaseResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Success {
+		t.Error("expected success=false")
+	}
+	if response.Error != "Request body too large" {
+		t.Errorf("expected error 'Request body too large', got %q", response.Error)
+	}
+}
+
 func TestHandleSelectDatabase_EmptyName(t *testing.T) {
 	cm := createTestClientManager()
 	handler := NewDatabaseHandler(cm, nil, false, false)

--- a/internal/api/databases_test.go
+++ b/internal/api/databases_test.go
@@ -108,6 +108,9 @@ func TestHandleListDatabases_MethodNotAllowed(t *testing.T) {
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", w.Code)
 	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("expected Allow header %q, got %q", http.MethodGet, allow)
+	}
 }
 
 func TestHandleListDatabases_WithTokenHash(t *testing.T) {
@@ -203,6 +206,9 @@ func TestHandleSelectDatabase_MethodNotAllowed(t *testing.T) {
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", w.Code)
+	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodPost {
+		t.Errorf("expected Allow header %q, got %q", http.MethodPost, allow)
 	}
 }
 

--- a/internal/compactor/http_handler.go
+++ b/internal/compactor/http_handler.go
@@ -29,6 +29,7 @@ const maxRequestBodySize = 10 * 1024 * 1024
 func HandleCompact(w http.ResponseWriter, r *http.Request) {
 	// Only accept POST requests
 	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
 		httperror.Write(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}

--- a/internal/compactor/http_handler.go
+++ b/internal/compactor/http_handler.go
@@ -12,29 +12,46 @@ package compactor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
+
+	"pgedge-postgres-mcp/internal/httperror"
 )
+
+// maxRequestBodySize is the maximum allowed size for a compaction
+// request body (10MB), preventing memory exhaustion from an oversized
+// message history.
+const maxRequestBodySize = 10 * 1024 * 1024
 
 // HandleCompact is the HTTP handler for the /api/chat/compact endpoint.
 func HandleCompact(w http.ResponseWriter, r *http.Request) {
 	// Only accept POST requests
 	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		httperror.Write(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
+
+	// Limit request body size to prevent memory exhaustion attacks
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
 
 	// Parse request
 	var req CompactRequest
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&req); err != nil {
-		http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			httperror.Write(w, http.StatusRequestEntityTooLarge, "Request body too large")
+			return
+		}
+		httperror.Write(w, http.StatusBadRequest, fmt.Sprintf("Invalid request body: %v", err))
 		return
 	}
 
 	// Validate request
 	if len(req.Messages) == 0 {
-		http.Error(w, "Messages array cannot be empty", http.StatusBadRequest)
+		httperror.Write(w, http.StatusBadRequest, "Messages array cannot be empty")
 		return
 	}
 
@@ -54,7 +71,6 @@ func HandleCompact(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	encoder := json.NewEncoder(w)
 	if err := encoder.Encode(response); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
+		fmt.Fprintf(os.Stderr, "WARNING: Failed to encode compact response: %v\n", err)
 	}
 }

--- a/internal/compactor/http_handler_test.go
+++ b/internal/compactor/http_handler_test.go
@@ -1,0 +1,118 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package compactor
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func decodeJSONError(t *testing.T, w *httptest.ResponseRecorder) map[string]string {
+	t.Helper()
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if body["error"] == "" {
+		t.Error("expected non-empty error message")
+	}
+	return body
+}
+
+func TestHandleCompact_MethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/chat/compact", nil)
+	w := httptest.NewRecorder()
+
+	HandleCompact(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", w.Code)
+	}
+	decodeJSONError(t, w)
+}
+
+func TestHandleCompact_InvalidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/compact",
+		strings.NewReader("{not valid json"))
+	w := httptest.NewRecorder()
+
+	HandleCompact(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+	decodeJSONError(t, w)
+}
+
+func TestHandleCompact_EmptyMessages(t *testing.T) {
+	body, _ := json.Marshal(CompactRequest{Messages: nil})
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/compact", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	HandleCompact(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+	decodeJSONError(t, w)
+}
+
+func TestHandleCompact_OversizedBody(t *testing.T) {
+	// Must be syntactically valid JSON so json.Decoder keeps reading
+	// (buffering the string token) until it exceeds the body-size cap,
+	// rather than failing fast on a syntax error before the cap is hit.
+	huge := bytes.Repeat([]byte("x"), maxRequestBodySize+1)
+	oversized := append(append([]byte(`{"messages":[{"role":"user","content":"`), huge...), []byte(`"}]}`)...)
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/compact", bytes.NewReader(oversized))
+	w := httptest.NewRecorder()
+
+	HandleCompact(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected status 413, got %d", w.Code)
+	}
+	decodeJSONError(t, w)
+}
+
+func TestHandleCompact_Success(t *testing.T) {
+	req := CompactRequest{
+		Messages: []Message{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi there"},
+		},
+	}
+	body, _ := json.Marshal(req)
+	httpReq := httptest.NewRequest(http.MethodPost, "/api/chat/compact", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	HandleCompact(w, httpReq)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d (body: %q)", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var resp CompactResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if len(resp.Messages) == 0 {
+		t.Error("expected non-empty compacted messages")
+	}
+}

--- a/internal/compactor/http_handler_test.go
+++ b/internal/compactor/http_handler_test.go
@@ -43,6 +43,9 @@ func TestHandleCompact_MethodNotAllowed(t *testing.T) {
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", w.Code)
 	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodPost {
+		t.Errorf("expected Allow header %q, got %q", http.MethodPost, allow)
+	}
 	decodeJSONError(t, w)
 }
 

--- a/internal/conversations/handler.go
+++ b/internal/conversations/handler.go
@@ -93,6 +93,7 @@ func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) boo
 // HandleList handles GET /api/conversations
 func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
 		sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
@@ -137,6 +138,7 @@ func (h *Handler) HandleList(w http.ResponseWriter, r *http.Request) {
 // HandleGet handles GET /api/conversations/{id}
 func (h *Handler) HandleGet(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
 		sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
@@ -178,6 +180,7 @@ type CreateRequest struct {
 // HandleCreate handles POST /api/conversations
 func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
 		sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
@@ -218,6 +221,7 @@ type UpdateRequest struct {
 // HandleUpdate handles PUT /api/conversations/{id}
 func (h *Handler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {
+		w.Header().Set("Allow", http.MethodPut)
 		sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
@@ -263,6 +267,7 @@ type RenameRequest struct {
 // HandleRename handles PATCH /api/conversations/{id}
 func (h *Handler) HandleRename(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPatch {
+		w.Header().Set("Allow", http.MethodPatch)
 		sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
@@ -306,6 +311,7 @@ func (h *Handler) HandleRename(w http.ResponseWriter, r *http.Request) {
 // HandleDelete handles DELETE /api/conversations/{id}
 func (h *Handler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
+		w.Header().Set("Allow", http.MethodDelete)
 		sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
@@ -339,6 +345,7 @@ func (h *Handler) HandleDelete(w http.ResponseWriter, r *http.Request) {
 // HandleDeleteAll handles DELETE /api/conversations (with query param all=true)
 func (h *Handler) HandleDeleteAll(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
+		w.Header().Set("Allow", http.MethodDelete)
 		sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
@@ -378,6 +385,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux, authWrapper func(http.Handl
 				sendError(w, http.StatusBadRequest, "Use ?all=true to delete all conversations")
 			}
 		default:
+			w.Header().Set("Allow", "GET, POST, DELETE")
 			sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		}
 	}))
@@ -394,6 +402,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux, authWrapper func(http.Handl
 		case http.MethodDelete:
 			h.HandleDelete(w, r)
 		default:
+			w.Header().Set("Allow", "GET, PUT, PATCH, DELETE")
 			sendError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		}
 	}))

--- a/internal/conversations/handler.go
+++ b/internal/conversations/handler.go
@@ -12,6 +12,7 @@ package conversations
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -19,6 +20,11 @@ import (
 
 	"pgedge-postgres-mcp/internal/auth"
 )
+
+// maxRequestBodySize is the maximum allowed size for a conversation
+// request body (10MB), preventing memory exhaustion from an oversized
+// request.
+const maxRequestBodySize = 10 * 1024 * 1024
 
 // Handler handles conversation API requests
 type Handler struct {
@@ -65,6 +71,23 @@ func sendJSON(w http.ResponseWriter, status int, data interface{}) {
 // sendError sends an error response
 func sendError(w http.ResponseWriter, status int, message string) {
 	sendJSON(w, status, map[string]string{"error": message})
+}
+
+// decodeJSONBody limits the request body size and decodes it as JSON
+// into dst. On failure it writes the appropriate JSON error response
+// (413 for an oversized body, 400 otherwise) and returns false.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			sendError(w, http.StatusRequestEntityTooLarge, "Request body too large")
+		} else {
+			sendError(w, http.StatusBadRequest, "Invalid request body")
+		}
+		return false
+	}
+	return true
 }
 
 // HandleList handles GET /api/conversations
@@ -166,8 +189,7 @@ func (h *Handler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req CreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		sendError(w, http.StatusBadRequest, "Invalid request body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 
@@ -214,8 +236,7 @@ func (h *Handler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req UpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		sendError(w, http.StatusBadRequest, "Invalid request body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 
@@ -260,8 +281,7 @@ func (h *Handler) HandleRename(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req RenameRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		sendError(w, http.StatusBadRequest, "Invalid request body")
+	if !decodeJSONBody(w, r, &req) {
 		return
 	}
 

--- a/internal/conversations/handler_test.go
+++ b/internal/conversations/handler_test.go
@@ -224,6 +224,37 @@ func TestHandleCreate_InvalidBody(t *testing.T) {
 	}
 }
 
+func TestHandleCreate_OversizedBody(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	// Must be syntactically valid JSON so json.Decoder keeps reading
+	// (buffering the string token) until it exceeds the body-size cap,
+	// rather than failing fast on a syntax error before the cap is hit.
+	huge := bytes.Repeat([]byte("x"), maxRequestBodySize+1)
+	oversized := append(append([]byte(`{"provider":"`), huge...), []byte(`"}`)...)
+	req := httptest.NewRequest("POST", "/api/conversations", bytes.NewReader(oversized))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreate(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("Expected status %d, got %d", http.StatusRequestEntityTooLarge, rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, rr.Body.String())
+	}
+	if body["error"] != "Request body too large" {
+		t.Errorf("expected error 'Request body too large', got %q", body["error"])
+	}
+}
+
 func TestHandleGet(t *testing.T) {
 	handler, cleanup, token := setupTestHandler(t)
 	defer cleanup()

--- a/internal/conversations/handler_test.go
+++ b/internal/conversations/handler_test.go
@@ -146,6 +146,159 @@ func TestHandleList_WrongMethod(t *testing.T) {
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
 	}
+	if allow := rr.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("expected Allow header %q, got %q", http.MethodGet, allow)
+	}
+}
+
+func TestHandleGet_WrongMethod(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("POST", "/api/conversations/some-id", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.HandleGet(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+	if allow := rr.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("expected Allow header %q, got %q", http.MethodGet, allow)
+	}
+}
+
+func TestHandleCreate_WrongMethod(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/conversations", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreate(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+	if allow := rr.Header().Get("Allow"); allow != http.MethodPost {
+		t.Errorf("expected Allow header %q, got %q", http.MethodPost, allow)
+	}
+}
+
+func TestHandleUpdate_WrongMethod(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/conversations/some-id", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdate(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+	if allow := rr.Header().Get("Allow"); allow != http.MethodPut {
+		t.Errorf("expected Allow header %q, got %q", http.MethodPut, allow)
+	}
+}
+
+func TestHandleRename_WrongMethod(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/conversations/some-id", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.HandleRename(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+	if allow := rr.Header().Get("Allow"); allow != http.MethodPatch {
+		t.Errorf("expected Allow header %q, got %q", http.MethodPatch, allow)
+	}
+}
+
+func TestHandleDelete_WrongMethod(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/conversations/some-id", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.HandleDelete(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+	if allow := rr.Header().Get("Allow"); allow != http.MethodDelete {
+		t.Errorf("expected Allow header %q, got %q", http.MethodDelete, allow)
+	}
+}
+
+func TestHandleDeleteAll_WrongMethod(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/conversations?all=true", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.HandleDeleteAll(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+	if allow := rr.Header().Get("Allow"); allow != http.MethodDelete {
+		t.Errorf("expected Allow header %q, got %q", http.MethodDelete, allow)
+	}
+}
+
+func TestRegisterRoutes_CollectionWrongMethod(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, func(h http.HandlerFunc) http.HandlerFunc { return h })
+
+	req := httptest.NewRequest("PATCH", "/api/conversations", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+	if allow := rr.Header().Get("Allow"); allow != "GET, POST, DELETE" {
+		t.Errorf("expected Allow header %q, got %q", "GET, POST, DELETE", allow)
+	}
+}
+
+func TestRegisterRoutes_SingleWrongMethod(t *testing.T) {
+	handler, cleanup, token := setupTestHandler(t)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, func(h http.HandlerFunc) http.HandlerFunc { return h })
+
+	req := httptest.NewRequest("POST", "/api/conversations/some-id", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+	if allow := rr.Header().Get("Allow"); allow != "GET, PUT, PATCH, DELETE" {
+		t.Errorf("expected Allow header %q, got %q", "GET, PUT, PATCH, DELETE", allow)
+	}
 }
 
 func TestHandleCreate(t *testing.T) {

--- a/internal/httperror/httperror.go
+++ b/internal/httperror/httperror.go
@@ -1,0 +1,34 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Package httperror provides a single, consistent JSON error body for all
+// REST-style HTTP endpoints, including framework-level cases that bypass
+// the normal handlers (unknown route, method not allowed, request
+// timeout, oversized body, panic recovery).
+package httperror
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Response is the JSON body written for any HTTP error.
+type Response struct {
+	Error string `json:"error"`
+}
+
+// Write sets the JSON content type, writes statusCode, and encodes a
+// Response with message as the body.
+func Write(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	//nolint:errcheck // Error would only occur if connection is closed
+	json.NewEncoder(w).Encode(Response{Error: message})
+}

--- a/internal/httperror/httperror_test.go
+++ b/internal/httperror/httperror_test.go
@@ -1,0 +1,52 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package httperror
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWrite(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	Write(w, 418, "I'm a teapot")
+
+	if w.Code != 418 {
+		t.Errorf("expected status 418, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var resp Response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if resp.Error != "I'm a teapot" {
+		t.Errorf("expected error message %q, got %q", "I'm a teapot", resp.Error)
+	}
+}
+
+func TestWrite_EmptyMessage(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	Write(w, 500, "")
+
+	var resp Response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if resp.Error != "" {
+		t.Errorf("expected empty error message, got %q", resp.Error)
+	}
+}

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -224,6 +224,7 @@ const MaxRequestBodySize = 10 * 1024 * 1024
 func (s *Server) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 	// Only accept POST requests
 	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
 		httperror.Write(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -15,14 +15,17 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
 	"pgedge-postgres-mcp/internal/auth"
+	"pgedge-postgres-mcp/internal/httperror"
 	"pgedge-postgres-mcp/internal/tracing"
 )
 
@@ -40,16 +43,11 @@ type HTTPConfig struct {
 	Debug         bool                           // Enable debug logging
 }
 
-// RunHTTP starts the MCP server in HTTP/HTTPS mode
-func (s *Server) RunHTTP(config *HTTPConfig) error {
-	if config == nil {
-		return fmt.Errorf("HTTP config is required")
-	}
-
-	// Store debug flag for use in handlers
-	s.debug = config.Debug
-
-	// Create HTTP handler
+// buildHandler assembles the full mux and middleware chain used in HTTP
+// mode. Split out from RunHTTP so the complete chain (including the
+// JSON 404 catch-all and panic recovery) can be exercised directly in
+// tests without binding a real listener.
+func (s *Server) buildHandler(config *HTTPConfig) (http.Handler, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mcp/v1", s.handleHTTPRequest)
 	mux.HandleFunc("/health", s.handleHealthCheck)
@@ -57,9 +55,15 @@ func (s *Server) RunHTTP(config *HTTPConfig) error {
 	// Call custom handler setup if provided (allows main.go to add LLM proxy endpoints)
 	if config.SetupHandlers != nil {
 		if err := config.SetupHandlers(mux); err != nil {
-			return fmt.Errorf("failed to setup custom handlers: %w", err)
+			return nil, fmt.Errorf("failed to setup custom handlers: %w", err)
 		}
 	}
+
+	// Catch-all for any path not matched above. http.ServeMux has no
+	// NotFoundHandler hook, so registering "/" (the least-specific
+	// pattern) is the standard way to intercept unmatched routes; it
+	// only fires when nothing more specific matched.
+	mux.HandleFunc("/", jsonNotFoundHandler)
 
 	// Wrap with auth middleware if enabled
 	var handler http.Handler = mux
@@ -70,10 +74,39 @@ func (s *Server) RunHTTP(config *HTTPConfig) error {
 	// Wrap with security headers middleware
 	handler = securityHeadersMiddleware(config.TLSEnable)(handler)
 
+	// Wrap with panic recovery so a handler panic always yields a JSON
+	// 500 response instead of an abruptly closed connection with no body.
+	handler = recoveryMiddleware(handler)
+
+	return handler, nil
+}
+
+// RunHTTP starts the MCP server in HTTP/HTTPS mode
+func (s *Server) RunHTTP(config *HTTPConfig) error {
+	if config == nil {
+		return fmt.Errorf("HTTP config is required")
+	}
+
+	// Store debug flag for use in handlers
+	s.debug = config.Debug
+
+	handler, err := s.buildHandler(config)
+	if err != nil {
+		return err
+	}
+
 	// Configure server
 	httpServer := &http.Server{
 		Addr:    config.Addr,
 		Handler: handler,
+
+		// Guard against slow-header and slow-body attacks (e.g.
+		// Slowloris): these fire before a request ever reaches a
+		// handler, so the connection is simply closed - there is no
+		// application-level body to write at this point.
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	// Start server with or without TLS
@@ -128,6 +161,38 @@ func (s *Server) loadTLSConfig(config *HTTPConfig) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// jsonNotFoundHandler responds to any request that didn't match a more
+// specific registered route with a JSON 404, instead of net/http's
+// default plaintext "404 page not found".
+func jsonNotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	httperror.Write(w, http.StatusNotFound, "Not found")
+}
+
+// recoveryMiddleware recovers from a panic anywhere in the wrapped
+// handler chain and responds with a JSON 500 instead of leaving the
+// client with an abruptly closed connection and no body at all. The
+// stack trace is logged the same way an unrecovered panic would be.
+func recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if p := recover(); p != nil {
+				// http.ErrAbortHandler is a sentinel panic value net/http
+				// itself treats specially: it silently aborts the
+				// response with no logging and no body. Preserve that
+				// behavior by re-panicking so the stdlib's own handling
+				// takes over instead of writing a JSON error for it.
+				if p == http.ErrAbortHandler {
+					panic(p)
+				}
+				fmt.Fprintf(os.Stderr, "PANIC serving %s %s: %v\n%s\n",
+					r.Method, r.URL.Path, p, debug.Stack())
+				httperror.Write(w, http.StatusInternalServerError, "Internal server error")
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
 // securityHeadersMiddleware adds standard HTTP security headers to all
 // responses to mitigate clickjacking, MIME-type confusion, and XSS.
 // It also adds the RFC 8631 Link header on /api/* paths for API
@@ -159,7 +224,7 @@ const MaxRequestBodySize = 10 * 1024 * 1024
 func (s *Server) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 	// Only accept POST requests
 	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		httperror.Write(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
 
@@ -173,7 +238,12 @@ func (s *Server) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 	// Read request body
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			httperror.Write(w, http.StatusRequestEntityTooLarge, "Request body too large")
+			return
+		}
+		httperror.Write(w, http.StatusBadRequest, "Failed to read request body")
 		return
 	}
 	defer func() {

--- a/internal/mcp/http_server_test.go
+++ b/internal/mcp/http_server_test.go
@@ -74,6 +74,9 @@ func TestHandleHTTPRequest_MethodNotAllowed(t *testing.T) {
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", w.Code)
 	}
+	if allow := w.Header().Get("Allow"); allow != http.MethodPost {
+		t.Errorf("expected Allow header %q, got %q", http.MethodPost, allow)
+	}
 	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("expected Content-Type application/json, got %q", ct)
 	}

--- a/internal/mcp/http_server_test.go
+++ b/internal/mcp/http_server_test.go
@@ -74,6 +74,41 @@ func TestHandleHTTPRequest_MethodNotAllowed(t *testing.T) {
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405, got %d", w.Code)
 	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if body["error"] == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestHandleHTTPRequest_OversizedBody(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	oversized := bytes.Repeat([]byte("x"), MaxRequestBodySize+1)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", bytes.NewReader(oversized))
+	w := httptest.NewRecorder()
+
+	server.handleHTTPRequest(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected status 413, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if body["error"] == "" {
+		t.Error("expected non-empty error message")
+	}
 }
 
 func TestHandleHTTPRequest_InvalidJSON(t *testing.T) {
@@ -1065,4 +1100,117 @@ func TestRunHTTP_NilConfig(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for nil config")
 	}
+}
+
+func TestBuildHandler_UnknownRouteReturnsJSON404(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	handler, err := server.buildHandler(&HTTPConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error building handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/this-route-does-not-exist", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if body["error"] == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestBuildHandler_KnownRouteStillWorks(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	handler, err := server.buildHandler(&HTTPConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error building handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected the JSON 404 catch-all to not shadow /health; got status %d", w.Code)
+	}
+}
+
+func TestBuildHandler_PanicRecoveryReturnsJSON500(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	handler, err := server.buildHandler(&HTTPConfig{
+		SetupHandlers: func(mux *http.ServeMux) error {
+			mux.HandleFunc("/panic", func(w http.ResponseWriter, r *http.Request) {
+				panic("boom")
+			})
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	w := httptest.NewRecorder()
+
+	// The handler must not panic out of ServeHTTP itself; recovery
+	// middleware should catch it and produce a JSON 500.
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+	}
+	if body["error"] == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+func TestBuildHandler_ErrAbortHandlerNotRecovered(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	handler, err := server.buildHandler(&HTTPConfig{
+		SetupHandlers: func(mux *http.ServeMux) error {
+			mux.HandleFunc("/abort", func(w http.ResponseWriter, r *http.Request) {
+				panic(http.ErrAbortHandler)
+			})
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/abort", nil)
+	w := httptest.NewRecorder()
+
+	defer func() {
+		p := recover()
+		if p != http.ErrAbortHandler {
+			t.Errorf("expected http.ErrAbortHandler to propagate past recoveryMiddleware, got %v", p)
+		}
+	}()
+	handler.ServeHTTP(w, req)
+	t.Error("expected handler.ServeHTTP to panic with http.ErrAbortHandler")
 }


### PR DESCRIPTION
Add a shared internal/httperror JSON writer and use it everywhere a plaintext http.Error was previously returned, including framework-level cases that bypassed the normal handlers: unknown routes (JSON 404 catch-all), panic recovery (JSON 500 instead of a dropped connection), and oversized request bodies (JSON 413, distinguished from other body read failures). Also cap request body size on endpoints that had no limit, and add ReadHeaderTimeout/ReadTimeout/IdleTimeout to the HTTP server to guard against slow-header and slow-body attacks.

Fixes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized REST error responses to a consistent JSON format, including auth failures, unknown routes (404), method mismatches (405), oversized/invalid bodies (413/400), and server/panic errors.
  - Added RFC-compliant `Allow` headers on “method not allowed” responses (including OpenAPI).
  - Enforced a 10 MB maximum request body size across supported endpoints; oversized requests now return `413` with JSON error details.
  - Hardened HTTP server handling with improved timeout settings and JSON panic recovery.
- **Documentation**
  - Updated the changelog and error reference to reflect the `413 Payload Too Large` behavior and 10 MB limit.
- **Tests**
  - Added/expanded unit tests for `Allow` headers, JSON error contracts, and oversized-body handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->