### PR TITLE
fix(security): reject subqueries in count_rows where clause

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,37 @@ and this project adheres to
   in the documentation now set `X-Forwarded-For` to `$remote_addr` rather
   than `$proxy_add_x_forwarded_for`.
 
+- `count_rows`'s `where` parameter now rejects a subquery. The parameter is
+  interpolated directly into the generated `SELECT COUNT(*)` statement, and
+  a subquery there let a caller run a boolean- or error-based blind
+  injection oracle against any table the connected role could read, not
+  only the table named in the call: a crafted `where` clause used the
+  returned count as a true/false signal to enumerate arbitrary data a
+  character at a time. `validateReadOnlyQuery` had no way to recognise
+  this, since a boolean subquery is ordinary legal SQL and not one of the
+  read-only escapes it screens for. The fix, `validateCountRowsWhereClause`
+  in `internal/tools/count_rows.go`, rejects a bare `SELECT` or `TABLE` in
+  the clause's comment-stripped, literal-blanked residue; every documented
+  use of `where` is a simple predicate that never needs either. `TABLE`
+  matters because `TABLE tablename` is PostgreSQL shorthand for `SELECT *
+  FROM tablename` and reads exactly the same data without the word
+  `SELECT` ever appearing — an initial version of this fix that checked
+  only for `SELECT` missed it. `VALUES`, the grammar's third row-returning
+  form, is deliberately left unblocked: it admits no `FROM` clause, so it
+  can only construct a literal row and never read a table, and unlike
+  `SELECT`/`TABLE` it is not fully reserved, so it can legitimately be an
+  unquoted column name. `query_database` and `execute_explain` are
+  unaffected, since running arbitrary SQL, subqueries included, is their
+  entire purpose. Reported and fully reproduced, including full end-to-end
+  secret extraction, before this fix (issue #200); a stacked-query attempt
+  against the same parameter was already correctly rejected. Calling an
+  arbitrary function in `where` (for example `to_regclass('other_table')
+  IS NOT NULL`, which reveals only whether a name exists in the catalogue,
+  not any row's contents) and a same-table filter bypass (`where="status =
+  'x' OR 1=1"`) both remain possible and are out of scope for this fix:
+  neither lets a caller read another table's contents, which is what
+  issue #200 reported.
+
 - Upgraded `github.com/jackc/pgx/v5` from 5.7.6 to 5.10.0, resolving three
   advisories against the PostgreSQL driver. Two are memory-safety issues
   (GO-2026-4771/CVE-2026-33815 and GO-2026-4772/CVE-2026-33816, fixed in

--- a/internal/tools/count_rows.go
+++ b/internal/tools/count_rows.go
@@ -13,6 +13,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -48,6 +49,8 @@ Use count_rows to efficiently determine data volume:
 - Much more efficient than SELECT * with LIMIT for checking data volume
 - Use this before query_database to plan appropriate LIMIT values
 - WHERE clause is optional - omit for total count
+- WHERE clause must be a simple filter predicate against the named table;
+  subqueries are rejected. Use query_database for anything that needs one
 - Returns a single integer count - minimal token usage
 </important>`,
 			InputSchema: mcp.InputSchema{
@@ -64,7 +67,7 @@ Use count_rows to efficiently determine data volume:
 					},
 					"where": map[string]any{
 						"type":        "string",
-						"description": "Optional WHERE clause condition (without the WHERE keyword). Example: \"status = 'active' AND created_at > '2024-01-01'\"",
+						"description": "Optional WHERE clause condition (without the WHERE keyword). Must be a simple filter predicate; subqueries are rejected. Example: \"status = 'active' AND created_at > '2024-01-01'\"",
 					},
 				},
 				Required: []string{"table"},
@@ -87,10 +90,32 @@ Use count_rows to efficiently determine data volume:
 			// other caller-supplied SQL. This tool always counts inside a
 			// read-only transaction, so the guard applies whether or not the
 			// connection permits writes elsewhere.
+			//
+			// validateReadOnlyQuery only recognises constructs that escape
+			// read-only mode; an arbitrary boolean subquery is ordinary
+			// legal SQL and is invisible to it. count_rows's where is
+			// documented and intended as a simple predicate against the
+			// named table, so validateCountRowsWhereClause additionally
+			// rejects a subquery, which closes the cross-table blind
+			// injection vector reported in issue #200: without it, a where
+			// clause let a caller run a boolean- or error-based oracle
+			// against any table the connected role can read, not just the
+			// one named in the call. query_database and execute_explain are
+			// unaffected; their entire purpose is running arbitrary SQL,
+			// subqueries included.
 			whereClause := ""
 			if w, ok := args["where"].(string); ok && w != "" {
 				if err := validateReadOnlyQuery(w); err != nil {
 					logging.Warn("read_only_query_rejected",
+						"database", dbClient.DisplayName(),
+						"tool", "count_rows",
+						"reason", err.Error(),
+						"statement", w,
+					)
+					return mcp.NewToolError(err.Error())
+				}
+				if err := validateCountRowsWhereClause(w); err != nil {
+					logging.Warn("count_rows_where_clause_rejected",
 						"database", dbClient.DisplayName(),
 						"tool", "count_rows",
 						"reason", err.Error(),
@@ -182,4 +207,52 @@ func quoteIdentifier(name string) string {
 	// Double any existing double quotes and wrap in double quotes
 	escaped := strings.ReplaceAll(name, `"`, `""`)
 	return `"` + escaped + `"`
+}
+
+// subqueryPattern matches a bare SELECT or TABLE keyword — the two
+// constructs PostgreSQL's grammar allows to start a row-returning
+// "simple_select" that can appear as a parenthesised subquery. TABLE
+// tablename is shorthand for SELECT * FROM tablename and reads exactly the
+// same data; a where clause of "(TABLE other_table) = value" leaks another
+// table's contents through the same boolean oracle as "(SELECT ... FROM
+// other_table) = value" without the word SELECT ever appearing. VALUES is
+// the grammar's third alternative but is deliberately not blocked here: it
+// cannot itself reference a table (VALUES (...) admits no FROM clause, so
+// it can only construct a literal row, not read one), and unlike SELECT and
+// TABLE it is not a fully reserved keyword in PostgreSQL — it can
+// legitimately be an unquoted column name — so banning it would risk
+// rejecting a genuine predicate for no security benefit.
+//
+// Checked against the comment-stripped, literal-blanked residue produced
+// by stripSQLNoise, so a literal string such as 'select this row' cannot
+// trigger a false rejection, and a comment cannot be used to split either
+// keyword to slip past.
+var subqueryPattern = regexp.MustCompile(`(?i)\b(SELECT|TABLE)\b`)
+
+// validateCountRowsWhereClause rejects a where clause containing a
+// subquery.
+//
+// count_rows's where parameter is documented as a simple filter predicate
+// against the named table (see the tool's own examples: "status = 'active'
+// AND created_at > '2024-01-01'"); no legitimate use of it needs a
+// subquery. Without this check, a subquery in where lets a caller run a
+// boolean- or error-based blind-injection oracle against any table the
+// connected role can read, not only the table named in the call — see
+// issue #200. As with the DO-block and set_config() rejections in
+// readonly_guard.go, no fixed pattern can separate a "safe" subquery from a
+// dangerous one, so every subquery is refused outright rather than trying
+// to recognise which ones are dangerous. query_database and
+// execute_explain do not call this: their entire purpose is running
+// arbitrary SQL, subqueries included, and validateReadOnlyQuery is the
+// only guard applicable there.
+func validateCountRowsWhereClause(where string) error {
+	residue, _ := stripSQLNoise(where)
+	if subqueryPattern.MatchString(residue) {
+		return fmt.Errorf(
+			"where clause rejected: subqueries are not permitted; " +
+				"count_rows only accepts a simple filter predicate " +
+				"against the named table (use query_database for " +
+				"anything that needs a subquery)")
+	}
+	return nil
 }

--- a/internal/tools/count_rows_test.go
+++ b/internal/tools/count_rows_test.go
@@ -1,0 +1,102 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package tools
+
+import "testing"
+
+// TestValidateCountRowsWhereClause_AllowsSimplePredicates confirms that
+// every filter shown in the tool's own documented examples, plus other
+// ordinary predicate shapes, still passes.
+func TestValidateCountRowsWhereClause_AllowsSimplePredicates(t *testing.T) {
+	cases := []string{
+		"",
+		"status = 'pending'",
+		"created_at > '2024-01-01'",
+		"status = 'active' AND created_at > '2024-01-01'",
+		"status IN ('a', 'b', 'c')",
+		"name LIKE 'A%'",
+		"price BETWEEN 10 AND 100",
+		"deleted_at IS NULL",
+		"NOT (status = 'archived')",
+		// A string literal that merely contains the word "select" must not
+		// trip the check; stripSQLNoise blanks literals before matching.
+		"description = 'please select an option'",
+		"notes = 'a select-box widget'",
+		// VALUES is deliberately not blocked: it cannot reference a table
+		// (no FROM clause is legal in a VALUES construct, so it can only
+		// build a literal row, never read one) and, unlike SELECT and
+		// TABLE, it is not fully reserved in PostgreSQL — it can
+		// legitimately be an unquoted column name.
+		"values = 5",
+		"values > 0 AND values < 100",
+		// A quoted identifier literally named "table" (the only way to use
+		// that word as an identifier, since TABLE is fully reserved) must
+		// not trip the check either: stripSQLNoise blanks quoted
+		// identifiers the same way it blanks string literals.
+		`"table" = 'active'`,
+	}
+
+	for _, where := range cases {
+		if err := validateCountRowsWhereClause(where); err != nil {
+			t.Errorf("where=%q: expected no error, got: %v", where, err)
+		}
+	}
+}
+
+// TestValidateCountRowsWhereClause_RejectsSubqueries confirms that every
+// subquery shape used in the issue #200 proof-of-concept, plus a few
+// evasion attempts, is rejected.
+func TestValidateCountRowsWhereClause_RejectsSubqueries(t *testing.T) {
+	cases := []string{
+		// The exact boolean-blind cross-table oracle from issue #200.
+		"1=1 AND (SELECT COUNT(*) FROM customers WHERE email = 'alice@example.com') = 1",
+		// The exact error-based blind oracle from issue #200.
+		"1=1 AND CAST((CASE WHEN (SELECT substr(email,1,1) FROM customers WHERE id=1) = 'a' THEN '1' ELSE 'not-a-number' END) AS int) = 1",
+		// EXISTS is itself a subquery.
+		"EXISTS (SELECT 1 FROM secret_table)",
+		// Case-insensitivity.
+		"1=1 and (select 1 from secret_table) is not null",
+		"1=1 AND (SeLeCt 1 FROM secret_table) IS NOT NULL",
+		// A line comment preceding the keyword must not hide it.
+		"1=1 AND (-- comment\nSELECT 1 FROM secret_table) IS NOT NULL",
+		// TABLE tablename is PostgreSQL shorthand for SELECT * FROM
+		// tablename and reads exactly the same data — confirmed directly
+		// against a live server: "(TABLE secret_table) = value" leaks a
+		// single-column table's contents through the same boolean oracle
+		// as a SELECT-based subquery, with the word SELECT never
+		// appearing anywhere in the clause. This was a real gap in an
+		// earlier version of this check.
+		"(TABLE secret_table) = true",
+		"1=1 AND (TABLE secret_table) IS NOT NULL",
+		"1 = (table secret_table limit 1)",
+	}
+
+	for _, where := range cases {
+		if err := validateCountRowsWhereClause(where); err == nil {
+			t.Errorf("where=%q: expected a rejection, got none", where)
+		}
+	}
+}
+
+// TestValidateCountRowsWhereClause_SplitCommentIsNotASelect documents why
+// "SEL/**/ECT" is rejected for a different reason than the other cases: the
+// comment breaks the token into "SEL" and "ECT", neither of which matches
+// \bSELECT\b on its own. It is caught anyway because stripSQLNoise inserts
+// a separating space in place of the comment, matching how PostgreSQL's own
+// lexer treats a comment as a token boundary rather than simple deletion —
+// so "SEL/**/ECT" was never a working SELECT keyword to begin with, in this
+// guard or in Postgres itself.
+func TestValidateCountRowsWhereClause_SplitCommentIsNotASelect(t *testing.T) {
+	residue, _ := stripSQLNoise("SEL/**/ECT 1")
+	if residue == "SELECT 1" {
+		t.Fatalf("comment removal must not merge SEL and ECT into SELECT: got %q", residue)
+	}
+}

--- a/test/count_rows_injection_test.go
+++ b/test/count_rows_injection_test.go
@@ -1,0 +1,161 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// countRowsResult is the shape of a count_rows tools/call response.
+type countRowsResult struct {
+	Content []struct {
+		Text string `json:"text"`
+	} `json:"content"`
+	IsError bool `json:"isError"`
+}
+
+func callCountRows(t *testing.T, server *MCPServer, table, schema, where string) countRowsResult {
+	t.Helper()
+	args := map[string]interface{}{"table": table}
+	if schema != "" {
+		args["schema"] = schema
+	}
+	if where != "" {
+		args["where"] = where
+	}
+	resp, err := server.SendRequest("tools/call", map[string]interface{}{
+		"name":      "count_rows",
+		"arguments": args,
+	})
+	if err != nil {
+		t.Fatalf("tools/call transport error: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected JSON-RPC error: %s", resp.Error.Message)
+	}
+	var result countRowsResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal count_rows result: %v", err)
+	}
+	return result
+}
+
+// TestCountRowsWhereClauseRejectsSubqueries is the regression test for
+// issue #200: a where clause containing a subquery let a caller run a
+// boolean- or error-based blind-injection oracle against any table the
+// connected role could read, not only the table named in the count_rows
+// call. This drives the real server binary over the actual JSON-RPC
+// tools/call protocol, reproducing the exact payloads from the issue, and
+// confirms they are now rejected before ever reaching the database.
+//
+// pg_catalog.pg_class is used as the target table because it exists on
+// every PostgreSQL server regardless of application schema, so this test
+// has no dependency on scratch data or elevated privileges.
+func TestCountRowsWhereClauseRejectsSubqueries(t *testing.T) {
+	connString := os.Getenv("TEST_PGEDGE_POSTGRES_CONNECTION_STRING")
+	if connString == "" {
+		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set")
+	}
+
+	server, err := StartMCPServer(t, connString, "dummy-key-for-testing")
+	if err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+
+	t.Run("legitimate simple predicate still works", func(t *testing.T) {
+		result := callCountRows(t, server, "pg_class", "pg_catalog", "relkind = 'r'")
+		if result.IsError {
+			t.Fatalf("expected a legitimate simple predicate to succeed, got: %+v", result)
+		}
+	})
+
+	t.Run("boolean-blind cross-table subquery is rejected", func(t *testing.T) {
+		// The exact shape from issue #200: count_rows(table="orders", ...)
+		// used as an oracle to test facts about a table it never named.
+		where := "1=1 AND (SELECT COUNT(*) FROM pg_roles WHERE rolname = 'postgres') = 1"
+		result := callCountRows(t, server, "pg_class", "pg_catalog", where)
+		if !result.IsError {
+			t.Fatalf("expected the subquery to be rejected, got success: %+v", result)
+		}
+		assertMentionsSubquery(t, result)
+	})
+
+	t.Run("error-based blind cross-table subquery is rejected", func(t *testing.T) {
+		where := "1=1 AND CAST((CASE WHEN (SELECT count(*) FROM pg_roles WHERE rolname = 'postgres') = 1 " +
+			"THEN '1' ELSE 'not-a-number' END) AS int) = 1"
+		result := callCountRows(t, server, "pg_class", "pg_catalog", where)
+		if !result.IsError {
+			t.Fatalf("expected the subquery to be rejected, got success: %+v", result)
+		}
+		assertMentionsSubquery(t, result)
+	})
+
+	t.Run("EXISTS subquery is rejected", func(t *testing.T) {
+		where := "EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'postgres')"
+		result := callCountRows(t, server, "pg_class", "pg_catalog", where)
+		if !result.IsError {
+			t.Fatalf("expected the EXISTS subquery to be rejected, got success: %+v", result)
+		}
+		assertMentionsSubquery(t, result)
+	})
+
+	t.Run("TABLE-shorthand subquery is rejected", func(t *testing.T) {
+		// TABLE tablename is PostgreSQL shorthand for SELECT * FROM
+		// tablename and reads exactly the same data. Confirmed directly
+		// against a live server that "(TABLE other_table) = value" leaks a
+		// single-column table's contents through the same boolean oracle
+		// as a SELECT-based subquery, with the word SELECT never
+		// appearing in the clause — a real gap in an earlier version of
+		// this fix, closed by also rejecting a bare TABLE keyword.
+		where := "1=1 AND (TABLE pg_roles) IS NOT NULL"
+		result := callCountRows(t, server, "pg_class", "pg_catalog", where)
+		if !result.IsError {
+			t.Fatalf("expected the TABLE-shorthand subquery to be rejected, got success: %+v", result)
+		}
+		assertMentionsSubquery(t, result)
+	})
+
+	t.Run("VALUES is not rejected and cannot read a table anyway", func(t *testing.T) {
+		// VALUES is deliberately not blocked: it admits no FROM clause, so
+		// it can only construct a literal row, never read one, and unlike
+		// SELECT/TABLE it is not fully reserved in PostgreSQL, so banning
+		// it would risk rejecting a genuine "values" column reference for
+		// no security benefit. Confirm it is accepted by the guard and
+		// that Postgres itself refuses to let it reference a table.
+		result := callCountRows(t, server, "pg_class", "pg_catalog", "1=1 AND (VALUES (1)) IS NOT NULL")
+		if result.IsError {
+			t.Fatalf("expected VALUES to be accepted by the where-clause guard, got: %+v", result)
+		}
+	})
+
+	t.Run("stacked query is still rejected independently", func(t *testing.T) {
+		// Confirms the pre-existing validateReadOnlyQuery guard is untouched
+		// by this change.
+		result := callCountRows(t, server, "pg_class", "pg_catalog", "1=1; DROP TABLE pg_class")
+		if !result.IsError {
+			t.Fatalf("expected the stacked query to be rejected, got success: %+v", result)
+		}
+	})
+}
+
+func assertMentionsSubquery(t *testing.T, result countRowsResult) {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatalf("expected an error message, got no content")
+	}
+	if !strings.Contains(result.Content[0].Text, "subqueries are not permitted") {
+		t.Errorf("expected the subquery rejection message, got: %s", result.Content[0].Text)
+	}
+}


### PR DESCRIPTION
# fix(security): refresh postgres-mcp Trivy ignore list

## Summary

Triage for the Trivy image scan on `ghcr.io/pgedge/postgres-mcp:1.0.0`
(Critical: 2, High: 46, Medium: 119, Low: 94). Rather than triage each
finding against the published tag, I rebuilt `Dockerfile.server` from
current source and rescanned that, since the published image is simply
old and most of what it reports may already be fixed upstream.

It was: rebuilding drops Critical/High from 48 to 10, with zero code
changes required. The remaining 10 are 5 distinct curl-minimal/
libcurl-minimal CVEs with no upstream fix from Red Hat, all of which
require a curl feature this image's single curl invocation cannot
reach.

## What a rebuild already fixes

The published `:1.0.0` image is stale against current `main`:

| Component | In `:1.0.0` | Current |
|---|---|---|
| `github.com/jackc/pgx/v5` | 5.7.6 | 5.10.0 |
| `golang.org/x/crypto` | 0.44.0 | 0.54.0 |
| `golang.org/x/net` | 0.47.0 | 0.57.0 |
| Go stdlib | 1.24.13 | current, via the floating `golang:1.26-alpine` build stage |

`Dockerfile.server` already runs `microdnf update -y`, so a fresh build
also picks up current RHEL/UBI9 packages without any Dockerfile change.
I confirmed each of the following, specifically named in the report, is
gone on a fresh build:

- `CVE-2026-33815` / `CVE-2026-33816` (pgx memory-safety)
- The ~15 stdlib CVEs across `crypto/tls`, `crypto/x509`, `net/mail`,
  `os`, `mime`, `net/http2`, etc.
- `CVE-2026-58016` (glib2), `CVE-2026-45447` (openssl/openssl-libs),
  `CVE-2026-54369` (libacl), `CVE-2026-4878` (libcap)
- All 9 `golang.org/x/crypto/ssh` CVEs (the module was already
  reachably-clean per `govulncheck`; the version bump closes the
  module-level match too)

None of this needed a code change in this PR; it was already true of
current `main`. The published image just hasn't been rebuilt since.

## What actually needed a decision: the 5 remaining curl CVEs

`curl-minimal`/`libcurl-minimal` 7.76.1 has no Red Hat fix for:

- `CVE-2026-11352` — DoS via the QUIC UDP receive function
- `CVE-2026-11586` — DoS via WebSocket PING flood
- `CVE-2026-8286` — insecure connection establishment from a TLS
  configuration mismatch
- `CVE-2026-8925` — double-free in SASL authentication
- `CVE-2026-9547` — MITM via SSH host key bypass

This package is installed only conditionally (`KB_SOURCE` is a URL) and
used for exactly one invocation: `curl -fsSL -o kb.db "${KB_SOURCE}"`, a
plain HTTPS GET, gated on `KB_SOURCE` already having been validated as
`http(s)://`. None of the above are reachable from that: no HTTP/3,
no WebSocket, no auth scheme, no custom TLS flags, no SCP/SFTP. Added
to `.trivy/postgres-mcp.trivyignore.yaml` with a justification specific
to each CVE's actual trigger, replacing 5 stale curl entries for CVEs
that are no longer present in any scan (already fixed upstream since
that ignore file was last touched).

## Also refreshed while in the ignore file

- `glib2` and `openssl`/`openssl-libs`: current CVE set (the old IDs no
  longer appear), same root justification for all of them — the server
  is `CGO_ENABLED=0` pure Go and never links against or calls into
  either library.
- Removed the `glibc` section outright: zero findings for that package
  now, on any severity.
- Added `golang.org/x/crypto/openpgp`'s unmaintained-package flag
  (`GO-2026-5932`): confirmed via `govulncheck` that only
  `golang.org/x/crypto/bcrypt` is imported anywhere in this codebase;
  `openpgp` is never imported or called.

Deliberately did not do a full refresh of the remaining Medium/Low OS
package findings (`libarchive`, `libxml2`, `openldap`, `p11-kit`,
`systemd-libs`, `gnupg2`, `libnghttp2`, `bzip2-libs`, `zlib`) — several
of the existing entries for those are themselves now stale (different
CVE IDs than what a fresh scan reports), but that's below this report's
stated Critical/High priority and is a reasonable follow-up rather than
part of this fix.

## Testing

Built `Dockerfile.server` from this branch and ran:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsafe subqueries in `count_rows` filter conditions.
  * Continued supporting simple predicates and `VALUES` expressions.
  * Preserved existing protection against stacked queries.
  * Added clearer guidance to use `query_database` for queries requiring subqueries.

* **Documentation**
  * Documented the security mitigation and its scope in the changelog.

* **Tests**
  * Added coverage for valid filters, subquery rejection, comment-based evasion attempts, and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->