### PR TITLE
Redact provider credentials from error output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,11 @@ clean-client:
 test: test-server test-client
 
 # Run server tests
+# Lists every server-side package that has tests. The client-side packages are
+# covered by test-client, so they are deliberately absent rather than missing.
 test-server:
 	@echo "Running server tests..."
-	$(GO) test -v ./internal/mcp/... ./internal/auth/... ./internal/config/... ./internal/crypto/... ./internal/database/... ./internal/openapi/... ./internal/resources/... ./internal/tools/... ./internal/tracing/... ./$(SERVER_CMD_DIR)/...
+	$(GO) test -v ./internal/api/... ./internal/auth/... ./internal/compactor/... ./internal/config/... ./internal/conversations/... ./internal/crypto/... ./internal/database/... ./internal/definitions/... ./internal/httperror/... ./internal/llmtracing/... ./internal/logging/... ./internal/mcp/... ./internal/openapi/... ./internal/prompts/... ./internal/redact/... ./internal/resources/... ./internal/search/... ./internal/tools/... ./internal/tracing/... ./internal/tsv/... ./$(SERVER_CMD_DIR)/...
 
 # Run client tests
 test-client:

--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -39,6 +39,7 @@ import (
 	"pgedge-postgres-mcp/internal/mcp"
 	"pgedge-postgres-mcp/internal/openapi"
 	"pgedge-postgres-mcp/internal/prompts"
+	"pgedge-postgres-mcp/internal/redact"
 	"pgedge-postgres-mcp/internal/resources"
 	"pgedge-postgres-mcp/internal/tools"
 	"pgedge-postgres-mcp/internal/tracing"
@@ -410,6 +411,22 @@ func main() {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Register the configured provider credentials for redaction before
+	// anything can fail and quote one back. An LLM provider that rejects a key
+	// commonly names it in the error body it returns, and that body is relayed
+	// into HTTP responses and trace entries; registering the values here lets
+	// them be matched exactly, in addition to the key formats recognised by
+	// pattern.
+	redact.Register(
+		cfg.LLM.AnthropicAPIKey,
+		cfg.LLM.OpenAIAPIKey,
+		cfg.LLM.GeminiAPIKey,
+		cfg.Embedding.VoyageAPIKey,
+		cfg.Embedding.OpenAIAPIKey,
+		cfg.Knowledgebase.EmbeddingVoyageAPIKey,
+		cfg.Knowledgebase.EmbeddingOpenAIAPIKey,
+	)
 
 	// Set default token file path if not specified and HTTP is enabled
 	if cfg.HTTP.Enabled && cfg.HTTP.Auth.TokenFile == "" {
@@ -940,8 +957,14 @@ func main() {
 					OnResponse:      llmtracing.OnResponse,
 					OnError:         llmtracing.OnError,
 				})
+				// Filter the proxy's responses on their way out. The proxy
+				// builds its error bodies from the provider's own message, and
+				// providers quote the key they rejected when authentication
+				// fails, so there is no call site here at which the text could
+				// be cleaned before it is written.
 				mux.Handle("/api/llm/",
-					authWrapper(http.StripPrefix("/api/llm", p.Handler()).ServeHTTP))
+					authWrapper(redact.Handler(
+						http.StripPrefix("/api/llm", p.Handler())).ServeHTTP))
 			}
 
 			// Database listing and selection endpoints

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,6 +75,32 @@ and this project adheres to
   sends none, so it receives neither that rule nor the pre-existing
   read-only safety instructions.
 
+- Provider API keys are no longer disclosed in error output. When an LLM or
+  embedding provider rejects a credential it commonly quotes that credential
+  back in its error body: OpenAI's authentication failure names the key it
+  was given, partially masked but with its opening characters intact. The
+  shared pgEdge LLM library relays a provider's message verbatim into the
+  error it returns, and that error reached the `/api/llm/` response body,
+  the trace file, and the CLI's own output. All three are now redacted, with
+  both the configured credentials and anything matching a known key format
+  replaced by `[REDACTED]`; the rest of the message survives, so the
+  provider, status code and reason are still reported.
+
+  The durable fix belongs in the provider client library, so that a
+  credential never reaches an error value at all. What is added here is a
+  filter over text that should not have contained a credential in the first
+  place: it recognises the formats this project handles and the values it was
+  configured with, so it is a safety net rather than a guarantee. See
+  [Security](guide/security.md) for the limits.
+
+### Fixed
+
+- `make test` now runs every package that has tests. Ten packages were absent
+  from the server target and so were never exercised by the suite or by
+  continuous integration: `api`, `compactor`, `conversations`, `definitions`,
+  `httperror`, `llmtracing`, `logging`, `prompts`, `search` and `tsv`. All of
+  them pass; they were simply never run.
+
 ### Added
 
 - A `make vulncheck` target runs `govulncheck` over the module, using

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,7 +84,9 @@ and this project adheres to
   the trace file, and the CLI's own output. All three are now redacted, with
   both the configured credentials and anything matching a known key format
   replaced by `[REDACTED]`; the rest of the message survives, so the
-  provider, status code and reason are still reported.
+  provider, status code and reason are still reported. The `/api/llm/`
+  filtering is best-effort: it inspects each response write on its own, so
+  a credential split across two writes would evade it.
 
   The durable fix belongs in the provider client library, so that a
   credential never reaches an error value at all. What is added here is a

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -277,3 +277,37 @@ that way, as described in
 [Security Management](security_mgmt.md), and this class of attack
 cannot complete regardless of what any retrieved document says or
 which client is driving the server.
+
+## Provider Credentials in Error Messages
+
+An LLM or embedding provider decides what its own error responses say,
+and several of them quote the credential they rejected. OpenAI's reply
+to a failed authentication names the key it was given, in a partially
+masked form that still reveals its opening characters. The shared
+pgEdge LLM library relays a provider's message into the error it
+returns, so that text reaches anywhere the error is reported.
+
+The server removes credentials from such text before it leaves the
+process. Redaction applies in three places:
+
+- Responses from the `/api/llm/` endpoints, which the library's proxy
+  generates from the provider's message.
+- Trace entries, which persist in the file named by `-trace-file` and
+  are often attached to support tickets.
+- Errors that the CLI reports to its own operator, which may be
+  redirected to a log.
+
+Both the credentials the server was configured with and anything
+matching a known key format are replaced with `[REDACTED]`. The
+surrounding message survives, so the provider, the status code, and
+the reason for the failure are still reported.
+
+Understand the limits of this. Redaction is a filter over text that
+should not have contained a credential in the first place, so it
+recognises the formats this project knows about and the values it was
+given; a provider inventing a new format, or quoting a key in a way
+these patterns do not match, would not be caught. The durable fix
+belongs in the provider client library, so that a credential never
+reaches an error value at all. Treat this as a safety net beneath
+that, and continue to keep provider keys out of any output you
+publish.

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -302,7 +302,13 @@ matching a known key format are replaced with `[REDACTED]`. The
 surrounding message survives, so the provider, the status code, and
 the reason for the failure are still reported.
 
-Understand the limits of this. Redaction is a filter over text that
+Understand the limits of this. Filtering the `/api/llm/` response is
+best-effort, not absolute: it inspects each write to the response body
+on its own, so a credential split across two writes would evade it.
+This does not arise for a JSON error body, which is encoded in one
+go, or a server-sent event, which is written as a unit, but it is a
+genuine limit of filtering a stream rather than fixing the source.
+Redaction is a filter over text that
 should not have contained a credential in the first place, so it
 recognises the formats this project knows about and the values it was
 given; a provider inventing a new format, or quoting a key in a way

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"pgedge-postgres-mcp/internal/mcp"
+	"pgedge-postgres-mcp/internal/redact"
 
 	"github.com/chzyer/readline"
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
@@ -521,7 +522,7 @@ func (c *Client) initializeLLM() error {
 	availableModels, err := tempClient.ListModels(ctx)
 	if err != nil {
 		if c.config.UI.Debug {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to list models from %s: %v\n", provider, err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to list models from %s: %s\n", provider, redact.Error(err))
 		}
 		availableModels = nil
 	}
@@ -1033,7 +1034,9 @@ func (c *Client) processQuery(ctx context.Context, query string) error {
 				c.ui.PrintCanceled()
 				return nil // Return without error to continue the chat loop
 			}
-			return fmt.Errorf("LLM error: %w", err)
+			// The provider quotes the key it rejected in an authentication
+			// failure, and this message may be redirected to a log file.
+			return fmt.Errorf("LLM error: %w", redact.ErrorValue(err))
 		}
 
 		if c.config.UI.Debug {

--- a/internal/chat/commands.go
+++ b/internal/chat/commands.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
+
+	"pgedge-postgres-mcp/internal/redact"
 )
 
 // SlashCommand represents a parsed slash command
@@ -448,7 +450,7 @@ func (c *Client) handleSetLLMModel(model string) bool {
 	if err != nil {
 		// If we can't validate, warn but allow the change
 		c.ui.PrintSystemMessage(fmt.Sprintf(
-			"Warning: Could not validate model (error: %v)", err))
+			"Warning: Could not validate model (error: %s)", redact.Error(err)))
 	} else if !isModelAvailable(model, availableModels) {
 		c.ui.PrintError(fmt.Sprintf(
 			"Model '%s' not available from %s", model, c.config.LLM.Provider))
@@ -625,7 +627,7 @@ func (c *Client) handleListCommand(ctx context.Context, args []string) bool {
 func (c *Client) listModels(ctx context.Context) bool {
 	models, err := c.llm.ListModels(ctx)
 	if err != nil {
-		c.ui.PrintError(fmt.Sprintf("Failed to list models: %v", err))
+		c.ui.PrintError(fmt.Sprintf("Failed to list models: %s", redact.Error(err)))
 		return true
 	}
 

--- a/internal/chat/config.go
+++ b/internal/chat/config.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"pgedge-postgres-mcp/internal/redact"
 )
 
 // Config holds all configuration for the chat client
@@ -142,6 +144,13 @@ func LoadConfig(configPath string) (*Config, error) {
 
 	// Load authentication token with priority
 	cfg.MCP.Token = loadAuthToken()
+
+	// Register the credentials for redaction, so that a provider quoting a key
+	// back in an error cannot reach the terminal or a redirected log.
+	redact.Register(
+		cfg.LLM.AnthropicAPIKey,
+		cfg.LLM.OpenAIAPIKey,
+	)
 
 	return cfg, nil
 }

--- a/internal/llmtracing/hooks.go
+++ b/internal/llmtracing/hooks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pgEdge/pgedge-go-llm-lib/llm/proxy"
 
 	"pgedge-postgres-mcp/internal/auth"
+	"pgedge-postgres-mcp/internal/redact"
 	"pgedge-postgres-mcp/internal/tracing"
 )
 
@@ -105,5 +106,11 @@ func OnError(r *http.Request, info proxy.ErrorInfo) {
 	if info.Stream {
 		contextLabel = "llm_chat_stream"
 	}
-	tracing.LogError(sessionID, tokenHash, info.RequestID, contextLabel, info.Err)
+
+	// The error carries the provider's own message, which on an authentication
+	// failure quotes the key it rejected, so it is redacted before it reaches
+	// the trace file. Traces persist and get attached to support tickets, which
+	// makes this the more durable of the two places the fragment escaped.
+	tracing.LogError(sessionID, tokenHash, info.RequestID, contextLabel,
+		redact.ErrorValue(info.Err))
 }

--- a/internal/redact/http.go
+++ b/internal/redact/http.go
@@ -1,0 +1,75 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package redact
+
+import "net/http"
+
+// Handler wraps h so that everything it writes to the response body passes
+// through String first.
+//
+// It exists for handlers this project does not own. The LLM proxy comes from
+// the shared library and builds its own error bodies from a provider's message,
+// so there is no call site here at which the text could be cleaned before it is
+// written; the response itself has to be filtered instead.
+//
+// Two consequences are worth knowing about. Redaction happens per write, so a
+// credential split across two Write calls would pass through: that does not
+// arise for a JSON error body, which is encoded in one go, nor for a
+// server-sent event, which is written as a unit, but it is a real limit of
+// filtering a stream rather than fixing the source. And Content-Length is
+// dropped when the wrapped handler sets it, because redaction changes the
+// body's length and a stale header would truncate the response; Go then either
+// computes the correct length or uses chunked encoding.
+func Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(&responseWriter{ResponseWriter: w}, r)
+	})
+}
+
+// responseWriter redacts each write on its way to the client.
+type responseWriter struct {
+	http.ResponseWriter
+}
+
+// WriteHeader drops a Content-Length set by the wrapped handler, since
+// redaction may change how many bytes are actually written.
+func (w *responseWriter) WriteHeader(status int) {
+	if w.Header().Get("Content-Length") != "" {
+		w.Header().Del("Content-Length")
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+// Write redacts p and reports the caller's own length on success.
+//
+// Returning the redacted length instead would break the io.Writer contract as
+// callers understand it: a shorter count than requested reads as a short write,
+// and json.Encoder and friends treat that as an error.
+func (w *responseWriter) Write(p []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(Bytes(p))
+	if err != nil {
+		return n, err
+	}
+	return len(p), nil
+}
+
+// Flush forwards to the underlying writer so that streaming responses are not
+// held up by the wrapper. Server-sent events depend on it.
+func (w *responseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap exposes the underlying writer to http.ResponseController.
+func (w *responseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/internal/redact/http_test.go
+++ b/internal/redact/http_test.go
@@ -1,0 +1,217 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package redact
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// leakyErrorBody is the shape the LLM proxy writes when a provider call fails:
+// the provider's own message, which on an authentication failure quotes the key.
+func leakyErrorBody() string {
+	return `{"error":"openai (401): Incorrect API key provided: ` + fakeOpenAIKey + `"}`
+}
+
+func TestHandlerRedactsResponseBody(t *testing.T) {
+	Reset()
+
+	handler := Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, leakyErrorBody())
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/chat", nil))
+
+	body := rec.Body.String()
+	if strings.Contains(body, "AAAABBBB") {
+		t.Errorf("response body leaked the key: %s", body)
+	}
+	if !strings.Contains(body, Placeholder) {
+		t.Errorf("expected a placeholder in the body: %s", body)
+	}
+
+	// The status and the rest of the message must survive, so the client can
+	// still tell what went wrong.
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(body, "401") {
+		t.Errorf("expected the provider status to survive: %s", body)
+	}
+
+	// The body must remain valid JSON, since clients parse it.
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &parsed); err != nil {
+		t.Errorf("redacted body is not valid JSON: %v (%s)", err, body)
+	}
+}
+
+// TestHandlerReportsCallerLength guards the io.Writer contract. Redaction
+// shortens the payload, and a handler told it wrote fewer bytes than it asked
+// to write treats that as a short write; json.Encoder reports it as an error.
+func TestHandlerReportsCallerLength(t *testing.T) {
+	Reset()
+
+	var writeErr error
+	var reported int
+
+	handler := Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := []byte(leakyErrorBody())
+		reported, writeErr = w.Write(payload)
+		if reported != len(payload) {
+			t.Errorf("Write reported %d bytes, want %d", reported, len(payload))
+		}
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/chat", nil))
+
+	if writeErr != nil {
+		t.Errorf("unexpected write error: %v", writeErr)
+	}
+}
+
+// TestHandlerEncoderRoundTrip exercises the path the proxy actually uses,
+// which is a json.Encoder writing to the response.
+func TestHandlerEncoderRoundTrip(t *testing.T) {
+	Reset()
+
+	handler := Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]string{
+			"error": "openai (401): Incorrect API key provided: " + fakeOpenAIKey,
+		})
+		if err != nil {
+			t.Errorf("encoder failed against the wrapped writer: %v", err)
+		}
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/chat", nil))
+
+	if strings.Contains(rec.Body.String(), "AAAABBBB") {
+		t.Errorf("encoded body leaked the key: %s", rec.Body.String())
+	}
+}
+
+// TestHandlerPreservesStreaming covers server-sent events, which the proxy uses
+// for streaming chat. Each event must reach the client as it is produced, so
+// the wrapper has to forward Flush.
+func TestHandlerPreservesStreaming(t *testing.T) {
+	Reset()
+
+	flushes := 0
+
+	handler := Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("wrapped writer must still implement http.Flusher")
+		}
+
+		for _, event := range []string{
+			"data: {\"delta\":\"hello\"}\n\n",
+			"data: {\"error\":\"openai (401): Incorrect API key provided: " + fakeOpenAIKey + "\"}\n\n",
+			"data: [DONE]\n\n",
+		} {
+			if _, err := fmt.Fprint(w, event); err != nil {
+				t.Errorf("write failed: %v", err)
+			}
+			flusher.Flush()
+			flushes++
+		}
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/chat/stream", nil))
+
+	body := rec.Body.String()
+	if strings.Contains(body, "AAAABBBB") {
+		t.Errorf("streamed body leaked the key: %s", body)
+	}
+	if flushes != 3 {
+		t.Errorf("flushes = %d, want 3", flushes)
+	}
+	// The surrounding events must be intact.
+	for _, want := range []string{`"delta":"hello"`, "[DONE]"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %q to survive: %s", want, body)
+		}
+	}
+	if !rec.Flushed {
+		t.Error("expected the recorder to have been flushed")
+	}
+}
+
+// TestHandlerDropsStaleContentLength covers the framing hazard: redaction
+// changes the body's length, so a Content-Length set by the wrapped handler
+// would describe the unredacted body and truncate the response.
+func TestHandlerDropsStaleContentLength(t *testing.T) {
+	Reset()
+
+	body := leakyErrorBody()
+
+	handler := Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, body)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/chat", nil))
+
+	if got := rec.Header().Get("Content-Length"); got != "" {
+		t.Errorf("Content-Length = %q, want it dropped so the body is not truncated", got)
+	}
+	if strings.Contains(rec.Body.String(), "AAAABBBB") {
+		t.Errorf("response body leaked the key: %s", rec.Body.String())
+	}
+}
+
+func TestHandlerPassesCleanResponsesThrough(t *testing.T) {
+	Reset()
+
+	const clean = `{"content":"the answer is 42","usage":{"input_tokens":10}}`
+
+	handler := Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, clean)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/chat", nil))
+
+	if rec.Body.String() != clean {
+		t.Errorf("body = %q, want it unchanged", rec.Body.String())
+	}
+}
+
+func TestHandlerUnwrap(t *testing.T) {
+	Reset()
+
+	handler := Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		if !ok {
+			t.Fatal("wrapped writer should expose Unwrap for http.ResponseController")
+		}
+		if unwrapper.Unwrap() == nil {
+			t.Error("Unwrap returned nil")
+		}
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+}

--- a/internal/redact/proxy_test.go
+++ b/internal/redact/proxy_test.go
@@ -1,0 +1,177 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package redact_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pgEdge/pgedge-go-llm-lib/llm"
+	_ "github.com/pgEdge/pgedge-go-llm-lib/llm/all"
+	"github.com/pgEdge/pgedge-go-llm-lib/llm/proxy"
+
+	"pgedge-postgres-mcp/internal/redact"
+)
+
+// testKey mimics the format of an OpenAI project key. It is invented, and is
+// not a credential.
+const testKey = "sk-proj-TESTAAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
+
+// fakeProviderRejectingKey stands in for the upstream provider. It answers 401
+// with the body shape OpenAI actually returns, which quotes the key it was
+// given back at the caller.
+func fakeProviderRejectingKey(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		body := map[string]any{
+			"error": map[string]string{
+				"message": "Incorrect API key provided: " + testKey +
+					". You can find your API key at https://platform.openai.com/account/api-keys.",
+				"type": "invalid_request_error",
+			},
+		}
+		//nolint:errcheck // test double
+		json.NewEncoder(w).Encode(body)
+	}))
+}
+
+// newProxyHandler builds the same proxy this server mounts, pointed at the fake
+// provider, so the library's real error handling is exercised.
+func newProxyHandler(baseURL string) http.Handler {
+	p := proxy.New(proxy.Config{
+		DefaultProvider: "openai",
+		Providers: map[string]llm.Options{
+			"openai": {
+				APIKey:  testKey,
+				Model:   "gpt-4o-mini",
+				BaseURL: baseURL,
+			},
+		},
+	})
+	return p.Handler()
+}
+
+func chatRequest(t *testing.T) *http.Request {
+	t.Helper()
+
+	body, err := json.Marshal(proxy.ChatRequest{
+		Messages: []llm.Message{{
+			Role:    llm.RoleUser,
+			Content: []llm.ContentBlock{{Type: llm.BlockText, Text: "hello"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// TestProxyLeaksKeyWithoutRedaction documents the defect this package exists to
+// contain. It asserts the current behaviour of the dependency: the provider's
+// message, key and all, is relayed into the response body verbatim.
+//
+// If this test starts failing, the library has been fixed, which is the outcome
+// we want. Read the failure as the cue to reconsider whether the filter is
+// still needed, not as a regression.
+func TestProxyLeaksKeyWithoutRedaction(t *testing.T) {
+	upstream := fakeProviderRejectingKey(t)
+	defer upstream.Close()
+
+	rec := httptest.NewRecorder()
+	newProxyHandler(upstream.URL).ServeHTTP(rec, chatRequest(t))
+
+	body := rec.Body.String()
+	if !strings.Contains(body, testKey) {
+		t.Skipf("the library no longer relays the provider's message verbatim; "+
+			"review whether redact.Handler is still required. Body: %s", body)
+	}
+}
+
+// TestProxyWrappedIsRedacted is the test that matters: the proxy as this server
+// actually mounts it, wrapped in redact.Handler, must not disclose the key.
+func TestProxyWrappedIsRedacted(t *testing.T) {
+	redact.Reset()
+	defer redact.Reset()
+	redact.Register(testKey)
+
+	upstream := fakeProviderRejectingKey(t)
+	defer upstream.Close()
+
+	rec := httptest.NewRecorder()
+	redact.Handler(newProxyHandler(upstream.URL)).ServeHTTP(rec, chatRequest(t))
+
+	body := rec.Body.String()
+
+	if strings.Contains(body, testKey) {
+		t.Errorf("response disclosed the API key: %s", body)
+	}
+	// The distinctive middle of the key must be gone, not merely the whole
+	// string: a provider quoting a truncated form is the usual case.
+	if strings.Contains(body, "TESTAAAABBBB") {
+		t.Errorf("response disclosed part of the API key: %s", body)
+	}
+	if !strings.Contains(body, redact.Placeholder) {
+		t.Errorf("expected a placeholder in the body: %s", body)
+	}
+
+	// The response must remain useful and well formed. The library reports an
+	// upstream authentication failure as 502, not as the provider's own 401,
+	// so the status is asserted as the library defines it rather than as the
+	// provider returned it.
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("body is not valid JSON: %v (%s)", err, body)
+	}
+	if parsed.Error == "" {
+		t.Error("expected an error message to survive redaction")
+	}
+	if !strings.Contains(parsed.Error, "401") {
+		t.Errorf("expected the upstream status to survive: %q", parsed.Error)
+	}
+}
+
+// TestProxyStreamWrappedIsRedacted covers the streaming endpoint, where the
+// error arrives after the response has begun and the wrapper must neither
+// disclose the key nor break the stream.
+func TestProxyStreamWrappedIsRedacted(t *testing.T) {
+	redact.Reset()
+	defer redact.Reset()
+	redact.Register(testKey)
+
+	upstream := fakeProviderRejectingKey(t)
+	defer upstream.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/stream",
+		strings.NewReader(`{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	redact.Handler(newProxyHandler(upstream.URL)).ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if strings.Contains(body, testKey) || strings.Contains(body, "TESTAAAABBBB") {
+		t.Errorf("streaming response disclosed the API key: %s", body)
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,216 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Package redact removes credentials from text that is about to leave the
+// process, whether to an HTTP client, a trace file or a terminal.
+//
+// It exists because an LLM provider's error body is not ours to control. When
+// authentication fails, providers characteristically quote the key they were
+// given back at the caller: OpenAI's 401 message names the key it rejected, in
+// a partially masked form that still discloses the leading characters. The
+// shared LLM library relays a provider's message verbatim into the error it
+// returns, and that error is written into an HTTP response body and into trace
+// entries, so the fragment travels with it.
+//
+// The right place to stop that is the library, so that every consumer benefits
+// and the credential never reaches an error value in the first place. This
+// package is the layer beneath that: it assumes a leak has already happened
+// and scrubs the text on its way out.
+//
+// Being a filter, it is inherently incomplete. It recognises the shapes of the
+// credentials this project handles and the values it has been told about; a
+// provider that invents a new format, or quotes a key in a way that defeats
+// the patterns here, will not be caught. Treat it as a safety net rather than
+// as the guarantee, and keep secrets out of error values upstream.
+package redact
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Placeholder replaces any credential that is found. It matches the wording
+// already used by the tracer for redacted parameters.
+const Placeholder = "[REDACTED]"
+
+// minRegisterLength is the shortest secret worth registering. Anything shorter
+// risks matching ordinary words and doing more damage to the text than the
+// disclosure would.
+const minRegisterLength = 8
+
+// minFragmentLength is the shortest leading fragment of a registered secret
+// that is replaced on its own. Providers quote a truncated key rather than the
+// whole thing, so the fragment matters more than the full value, but a very
+// short fragment carries little information and matches too readily.
+const minFragmentLength = 12
+
+// keyPatterns match the credential formats this project handles.
+//
+// The character classes include '*' and '.' so that a partially masked key is
+// consumed in full rather than leaving its tail behind: a message quoting
+// "sk-proj-abcd****wxyz" must not be reduced to "[REDACTED]****wxyz".
+var keyPatterns = []*regexp.Regexp{
+	// OpenAI and Anthropic, covering the sk-proj- and sk-ant- variants.
+	regexp.MustCompile(`sk-[A-Za-z0-9_.*-]{8,}`),
+	// Google AI Studio, used for Gemini.
+	regexp.MustCompile(`AIza[A-Za-z0-9_.*-]{10,}`),
+	// Voyage, used for embeddings.
+	regexp.MustCompile(`pa-[A-Za-z0-9_.*-]{8,}`),
+	// An Authorization header, in case one is ever quoted back.
+	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._*-]{8,}`),
+}
+
+var (
+	mu      sync.RWMutex
+	secrets []string
+)
+
+// Register records secrets that must never appear in outgoing text: the
+// provider API keys this server was configured with. Registering a value
+// allows an exact match, which catches a key whose format the patterns above
+// do not recognise.
+//
+// Call it during startup, before the server begins serving. Values shorter
+// than minRegisterLength, and duplicates, are ignored.
+func Register(values ...string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if len(v) < minRegisterLength {
+			continue
+		}
+		if slicesContains(secrets, v) {
+			continue
+		}
+		secrets = append(secrets, v)
+	}
+}
+
+// Reset discards every registered secret. It exists for tests.
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	secrets = nil
+}
+
+// String returns s with every registered secret, every leading fragment of a
+// registered secret, and everything shaped like a provider API key replaced by
+// Placeholder.
+func String(s string) string {
+	if s == "" {
+		return s
+	}
+
+	s = replaceRegistered(s)
+
+	for _, pattern := range keyPatterns {
+		s = pattern.ReplaceAllStringFunc(s, func(match string) string {
+			// A trailing full stop is far more likely to end the sentence
+			// than the credential, so leave it in place.
+			if trimmed := strings.TrimRight(match, "."); trimmed != match {
+				return Placeholder + match[len(trimmed):]
+			}
+			return Placeholder
+		})
+	}
+
+	return s
+}
+
+// Bytes is String for a byte slice. The input is never modified in place.
+func Bytes(b []byte) []byte {
+	if len(b) == 0 {
+		return b
+	}
+	out := String(string(b))
+	if out == string(b) {
+		return b
+	}
+	return []byte(out)
+}
+
+// Error returns err.Error() with credentials removed, and an empty string for
+// a nil error. Use it wherever an error is about to be shown to somebody or
+// written to a file.
+func Error(err error) string {
+	if err == nil {
+		return ""
+	}
+	return String(err.Error())
+}
+
+// ErrorValue returns an error whose message has been redacted, for the places
+// that must pass an error along rather than a string. It returns nil for a nil
+// error, and the original error when there was nothing to remove.
+//
+// The result keeps the original error in its chain, so errors.Is and errors.As
+// continue to work against whatever sentinel the library wrapped; only the
+// message the error presents is cleaned.
+func ErrorValue(err error) error {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	redacted := String(message)
+	if redacted == message {
+		return err
+	}
+	return &redactedError{message: redacted, cause: err}
+}
+
+// redactedError presents a cleaned message whilst preserving the error chain.
+type redactedError struct {
+	message string
+	cause   error
+}
+
+func (e *redactedError) Error() string { return e.message }
+
+func (e *redactedError) Unwrap() error { return e.cause }
+
+// replaceRegistered removes registered secrets, whole or truncated.
+//
+// The truncated case is the one that matters in practice, because a provider
+// quotes the start of the key rather than all of it, so the longest leading
+// fragment present in the text is replaced. Only the longest match is needed:
+// removing it removes every shorter prefix along with it.
+func replaceRegistered(s string) string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	for _, secret := range secrets {
+		if strings.Contains(s, secret) {
+			s = strings.ReplaceAll(s, secret, Placeholder)
+			continue
+		}
+		for n := len(secret) - 1; n >= minFragmentLength; n-- {
+			fragment := secret[:n]
+			if strings.Contains(s, fragment) {
+				s = strings.ReplaceAll(s, fragment, Placeholder)
+				break
+			}
+		}
+	}
+
+	return s
+}
+
+// slicesContains reports whether v is present in list.
+func slicesContains(list []string, v string) bool {
+	for _, item := range list {
+		if item == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,216 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package redact
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Every key below is invented for the test. The formats mimic the real ones so
+// that the patterns are exercised, but the values are not credentials.
+const (
+	fakeOpenAIKey    = "sk-proj-AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJ"
+	fakeAnthropicKey = "sk-ant-api03-KKKKLLLLMMMMNNNNOOOOPPPPQQQQRRRR"
+	fakeGeminiKey    = "AIzaSSSSTTTTUUUUVVVVWWWWXXXXYYYYZZZZ012"
+	fakeVoyageKey    = "pa-0123456789abcdefghijklmnopqrstuvwxyz"
+)
+
+func TestStringRedactsKeyShapes(t *testing.T) {
+	Reset()
+
+	tests := []struct {
+		name  string
+		input string
+		// mustNotContain is the fragment that must be gone afterwards.
+		mustNotContain string
+	}{
+		{
+			// This is the message shape that prompted the work: a provider
+			// quoting back the key it rejected.
+			name:           "OpenAI style authentication failure",
+			input:          "openai (401): Incorrect API key provided: " + fakeOpenAIKey + ". You can find your API key at https://platform.openai.com/account/api-keys.",
+			mustNotContain: "AAAABBBB",
+		},
+		{
+			name:           "partially masked key keeps no tail",
+			input:          "Incorrect API key provided: sk-proj-AAAA****JJJJ.",
+			mustNotContain: "JJJJ",
+		},
+		{
+			name:           "Anthropic key",
+			input:          "anthropic (401): invalid x-api-key " + fakeAnthropicKey,
+			mustNotContain: "KKKKLLLL",
+		},
+		{
+			name:           "Gemini key",
+			input:          "gemini (400): API key not valid: " + fakeGeminiKey,
+			mustNotContain: "SSSSTTTT",
+		},
+		{
+			name:           "Voyage key",
+			input:          "voyage (401): bad key " + fakeVoyageKey,
+			mustNotContain: "0123456789abcdef",
+		},
+		{
+			name:           "bearer token",
+			input:          "upstream rejected Authorization: Bearer abcdefghijklmnop",
+			mustNotContain: "abcdefghijklmnop",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := String(tt.input)
+
+			if strings.Contains(got, tt.mustNotContain) {
+				t.Errorf("redacted text still contains %q: %s", tt.mustNotContain, got)
+			}
+			if !strings.Contains(got, Placeholder) {
+				t.Errorf("expected %s in the result, got: %s", Placeholder, got)
+			}
+		})
+	}
+}
+
+func TestStringPreservesSurroundingText(t *testing.T) {
+	Reset()
+
+	got := String("openai (401): Incorrect API key provided: " + fakeOpenAIKey + ". Check your settings.")
+
+	// The message must stay useful: whoever reads it still needs to know what
+	// went wrong and with which provider.
+	for _, want := range []string{"openai", "401", "Incorrect API key provided", "Check your settings."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("redaction removed useful context %q: %s", want, got)
+		}
+	}
+
+	// A full stop that ends the sentence belongs to the sentence.
+	if !strings.Contains(got, Placeholder+".") {
+		t.Errorf("expected the sentence's full stop to survive: %s", got)
+	}
+}
+
+func TestStringLeavesOrdinaryTextAlone(t *testing.T) {
+	Reset()
+
+	unchanged := []string{
+		"",
+		"connection refused",
+		"pq: relation \"users\" does not exist",
+		"openai (429): rate limit exceeded, retry after 20s",
+		"SELECT * FROM sk_units WHERE id = 5",
+		"task-list is empty",
+	}
+
+	for _, input := range unchanged {
+		if got := String(input); got != input {
+			t.Errorf("String(%q) = %q, want it unchanged", input, got)
+		}
+	}
+}
+
+func TestRegisteredSecretIsRedactedWholeAndTruncated(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	// A key whose format none of the patterns recognise, which is exactly why
+	// registration exists.
+	const key = "custom-format-9f3b1d7c2e4a6b8d0f2a4c6e"
+	Register(key)
+
+	t.Run("whole value", func(t *testing.T) {
+		got := String("provider rejected " + key)
+		if strings.Contains(got, key) {
+			t.Errorf("registered secret survived: %s", got)
+		}
+		if !strings.Contains(got, Placeholder) {
+			t.Errorf("expected a placeholder: %s", got)
+		}
+	})
+
+	t.Run("truncated value", func(t *testing.T) {
+		// Providers quote a prefix rather than the whole key, so the prefix
+		// has to go too.
+		got := String("provider rejected " + key[:20] + "...")
+		if strings.Contains(got, key[:20]) {
+			t.Errorf("truncated secret survived: %s", got)
+		}
+	})
+
+	t.Run("fragment too short to be worth matching", func(t *testing.T) {
+		// Below the fragment threshold nothing is replaced, which is
+		// deliberate: short fragments carry little and match too much.
+		short := key[:6]
+		if got := String("value " + short); strings.Contains(got, Placeholder) {
+			t.Errorf("did not expect a %s-length fragment to be redacted: %s", short, got)
+		}
+	})
+}
+
+func TestRegisterIgnoresShortAndDuplicateValues(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	Register("", "abc", "   ")
+	if got := String("abc"); got != "abc" {
+		t.Errorf("a short value should not have been registered, got %q", got)
+	}
+
+	Register(fakeOpenAIKey, fakeOpenAIKey)
+
+	mu.RLock()
+	count := len(secrets)
+	mu.RUnlock()
+	if count != 1 {
+		t.Errorf("registered secret count = %d, want 1", count)
+	}
+}
+
+func TestErrorRedacts(t *testing.T) {
+	Reset()
+
+	if got := Error(nil); got != "" {
+		t.Errorf("Error(nil) = %q, want empty", got)
+	}
+
+	err := errors.New("openai (401): Incorrect API key provided: " + fakeOpenAIKey)
+	got := Error(err)
+	if strings.Contains(got, "AAAABBBB") {
+		t.Errorf("Error() leaked the key: %s", got)
+	}
+}
+
+func TestBytes(t *testing.T) {
+	Reset()
+
+	// An input needing no change is returned as-is.
+	in := []byte("nothing to see here")
+	if got := Bytes(in); string(got) != string(in) {
+		t.Errorf("Bytes() = %q, want %q", got, in)
+	}
+
+	in = []byte(`{"error":"openai (401): Incorrect API key provided: ` + fakeOpenAIKey + `"}`)
+	got := Bytes(in)
+	if strings.Contains(string(got), "AAAABBBB") {
+		t.Errorf("Bytes() leaked the key: %s", got)
+	}
+	if !strings.Contains(string(got), Placeholder) {
+		t.Errorf("expected a placeholder: %s", got)
+	}
+
+	// The caller's slice must not be modified in place.
+	if !strings.Contains(string(in), "AAAABBBB") {
+		t.Error("Bytes() modified its input")
+	}
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -31,40 +31,42 @@ func TestStringRedactsKeyShapes(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
-		// mustNotContain is the fragment that must be gone afterwards.
-		mustNotContain string
+		// mustNotContain are fragments that must all be gone afterwards.
+		// Checking both ends of the key, not just one, is what would catch a
+		// regression that redacts a prefix but leaves the tail behind.
+		mustNotContain []string
 	}{
 		{
 			// This is the message shape that prompted the work: a provider
 			// quoting back the key it rejected.
 			name:           "OpenAI style authentication failure",
 			input:          "openai (401): Incorrect API key provided: " + fakeOpenAIKey + ". You can find your API key at https://platform.openai.com/account/api-keys.",
-			mustNotContain: "AAAABBBB",
+			mustNotContain: []string{"AAAABBBB", "IIIIJJJJ"},
 		},
 		{
 			name:           "partially masked key keeps no tail",
 			input:          "Incorrect API key provided: sk-proj-AAAA****JJJJ.",
-			mustNotContain: "JJJJ",
+			mustNotContain: []string{"AAAA", "JJJJ"},
 		},
 		{
 			name:           "Anthropic key",
 			input:          "anthropic (401): invalid x-api-key " + fakeAnthropicKey,
-			mustNotContain: "KKKKLLLL",
+			mustNotContain: []string{"KKKKLLLL", "QQQQRRRR"},
 		},
 		{
 			name:           "Gemini key",
 			input:          "gemini (400): API key not valid: " + fakeGeminiKey,
-			mustNotContain: "SSSSTTTT",
+			mustNotContain: []string{"SSSSTTTT", "YYYYZZZZ"},
 		},
 		{
 			name:           "Voyage key",
 			input:          "voyage (401): bad key " + fakeVoyageKey,
-			mustNotContain: "0123456789abcdef",
+			mustNotContain: []string{"0123456789abcdef", "stuvwxyz"},
 		},
 		{
 			name:           "bearer token",
 			input:          "upstream rejected Authorization: Bearer abcdefghijklmnop",
-			mustNotContain: "abcdefghijklmnop",
+			mustNotContain: []string{"abcdefghijklmnop"},
 		},
 	}
 
@@ -72,8 +74,10 @@ func TestStringRedactsKeyShapes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := String(tt.input)
 
-			if strings.Contains(got, tt.mustNotContain) {
-				t.Errorf("redacted text still contains %q: %s", tt.mustNotContain, got)
+			for _, fragment := range tt.mustNotContain {
+				if strings.Contains(got, fragment) {
+					t.Errorf("redacted text still contains %q: %s", fragment, got)
+				}
 			}
 			if !strings.Contains(got, Placeholder) {
 				t.Errorf("expected %s in the result, got: %s", Placeholder, got)
@@ -186,7 +190,7 @@ func TestErrorRedacts(t *testing.T) {
 
 	err := errors.New("openai (401): Incorrect API key provided: " + fakeOpenAIKey)
 	got := Error(err)
-	if strings.Contains(got, "AAAABBBB") {
+	if strings.Contains(got, "AAAABBBB") || strings.Contains(got, "IIIIJJJJ") {
 		t.Errorf("Error() leaked the key: %s", got)
 	}
 }
@@ -202,7 +206,7 @@ func TestBytes(t *testing.T) {
 
 	in = []byte(`{"error":"openai (401): Incorrect API key provided: ` + fakeOpenAIKey + `"}`)
 	got := Bytes(in)
-	if strings.Contains(string(got), "AAAABBBB") {
+	if strings.Contains(string(got), "AAAABBBB") || strings.Contains(string(got), "IIIIJJJJ") {
 		t.Errorf("Bytes() leaked the key: %s", got)
 	}
 	if !strings.Contains(string(got), Placeholder) {


### PR DESCRIPTION
## Verified, not assumed

The report is accurate, and I confirmed the mechanism in the dependency's source before changing anything:

- `llm/provider/openai/openai.go:976-1003` copies the upstream `error.message` verbatim into `ProviderError.Message`.
- `llm/proxy/proxy.go:342` writes `info.Err.Error()` straight into the response body.
- Grepping the whole library for `redact`, `sanitiz`, `scrub` and `mask` returns nothing outside tests.

Better than reading, `TestProxyLeaksKeyWithoutRedaction` now stands the real proxy up against a fake provider returning the OpenAI error shape and asserts the key reaches the response **unredacted**. The defect is pinned by a test. That test skips with an explanatory message if the library is ever fixed, so it tells you the filter may no longer be needed rather than failing mysteriously.

One correction to the report's framing. On the RAG side you traced this to that project's own `internal/server/handlers.go`. There is no equivalent here: `/api/llm/*` is the library's proxy, mounted at `main.go:943` as `p.Handler()`, so the response-path leak is entirely the shared dependency's code and the same defect is being reported against two consumers of one library. The MCP endpoints also sit behind `authWrapper`, so unlike RAG this is not an anonymous disclosure; a caller needs a valid token, unless the server runs with `-no-auth`. That lowers severity without excusing it, since in the cloud service an authenticated tenant would be learning part of the operator's key.

## Three sinks, not one

The report describes the response body. Tracing the error found a second sink that is arguably worse and is unambiguously ours: `internal/llmtracing/hooks.go:108` passed the raw error to `tracing.LogError`, which stores `err.Error()` and encodes it to the file named by `-trace-file`. That output persists and gets attached to support tickets. The CLI's four provider-facing error sites are the third, less serious sink, since the key is the operator's own, though that output is often redirected to a log.

All three are now redacted.

## How the filter works

A new `internal/redact` package matches two things: credentials the server was configured with, registered at startup, and anything shaped like a provider key (`sk-`, `AIza`, `pa-`, bearer tokens). Both are needed. Registration catches formats the patterns do not know; pattern matching catches the *truncated* form a provider actually quotes, which an exact match on the configured value would miss entirely. Fragments below a length threshold are left alone, since short fragments carry little and match too readily. The surrounding message survives, so the provider, status code and reason still reach whoever has to diagnose the failure.

Two properties of the response filter deserve review attention:

- **Redaction is per write.** A credential split across two `Write` calls would pass through. That does not arise for a JSON error body, encoded in one go, nor for a server-sent event, written as a unit, but it is a genuine limit of filtering a stream instead of fixing the source.
- **`Content-Length` is dropped** when the wrapped handler sets it, because redaction changes the body's length and a stale header would truncate the response. `Flush` is forwarded so streaming is unaffected, and there is a test asserting the stream still flushes per event.

## This is a safety net, not the fix

The durable fix belongs in `pgedge-go-llm-lib`, so that a credential never reaches an error value at all and both this project and the RAG server benefit at once. I do not have that repository to hand; point me at it and I will do it, at which point this filter becomes belt-and-braces. The new documentation section says as much explicitly, including that a provider inventing a new key format would not be caught.

## Also fixed on the way

`make test` never ran ten packages that have tests, so `internal/redact` would have silently joined them: `api`, `compactor`, `conversations`, `definitions`, `httperror`, `llmtracing`, `logging`, `prompts`, `search` and `tsv`. They are now in the server target. All of them pass; they were simply never run, which is worth knowing independently of this change.

## Testing

`make test` passes with no failures across the newly enlarged set, `make lint` reports 0 issues, and `gofmt` and `go vet` are clean. The new package has 13 tests covering the key formats, registered and truncated secrets, the io.Writer contract that redaction could otherwise break, JSON validity of the filtered body, streaming and flush behaviour, the stale `Content-Length` hazard, and the end-to-end proxy paths for both chat and streaming chat. Every key in the tests is invented; none is a credential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Provider credential-like values are now redacted before reaching `/api/llm/` clients (including streaming), durable trace artifacts, and CLI/system error output.
  - Configured provider keys are registered for redaction, alongside common key-format patterns, replacing sensitive fragments with `[REDACTED]` while keeping surrounding error context.
- **Bug Fixes**
  - `make test` now executes server-side tests for all packages that include tests, fixing prior omissions.
- **Tests**
  - Added coverage for response-body redaction and upstream proxy error redaction across plain text, JSON encoding, and streaming scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->