### PR TITLE
Resolve client addresses from the connection, not caller headers

### DIFF
--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -797,6 +797,24 @@ func main() {
 
 	if cfg.HTTP.Enabled {
 		// HTTP/HTTPS mode
+		// Decide how the client address is determined before serving anything,
+		// so that a configuration which cannot be honoured safely fails at
+		// startup rather than silently falling back at request time. The error
+		// has its own variable because err carries the server's exit status for
+		// the remainder of this block and must not be shadowed here.
+		clientIPResolver, clientIPErr := auth.NewClientIPResolver(
+			cfg.HTTP.ClientIP.Source,
+			cfg.HTTP.ClientIP.Header,
+			cfg.HTTP.ClientIP.TrustedProxies)
+		if clientIPErr != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Invalid client IP configuration: %v\n", clientIPErr)
+			os.Exit(1)
+		}
+		if strings.EqualFold(cfg.HTTP.ClientIP.Source, auth.ClientIPSourceHeader) {
+			fmt.Fprintf(os.Stderr, "Client addresses read from %s, trusting %d proxy entries\n",
+				cfg.HTTP.ClientIP.Header, len(cfg.HTTP.ClientIP.TrustedProxies))
+		}
+
 		// Create HTTP server configuration
 		httpConfig := &mcp.HTTPConfig{
 			Addr:        cfg.HTTP.Address,
@@ -807,6 +825,7 @@ func main() {
 			AuthEnabled: cfg.HTTP.Auth.Enabled,
 			TokenStore:  tokenStore,
 			UserStore:   userStore,
+			ClientIP:    clientIPResolver,
 			Debug:       *debug,
 		}
 

--- a/docs/advanced/distributed-deployment.md
+++ b/docs/advanced/distributed-deployment.md
@@ -109,8 +109,7 @@ server {
         proxy_pass http://mcp_backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For
-            $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
@@ -123,6 +122,25 @@ server {
 The `upstream` block defines the pool of backend servers. The
 `/health` endpoint enables load balancer health checks without
 authentication.
+
+Both forwarding headers are set to `$remote_addr` so that they replace
+any value the caller sent; `$proxy_add_x_forwarded_for` would append to
+it instead. Each backend then needs to read the client address from the
+header, trusting the load balancer that fronts it:
+
+```yaml
+http:
+  client_ip:
+    source: header
+    header: X-Real-IP
+    trusted_proxies:
+      - 192.0.2.0/24        # The subnet the load balancers run in
+```
+
+Every backend sees the load balancer as its peer, so without this
+setting all login rate limiting collapses onto one address. For
+details, see [Client Address
+Resolution](../guide/configuration.md#client-address-resolution).
 
 ### AWS Application Load Balancer
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,25 @@ and this project adheres to
 
 ### Security
 
+- Login rate limiting no longer counts against an address the caller can
+  choose. The server previously read the leftmost entry of
+  `X-Forwarded-For`, which is the part of that header a caller sets for
+  itself, so rotating the value defeated `rate_limit_max_attempts`
+  entirely, and sending someone else's address had their attempts counted
+  against them. The reverse proxy configurations in these docs appended to
+  the header rather than replacing it, so this needed no misconfiguration
+  to reproduce. Client addresses now come from the network connection by
+  default, and a new `http.client_ip` block opts into reading a forwarding
+  header, which is honoured only on connections from an address listed in
+  `client_ip.trusted_proxies`; `X-Forwarded-For` is read from right to
+  left, past trusted entries, and every instance of the header is treated
+  as one list. Candidate addresses that do not parse are discarded rather
+  than becoming rate limiter keys, and IPv6 addresses are no longer
+  counted twice under bracketed and unbracketed forms. Note that account
+  lockout is keyed on the username and was unaffected. The nginx examples
+  in the documentation now set `X-Forwarded-For` to `$remote_addr` rather
+  than `$proxy_add_x_forwarded_for`.
+
 - Upgraded `github.com/jackc/pgx/v5` from 5.7.6 to 5.10.0, resolving three
   advisories against the PostgreSQL driver. Two are memory-safety issues
   (GO-2026-4771/CVE-2026-33815 and GO-2026-4772/CVE-2026-33816, fixed in

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -56,6 +56,14 @@ Failed authentication attempts are tracked per IP address to prevent brute force
 - Automatic cleanup ensures that old attempts are automatically removed from memory.
 - Lockout is status-blind - rate limiting applies regardless of whether the username exists.
 
+The address a request is counted against comes from the network
+connection itself, so a caller cannot choose it. Deployments behind a
+reverse proxy see the proxy's address on every connection and must
+configure `http.client_ip` to read the real address from a forwarding
+header; the server honours that header only on connections from a
+trusted proxy. See [Client Address
+Resolution](configuration.md#client-address-resolution) for details.
+
 ### Configuring Rate Limiting and Lockout
 
 To configure lockout with a configuration file, add these properties to the file:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,6 +44,49 @@ specify property values, grouped by section.
 | `http.auth.max_failed_attempts_before_lockout` | N/A | `PGEDGE_AUTH_MAX_FAILED_ATTEMPTS_BEFORE_LOCKOUT` | Lock account after N failed attempts (0 = disabled, default: 0) |
 | `http.auth.rate_limit_window_minutes` | N/A | `PGEDGE_AUTH_RATE_LIMIT_WINDOW_MINUTES` | Time window for rate limiting in minutes (default: 15) |
 | `http.auth.rate_limit_max_attempts` | N/A | `PGEDGE_AUTH_RATE_LIMIT_MAX_ATTEMPTS` | Max failed attempts per IP per window (default: 10) |
+| `http.client_ip.source` | N/A | `PGEDGE_HTTP_CLIENT_IP_SOURCE` | Where the client address is read from; `socket` or `header` (default: "socket") |
+| `http.client_ip.header` | N/A | `PGEDGE_HTTP_CLIENT_IP_HEADER` | Forwarding header read when the source is `header` (default: "X-Real-IP") |
+| `http.client_ip.trusted_proxies` | N/A | `PGEDGE_HTTP_CLIENT_IP_TRUSTED_PROXIES` | Comma-separated addresses or CIDR blocks permitted to set that header |
+
+### Client Address Resolution
+
+The server attributes each request to a client address, which it uses
+for login rate limiting and request logging. The `http.client_ip`
+settings control where that address comes from.
+
+By default, the source is `socket`; the server takes the address from
+the network connection and ignores forwarding headers entirely. This
+default is correct for a server that clients reach directly, and a
+caller cannot influence it.
+
+Deployments behind a reverse proxy see the proxy's address on every
+connection, so they need the real address from a forwarding header
+instead. Set the source to `header` and list the proxies you trust:
+
+```yaml
+http:
+  client_ip:
+    source: header
+    header: X-Real-IP
+    trusted_proxies:
+      - 192.0.2.10          # A single proxy address
+      - 192.0.2.0/24        # Or a CIDR block
+```
+
+The server honours the header only when the connection comes from one
+of the listed proxies; a request that arrives from anywhere else is
+attributed to its own connection address. Starting the server with the
+source set to `header` and no trusted proxies configured is an error,
+because a forwarding header carries no authority unless the server
+knows which peer is entitled to set it.
+
+`X-Forwarded-For` also works as the header, and the server handles it
+as the history list it is. Each proxy appends the address it received
+the request from, so the server reads the list from right to left,
+skipping entries that match `trusted_proxies` and taking the first one
+that does not. Reading from the left instead would return whatever the
+original caller chose to send, since anything a caller invents ends up
+at the far left of the list.
 
 ### Database Connections
 

--- a/docs/guide/services_config.md
+++ b/docs/guide/services_config.md
@@ -223,7 +223,7 @@ server {
         proxy_pass http://localhost:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
@@ -234,3 +234,27 @@ server {
     return 301 https://$host$request_uri;
 }
 ```
+
+Note that both `X-Real-IP` and `X-Forwarded-For` are set to
+`$remote_addr`, which replaces whatever the caller sent. The more
+commonly seen `$proxy_add_x_forwarded_for` appends to the caller's
+value instead, leaving an address of the caller's choosing at the head
+of the list; use it only where a trusted proxy sits in front of nginx
+and you have accounted for the extra hop.
+
+Behind this proxy, configure the server to read the client address from
+the header rather than from the connection, which now always belongs to
+nginx:
+
+```yaml
+http:
+  client_ip:
+    source: header
+    header: X-Real-IP
+    trusted_proxies:
+      - 127.0.0.1
+```
+
+Without this, login rate limiting counts every request against the
+proxy's address rather than the caller's. See [Client Address
+Resolution](configuration.md#client-address-resolution) for details.

--- a/docs/reference/config-examples/server.md
+++ b/docs/reference/config-examples/server.md
@@ -103,6 +103,32 @@ http:
         # - List tokens:  ./bin/pgedge-postgres-mcp -list-tokens
         # - Remove token: ./bin/pgedge-postgres-mcp -remove-token <id>
 
+    # Client address resolution, used for login rate limiting and logging
+    client_ip:
+        # Where the client address is read from
+        # "socket" takes it from the network connection and ignores
+        #          forwarding headers; correct when clients connect directly
+        # "header" takes it from the header below, but only when the
+        #          connection comes from a trusted proxy listed underneath
+        # Default: socket
+        # Environment variable: PGEDGE_HTTP_CLIENT_IP_SOURCE
+        source: socket
+
+        # Forwarding header consulted when source is "header"
+        # X-Forwarded-For is also supported and is read from right to left,
+        # skipping trusted proxies, because each proxy appends to it
+        # Default: X-Real-IP
+        # Environment variable: PGEDGE_HTTP_CLIENT_IP_HEADER
+        header: X-Real-IP
+
+        # Addresses or CIDR blocks permitted to set that header; the header is
+        # ignored on connections from anywhere else. Required when source is
+        # "header", as the server otherwise refuses to start
+        # Default: empty (no proxy is trusted)
+        # Environment variable: PGEDGE_HTTP_CLIENT_IP_TRUSTED_PROXIES
+        #                       (comma-separated)
+        trusted_proxies: []
+
 # ============================================================================
 # ENCRYPTION SECRET FILE (Optional)
 # ============================================================================

--- a/examples/helm/pgedge-nla/templates/configmap.yaml
+++ b/examples/helm/pgedge-nla/templates/configmap.yaml
@@ -23,13 +23,19 @@ data:
         max_failed_attempts_before_lockout: 5
         rate_limit_window_minutes: 15
         rate_limit_max_attempts: 10
-      # Requests reach the pod through a Service or Ingress, so set source to
-      # "header" and trust the ingress controller's addresses to have login
-      # rate limiting count against real client addresses rather than the proxy
+      # Requests reach the pod through a Service or Ingress, which becomes the
+      # peer on every connection. Populate server.clientIp.trustedProxies with
+      # the ingress controller's addresses to have login rate limiting count
+      # against real client addresses rather than against the proxy.
       client_ip:
+      {{- if .Values.server.clientIp.trustedProxies }}
+        source: header
+        header: {{ .Values.server.clientIp.header }}
+        trusted_proxies:
+          {{- toYaml .Values.server.clientIp.trustedProxies | nindent 10 }}
+      {{- else }}
         source: socket
-        header: X-Real-IP
-        trusted_proxies: []
+      {{- end }}
 
     llm:
       enabled: false

--- a/examples/helm/pgedge-nla/templates/configmap.yaml
+++ b/examples/helm/pgedge-nla/templates/configmap.yaml
@@ -23,6 +23,13 @@ data:
         max_failed_attempts_before_lockout: 5
         rate_limit_window_minutes: 15
         rate_limit_max_attempts: 10
+      # Requests reach the pod through a Service or Ingress, so set source to
+      # "header" and trust the ingress controller's addresses to have login
+      # rate limiting count against real client addresses rather than the proxy
+      client_ip:
+        source: socket
+        header: X-Real-IP
+        trusted_proxies: []
 
     llm:
       enabled: false

--- a/examples/helm/pgedge-nla/values.yaml
+++ b/examples/helm/pgedge-nla/values.yaml
@@ -31,6 +31,16 @@ server:
   config:
     logLevel: info
 
+  # Client address resolution, used for login rate limiting and logging.
+  # Requests arrive through a Service or Ingress, so the connection's peer is
+  # the proxy rather than the caller. List the addresses or CIDR blocks your
+  # ingress controller connects from to have the server read the real client
+  # address from the header below; whilst trustedProxies is empty the server
+  # uses the connection's peer, which no caller can influence.
+  clientIp:
+    header: X-Real-IP
+    trustedProxies: []
+
   # PostgreSQL connection
   database:
     host: postgres-postgresql

--- a/examples/pgedge-postgres-mcp-http.yaml.example
+++ b/examples/pgedge-postgres-mcp-http.yaml.example
@@ -25,6 +25,15 @@ http:
         rate_limit_window_minutes: 15
         rate_limit_max_attempts: 10
 
+    # How the client address is determined, for rate limiting and logging.
+    # "socket" reads it from the connection and ignores forwarding headers.
+    # Behind a reverse proxy, set source to "header" and list the proxies
+    # entitled to set it; the header is ignored from any other peer.
+    client_ip:
+        source: socket
+        header: X-Real-IP
+        trusted_proxies: []
+
 # Database connection configuration
 # Multiple databases can be configured; each must have a unique name.
 # Use available_to_users to restrict access to specific users (empty = all users)

--- a/internal/auth/client_ip.go
+++ b/internal/auth/client_ip.go
@@ -109,6 +109,22 @@ func parseTrustedProxy(entry string) (netip.Prefix, error) {
 		if err != nil {
 			return netip.Prefix{}, fmt.Errorf("invalid trusted proxy CIDR %q: %w", entry, err)
 		}
+
+		// An IPv4-mapped IPv6 prefix such as ::ffff:192.0.2.0/120 describes a
+		// range of IPv4 addresses, and every candidate is unmapped before it is
+		// compared, so the prefix has to be unmapped as well. Without this,
+		// netip.Prefix.Contains rejects each candidate on the address family
+		// alone and the entry silently never matches: the configuration is
+		// accepted, no error is raised, and the forwarding header is quietly
+		// ignored, which is the most misleading way for this to fail. The
+		// mapped range occupies the final 32 bits, hence the shift of 96.
+		//
+		// A shorter prefix than /96 is left alone, because it spans more than
+		// the mapped-IPv4 range and so does not describe an IPv4 block.
+		if addr := prefix.Addr(); addr.Is4In6() && prefix.Bits() >= 96 {
+			prefix = netip.PrefixFrom(addr.Unmap(), prefix.Bits()-96)
+		}
+
 		// Masking discards any host bits, which ParsePrefix preserves but
 		// Contains ignores; normalising keeps comparisons predictable.
 		return prefix.Masked(), nil

--- a/internal/auth/client_ip.go
+++ b/internal/auth/client_ip.go
@@ -1,0 +1,238 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// Client IP sources, as accepted by the http.client_ip.source setting.
+const (
+	// ClientIPSourceSocket takes the address from the connection's peer,
+	// ignoring any forwarding headers. This is the default.
+	ClientIPSourceSocket = "socket"
+
+	// ClientIPSourceHeader takes the address from a forwarding header, but
+	// only when the connection's peer is a configured trusted proxy.
+	ClientIPSourceHeader = "header"
+)
+
+// DefaultClientIPHeader is the header consulted when http.client_ip.source is
+// "header" and no header name is configured. X-Real-IP is preferred over
+// X-Forwarded-For because the reverse proxy configurations we document set it
+// to the address the proxy actually observed, replacing rather than appending
+// to whatever the caller sent.
+const DefaultClientIPHeader = "X-Real-IP"
+
+// ClientIPResolver determines the address a request came from.
+//
+// A forwarding header is only ever honoured when the immediate peer is a
+// configured trusted proxy, and the header list is then read from right to
+// left, skipping trusted entries. This matters because X-Forwarded-For is a
+// history list to which each proxy appends the address it received the request
+// from: anything the caller invents lands at the far left and everything the
+// infrastructure adds lands to the right of it, so counting from the right is
+// the only reliable direction. A nil resolver resolves from the socket, which
+// makes the safe behaviour the zero value.
+type ClientIPResolver struct {
+	useHeader bool
+	header    string
+	trusted   []netip.Prefix
+}
+
+// NewClientIPResolver builds a resolver from configuration.
+//
+// The source must be "socket" (the default when empty) or "header". When it is
+// "header", at least one trusted proxy is required, since a header carries no
+// authority unless we know which peer is entitled to set it.
+func NewClientIPResolver(source, header string, trustedProxies []string) (*ClientIPResolver, error) {
+	resolver := &ClientIPResolver{}
+
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "", ClientIPSourceSocket:
+		// Socket only; the header and trusted proxy settings are unused.
+		return resolver, nil
+	case ClientIPSourceHeader:
+		resolver.useHeader = true
+	default:
+		return nil, fmt.Errorf(
+			"invalid client IP source %q: must be %q or %q",
+			source, ClientIPSourceSocket, ClientIPSourceHeader)
+	}
+
+	resolver.header = strings.TrimSpace(header)
+	if resolver.header == "" {
+		resolver.header = DefaultClientIPHeader
+	}
+
+	if len(trustedProxies) == 0 {
+		return nil, fmt.Errorf(
+			"client IP source is %q but no trusted proxies are configured; "+
+				"a forwarding header can only be trusted when it arrives from a known proxy",
+			ClientIPSourceHeader)
+	}
+
+	for _, entry := range trustedProxies {
+		prefix, err := parseTrustedProxy(entry)
+		if err != nil {
+			return nil, err
+		}
+		resolver.trusted = append(resolver.trusted, prefix)
+	}
+
+	return resolver, nil
+}
+
+// parseTrustedProxy parses a trusted proxy entry, which may be either a CIDR
+// block or a single address; a single address becomes a host-sized prefix.
+func parseTrustedProxy(entry string) (netip.Prefix, error) {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return netip.Prefix{}, fmt.Errorf("trusted proxy entry is empty")
+	}
+
+	if strings.Contains(entry, "/") {
+		prefix, err := netip.ParsePrefix(entry)
+		if err != nil {
+			return netip.Prefix{}, fmt.Errorf("invalid trusted proxy CIDR %q: %w", entry, err)
+		}
+		// Masking discards any host bits, which ParsePrefix preserves but
+		// Contains ignores; normalising keeps comparisons predictable.
+		return prefix.Masked(), nil
+	}
+
+	addr, err := netip.ParseAddr(entry)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("invalid trusted proxy address %q: %w", entry, err)
+	}
+	addr = normaliseAddr(addr)
+
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}
+
+// Resolve returns the address the request should be attributed to, for rate
+// limiting and for logging alike. The result is always either the connection's
+// peer or an address a trusted proxy vouched for, and it is normalised so that
+// one client cannot occupy two different keys.
+func (r *ClientIPResolver) Resolve(req *http.Request) string {
+	socket, socketOK := parseCandidateAddr(req.RemoteAddr)
+
+	// RemoteAddr is always host:port for TCP connections, so this is
+	// defensive. Falling back to the raw value keeps a stable per-peer key
+	// rather than returning nothing, and the value is not caller-controlled.
+	if !socketOK {
+		return strings.TrimSpace(req.RemoteAddr)
+	}
+
+	if r == nil || !r.useHeader {
+		return socket.String()
+	}
+
+	// The header carries no authority unless the peer that sent it is trusted.
+	if !r.isTrusted(socket) {
+		return socket.String()
+	}
+
+	// A request may carry the header more than once, and every instance has to
+	// be treated as one list in order; reading only the first instance would
+	// mean reading only what a caller chose to send.
+	candidates := make([]string, 0, 4)
+	for _, value := range req.Header.Values(r.header) {
+		for _, part := range strings.Split(value, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				candidates = append(candidates, part)
+			}
+		}
+	}
+
+	for i := len(candidates) - 1; i >= 0; i-- {
+		addr, ok := parseCandidateAddr(candidates[i])
+		if !ok {
+			// An unparseable entry means the positions to its left can no
+			// longer be trusted to mean what they appear to, so stop here and
+			// use the peer instead of guessing.
+			return socket.String()
+		}
+		if r.isTrusted(addr) {
+			continue
+		}
+		return addr.String()
+	}
+
+	// Either the header was absent or every entry was a trusted proxy, so the
+	// nearest thing to a client address we have is the peer itself.
+	return socket.String()
+}
+
+// isTrusted reports whether an address belongs to a configured trusted proxy.
+func (r *ClientIPResolver) isTrusted(addr netip.Addr) bool {
+	for _, prefix := range r.trusted {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseCandidateAddr parses an address that may arrive bare, bracketed, or
+// with a port attached, and rejects anything that is not an address at all.
+func parseCandidateAddr(value string) (netip.Addr, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return netip.Addr{}, false
+	}
+
+	if addr, err := netip.ParseAddr(value); err == nil {
+		return normaliseAddr(addr), true
+	}
+
+	// "192.0.2.1:8080" and "[2001:db8::1]:8080"; SplitHostPort also handles
+	// the bracketed IPv6 form correctly, which manual index arithmetic on the
+	// last colon does not.
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		if addr, err := netip.ParseAddr(host); err == nil {
+			return normaliseAddr(addr), true
+		}
+	}
+
+	// A bracketed IPv6 address with no port, as some proxies emit.
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		if addr, err := netip.ParseAddr(value[1 : len(value)-1]); err == nil {
+			return normaliseAddr(addr), true
+		}
+	}
+
+	return netip.Addr{}, false
+}
+
+// normaliseAddr reduces an address to one canonical form, so that the same
+// client cannot end up under two separate rate limiter keys. IPv4-mapped IPv6
+// addresses collapse to their IPv4 form, and interface zones are dropped.
+func normaliseAddr(addr netip.Addr) netip.Addr {
+	return addr.Unmap().WithZone("")
+}
+
+// ClientIPMiddleware resolves the client address once per request and places it
+// in the request context, so that everything downstream (rate limiting, logs)
+// agrees on which address a request came from.
+func ClientIPMiddleware(resolver *ClientIPResolver) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), IPAddressContextKey, resolver.Resolve(r))
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/internal/auth/client_ip_test.go
+++ b/internal/auth/client_ip_test.go
@@ -353,6 +353,109 @@ func TestClientIPResolverHeaderSource(t *testing.T) {
 // TestClientIPResolverRotationCannotEvadeLimiter is the brute force case: with
 // the header honoured only from a trusted peer, a caller rotating the value it
 // sends still resolves to one stable address, so the rate limiter keeps counting.
+// TestClientIPResolverMappedCIDRTrustedProxy covers a trusted proxy written as
+// an IPv4-mapped IPv6 CIDR. Candidates are unmapped before comparison, so the
+// prefix must be unmapped too; otherwise netip.Prefix.Contains rejects every
+// candidate on the address family and the entry silently never matches, leaving
+// the operator with an accepted configuration whose header is ignored.
+func TestClientIPResolverMappedCIDRTrustedProxy(t *testing.T) {
+	tests := []struct {
+		name           string
+		trustedProxies []string
+		remoteAddr     string
+		want           string
+	}{
+		{
+			name:           "mapped CIDR trusts a plain IPv4 peer",
+			trustedProxies: []string{"::ffff:192.0.2.0/120"},
+			remoteAddr:     "192.0.2.1:44444",
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "mapped CIDR trusts a mapped peer",
+			trustedProxies: []string{"::ffff:192.0.2.0/120"},
+			remoteAddr:     "[::ffff:192.0.2.1]:44444",
+			want:           "198.51.100.7",
+		},
+		{
+			// /120 mapped is a /24, so .255 is inside the block; the peer
+			// outside it has to differ in the third octet.
+			name:           "mapped CIDR still excludes an address outside it",
+			trustedProxies: []string{"::ffff:192.0.2.0/120"},
+			remoteAddr:     "192.0.3.1:44444",
+			want:           "192.0.3.1",
+		},
+		{
+			// ::ffff:0.0.0.0/96 unmaps to 0.0.0.0/0, which trusts every
+			// address, so each header entry counts as a trusted proxy too and
+			// the walk exhausts the list and falls back to the peer. Trusting
+			// everything therefore makes the header useless rather than
+			// authoritative, which is the safe direction to fail in.
+			name:           "trusting the whole mapped range falls back to the peer",
+			trustedProxies: []string{"::ffff:0.0.0.0/96"},
+			remoteAddr:     "203.0.113.5:44444",
+			want:           "203.0.113.5",
+		},
+		{
+			name:           "plain IPv4 CIDR is unaffected",
+			trustedProxies: []string{"192.0.2.0/24"},
+			remoteAddr:     "192.0.2.1:44444",
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "a genuine IPv6 CIDR is unaffected",
+			trustedProxies: []string{"2001:db8::/32"},
+			remoteAddr:     "[2001:db8::1]:44444",
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "a mapped prefix shorter than /96 is left as IPv6",
+			trustedProxies: []string{"::ffff:0.0.0.0/64"},
+			remoteAddr:     "192.0.2.1:44444",
+			want:           "192.0.2.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver, err := NewClientIPResolver("header", "X-Forwarded-For", tt.trustedProxies)
+			if err != nil {
+				t.Fatalf("failed to build resolver: %v", err)
+			}
+			headers := map[string][]string{"X-Forwarded-For": {"9.9.9.9, 198.51.100.7"}}
+			if got := resolver.Resolve(newRequest(tt.remoteAddr, headers)); got != tt.want {
+				t.Errorf("Resolve() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseTrustedProxyMappedCIDREquivalence checks that a mapped CIDR and its
+// plain IPv4 equivalent parse to exactly the same prefix, so the two spellings
+// cannot drift apart in behaviour.
+func TestParseTrustedProxyMappedCIDREquivalence(t *testing.T) {
+	pairs := [][2]string{
+		{"::ffff:192.0.2.0/120", "192.0.2.0/24"},
+		{"::ffff:10.0.0.0/104", "10.0.0.0/8"},
+		{"::ffff:0.0.0.0/96", "0.0.0.0/0"},
+	}
+
+	for _, pair := range pairs {
+		mapped, err := parseTrustedProxy(pair[0])
+		if err != nil {
+			t.Fatalf("parseTrustedProxy(%q): %v", pair[0], err)
+		}
+		plain, err := parseTrustedProxy(pair[1])
+		if err != nil {
+			t.Fatalf("parseTrustedProxy(%q): %v", pair[1], err)
+		}
+		if mapped != plain {
+			t.Errorf("parseTrustedProxy(%q) = %v, want it to equal parseTrustedProxy(%q) = %v",
+				pair[0], mapped, pair[1], plain)
+		}
+	}
+}
+
 func TestClientIPResolverRotationCannotEvadeLimiter(t *testing.T) {
 	resolver, err := NewClientIPResolver("header", "X-Forwarded-For", []string{"192.0.2.1"})
 	if err != nil {

--- a/internal/auth/client_ip_test.go
+++ b/internal/auth/client_ip_test.go
@@ -1,0 +1,433 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newRequest builds a request with the given peer address and headers, where
+// each header entry may be repeated to simulate a caller sending its own copy.
+func newRequest(remoteAddr string, headers map[string][]string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", nil)
+	req.RemoteAddr = remoteAddr
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+	return req
+}
+
+func TestExtractIPAddressIgnoresForwardingHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string][]string
+		want       string
+	}{
+		{
+			name:       "plain IPv4 peer",
+			remoteAddr: "192.0.2.10:54321",
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "X-Forwarded-For is not trusted by default",
+			remoteAddr: "192.0.2.10:54321",
+			headers:    map[string][]string{"X-Forwarded-For": {"9.9.9.9"}},
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "appended X-Forwarded-For is not trusted by default",
+			remoteAddr: "192.0.2.10:54321",
+			headers:    map[string][]string{"X-Forwarded-For": {"9.9.9.9, 198.51.100.7"}},
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "X-Real-IP is not trusted by default",
+			remoteAddr: "192.0.2.10:54321",
+			headers:    map[string][]string{"X-Real-IP": {"9.9.9.9"}},
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "IPv6 peer is returned unbracketed",
+			remoteAddr: "[2001:db8::1]:54321",
+			want:       "2001:db8::1",
+		},
+		{
+			name:       "IPv6 loopback peer is returned unbracketed",
+			remoteAddr: "[::1]:54321",
+			want:       "::1",
+		},
+		{
+			name:       "IPv4-mapped IPv6 peer collapses to its IPv4 form",
+			remoteAddr: "[::ffff:192.0.2.10]:54321",
+			want:       "192.0.2.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractIPAddress(newRequest(tt.remoteAddr, tt.headers))
+			if got != tt.want {
+				t.Errorf("ExtractIPAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractIPAddressIPv6KeyConsistency guards the specific defect where port
+// stripping by last colon left IPv6 peers bracketed, so the same client could
+// occupy two different rate limiter keys depending on the code path.
+func TestExtractIPAddressIPv6KeyConsistency(t *testing.T) {
+	withPort := ExtractIPAddress(newRequest("[2001:db8::1]:54321", nil))
+	if withPort == "[2001:db8::1]" {
+		t.Fatal("IPv6 address is still bracketed; port stripping must use net.SplitHostPort")
+	}
+	if withPort != "2001:db8::1" {
+		t.Fatalf("got %q, want %q", withPort, "2001:db8::1")
+	}
+}
+
+func TestParseCandidateAddr(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+		ok    bool
+	}{
+		{name: "bare IPv4", value: "192.0.2.1", want: "192.0.2.1", ok: true},
+		{name: "bare IPv6", value: "2001:db8::1", want: "2001:db8::1", ok: true},
+		{name: "IPv4 with port", value: "192.0.2.1:8080", want: "192.0.2.1", ok: true},
+		{name: "bracketed IPv6 with port", value: "[2001:db8::1]:8080", want: "2001:db8::1", ok: true},
+		{name: "bracketed IPv6 without port", value: "[2001:db8::1]", want: "2001:db8::1", ok: true},
+		{name: "IPv4-mapped IPv6 collapses", value: "::ffff:192.0.2.1", want: "192.0.2.1", ok: true},
+		{name: "zone is dropped", value: "fe80::1%eth0", want: "fe80::1", ok: true},
+		{name: "empty", value: ""},
+		{name: "whitespace only", value: "   "},
+		{name: "not an address", value: "not-an-address"},
+		{name: "bracketed rubbish", value: "[not-an-address]"},
+		{name: "hostname with port", value: "example.com:8080"},
+		{name: "truncated IPv4", value: "192.0.2."},
+		{name: "SQL fragment", value: "'; DROP TABLE users; --"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, ok := parseCandidateAddr(tt.value)
+			if ok != tt.ok {
+				t.Fatalf("parseCandidateAddr(%q) ok = %v, want %v", tt.value, ok, tt.ok)
+			}
+			if ok && addr.String() != tt.want {
+				t.Errorf("parseCandidateAddr(%q) = %q, want %q", tt.value, addr.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestNewClientIPResolverValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		source         string
+		header         string
+		trustedProxies []string
+		wantErr        bool
+	}{
+		{name: "empty source defaults to socket", source: ""},
+		{name: "socket source", source: "socket"},
+		{name: "socket source is case insensitive", source: "Socket"},
+		{name: "socket source ignores missing trusted proxies", source: "socket", header: "X-Forwarded-For"},
+		{
+			name:           "header source with trusted proxy",
+			source:         "header",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+		},
+		{
+			name:           "header source with CIDR",
+			source:         "header",
+			trustedProxies: []string{"192.0.2.0/24", "2001:db8::/32"},
+		},
+		{name: "unknown source is rejected", source: "proxy_protocol", wantErr: true},
+		{
+			name:    "header source without trusted proxies is rejected",
+			source:  "header",
+			wantErr: true,
+		},
+		{
+			name:           "header source with empty trusted proxy entry is rejected",
+			source:         "header",
+			trustedProxies: []string{""},
+			wantErr:        true,
+		},
+		{
+			name:           "malformed trusted proxy address is rejected",
+			source:         "header",
+			trustedProxies: []string{"not-an-address"},
+			wantErr:        true,
+		},
+		{
+			name:           "malformed trusted proxy CIDR is rejected",
+			source:         "header",
+			trustedProxies: []string{"192.0.2.0/99"},
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver, err := NewClientIPResolver(tt.source, tt.header, tt.trustedProxies)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resolver == nil {
+				t.Fatal("expected a resolver, got nil")
+			}
+		})
+	}
+}
+
+func TestClientIPResolverHeaderSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		header         string
+		trustedProxies []string
+		remoteAddr     string
+		headers        map[string][]string
+		want           string
+	}{
+		{
+			name:           "spoofed leftmost entry is ignored in favour of the appended one",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"9.9.9.9, 198.51.100.7"}},
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "chain of trusted proxies is walked right to left",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.0/24"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"9.9.9.9, 198.51.100.7, 192.0.2.9"}},
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "untrusted peer means the header is ignored entirely",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "203.0.113.5:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"9.9.9.9"}},
+			want:           "203.0.113.5",
+		},
+		{
+			name:           "repeated header instances are treated as one list",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"9.9.9.9", "198.51.100.7"}},
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "absent header falls back to the peer",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			want:           "192.0.2.1",
+		},
+		{
+			name:           "a list of only trusted proxies falls back to the peer",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.0/24"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"192.0.2.8, 192.0.2.9"}},
+			want:           "192.0.2.1",
+		},
+		{
+			name:           "unparseable entry falls back to the peer",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"not-an-address"}},
+			want:           "192.0.2.1",
+		},
+		{
+			name:           "arbitrary strings cannot become rate limiter keys",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"'; DROP TABLE users; --"}},
+			want:           "192.0.2.1",
+		},
+		{
+			name:           "X-Real-IP set by a trusted proxy is honoured",
+			header:         "X-Real-IP",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Real-IP": {"198.51.100.7"}},
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "the configured header is the only one consulted",
+			header:         "X-Real-IP",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers: map[string][]string{
+				"X-Real-IP":       {"198.51.100.7"},
+				"X-Forwarded-For": {"9.9.9.9"},
+			},
+			want: "198.51.100.7",
+		},
+		{
+			name:           "header name matching is case insensitive",
+			header:         "x-forwarded-for",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"198.51.100.7"}},
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "entries carrying a port are accepted",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"198.51.100.7:1234"}},
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "bracketed IPv6 entries are accepted and normalised",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"[2001:db8::7]"}},
+			want:           "2001:db8::7",
+		},
+		{
+			name:           "an IPv6 trusted proxy is matched by CIDR",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"2001:db8::/32"},
+			remoteAddr:     "[2001:db8::1]:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"198.51.100.7, 2001:db8::9"}},
+			want:           "198.51.100.7",
+		},
+		{
+			name:           "whitespace around entries is tolerated",
+			header:         "X-Forwarded-For",
+			trustedProxies: []string{"192.0.2.1"},
+			remoteAddr:     "192.0.2.1:44444",
+			headers:        map[string][]string{"X-Forwarded-For": {"  9.9.9.9 ,   198.51.100.7  "}},
+			want:           "198.51.100.7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver, err := NewClientIPResolver("header", tt.header, tt.trustedProxies)
+			if err != nil {
+				t.Fatalf("failed to build resolver: %v", err)
+			}
+			got := resolver.Resolve(newRequest(tt.remoteAddr, tt.headers))
+			if got != tt.want {
+				t.Errorf("Resolve() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClientIPResolverRotationCannotEvadeLimiter is the brute force case: with
+// the header honoured only from a trusted peer, a caller rotating the value it
+// sends still resolves to one stable address, so the rate limiter keeps counting.
+func TestClientIPResolverRotationCannotEvadeLimiter(t *testing.T) {
+	resolver, err := NewClientIPResolver("header", "X-Forwarded-For", []string{"192.0.2.1"})
+	if err != nil {
+		t.Fatalf("failed to build resolver: %v", err)
+	}
+
+	spoofed := []string{"9.9.9.9", "10.0.0.1", "203.0.113.99", "not-an-address", ""}
+	for _, value := range spoofed {
+		headers := map[string][]string{"X-Forwarded-For": {value + ", 198.51.100.7"}}
+		if got := resolver.Resolve(newRequest("192.0.2.1:44444", headers)); got != "198.51.100.7" {
+			t.Errorf("with spoofed prefix %q, Resolve() = %q, want %q", value, got, "198.51.100.7")
+		}
+	}
+
+	// Directly connected callers get their own address regardless of what they send
+	for _, value := range spoofed {
+		headers := map[string][]string{"X-Forwarded-For": {value}}
+		if got := resolver.Resolve(newRequest("203.0.113.5:44444", headers)); got != "203.0.113.5" {
+			t.Errorf("with spoofed value %q, Resolve() = %q, want %q", value, got, "203.0.113.5")
+		}
+	}
+}
+
+func TestClientIPResolverNilResolvesFromSocket(t *testing.T) {
+	var resolver *ClientIPResolver
+	headers := map[string][]string{"X-Forwarded-For": {"9.9.9.9"}}
+	if got := resolver.Resolve(newRequest("192.0.2.10:54321", headers)); got != "192.0.2.10" {
+		t.Errorf("Resolve() = %q, want %q", got, "192.0.2.10")
+	}
+}
+
+func TestClientIPResolverMalformedRemoteAddr(t *testing.T) {
+	// RemoteAddr is always host:port for TCP, so this only exercises the
+	// defensive path; the value must still be stable rather than empty, since an
+	// empty address disables rate limiting for the request.
+	resolver, err := NewClientIPResolver("socket", "", nil)
+	if err != nil {
+		t.Fatalf("failed to build resolver: %v", err)
+	}
+	if got := resolver.Resolve(newRequest("@", nil)); got != "@" {
+		t.Errorf("Resolve() = %q, want %q", got, "@")
+	}
+}
+
+func TestClientIPMiddlewarePlacesAddressInContext(t *testing.T) {
+	resolver, err := NewClientIPResolver("header", "X-Forwarded-For", []string{"192.0.2.1"})
+	if err != nil {
+		t.Fatalf("failed to build resolver: %v", err)
+	}
+
+	var seen string
+	handler := ClientIPMiddleware(resolver)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = GetIPAddressFromContext(r.Context())
+	}))
+
+	req := newRequest("192.0.2.1:44444", map[string][]string{
+		"X-Forwarded-For": {"9.9.9.9, 198.51.100.7"},
+	})
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen != "198.51.100.7" {
+		t.Errorf("context address = %q, want %q", seen, "198.51.100.7")
+	}
+}
+
+func TestClientIPMiddlewareWithNilResolver(t *testing.T) {
+	var seen string
+	handler := ClientIPMiddleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = GetIPAddressFromContext(r.Context())
+	}))
+
+	req := newRequest("192.0.2.10:54321", map[string][]string{"X-Forwarded-For": {"9.9.9.9"}})
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen != "192.0.2.10" {
+		t.Errorf("context address = %q, want %q", seen, "192.0.2.10")
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -94,32 +94,17 @@ func writeJSONError(w http.ResponseWriter, message string, statusCode int) {
 	json.NewEncoder(w).Encode(JSONErrorResponse{Error: message})
 }
 
-// ExtractIPAddress extracts the client IP address from an HTTP request
-// Checks X-Forwarded-For and X-Real-IP headers first (for proxies), then falls back to RemoteAddr
+// ExtractIPAddress returns the address of the peer that opened the connection,
+// ignoring forwarding headers entirely.
+//
+// Forwarding headers are deliberately not consulted here: a caller can set them
+// for itself, and the reverse proxy configurations we document append to
+// X-Forwarded-For rather than replacing it, so its leftmost entry is whatever
+// the caller chose to send. Deployments behind a proxy opt into reading a header
+// through http.client_ip, which honours it only from a trusted peer; see
+// ClientIPResolver.
 func ExtractIPAddress(r *http.Request) string {
-	// Check X-Forwarded-For header first (used by proxies/load balancers)
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2, ...)
-		// Use the first one (original client IP)
-		parts := strings.Split(xff, ",")
-		if len(parts) > 0 {
-			return strings.TrimSpace(parts[0])
-		}
-	}
-
-	// Check X-Real-IP header (used by some proxies)
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return strings.TrimSpace(xri)
-	}
-
-	// Fall back to RemoteAddr
-	// This may include the port, so strip it if present
-	ip := r.RemoteAddr
-	if colonIndex := strings.LastIndex(ip, ":"); colonIndex != -1 {
-		ip = ip[:colonIndex]
-	}
-
-	return ip
+	return (*ClientIPResolver)(nil).Resolve(r)
 }
 
 // AuthMiddleware creates an HTTP middleware that validates API tokens and session tokens

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,10 +145,25 @@ func (c *PromptsConfig) IsPromptEnabled(promptName string) bool {
 
 // HTTPConfig holds HTTP/HTTPS server settings
 type HTTPConfig struct {
-	Enabled bool       `yaml:"enabled"`
-	Address string     `yaml:"address"`
-	TLS     TLSConfig  `yaml:"tls"`
-	Auth    AuthConfig `yaml:"auth"`
+	Enabled  bool           `yaml:"enabled"`
+	Address  string         `yaml:"address"`
+	TLS      TLSConfig      `yaml:"tls"`
+	Auth     AuthConfig     `yaml:"auth"`
+	ClientIP ClientIPConfig `yaml:"client_ip"`
+}
+
+// ClientIPConfig controls how the server decides which address a request came
+// from, for rate limiting and request logging.
+//
+// The default reads the address from the connection itself, which is correct for
+// a server that is not behind a reverse proxy and cannot be influenced by the
+// caller. Deployments behind a proxy set Source to "header" and list the proxies
+// they trust; a forwarding header is never honoured from an untrusted peer,
+// because its contents are otherwise chosen by whoever sent the request.
+type ClientIPConfig struct {
+	Source         string   `yaml:"source"`          // "socket" (the default) or "header"
+	Header         string   `yaml:"header"`          // Header read when source is "header" (default: X-Real-IP)
+	TrustedProxies []string `yaml:"trusted_proxies"` // Addresses or CIDR blocks permitted to set that header
 }
 
 // AuthConfig holds authentication settings
@@ -640,6 +655,11 @@ func defaultConfig() *Config {
 				RateLimitWindowMinutes:         15,   // 15 minute window for rate limiting
 				RateLimitMaxAttempts:           10,   // 10 attempts per IP per window
 			},
+			ClientIP: ClientIPConfig{
+				Source:         "socket",    // Trust the connection, not the caller's headers
+				Header:         "X-Real-IP", // Only consulted when source is "header"
+				TrustedProxies: nil,         // No proxy is trusted until an operator names one
+			},
 		},
 		Databases: []NamedDatabaseConfig{}, // Empty by default, populated from config file
 		Embedding: EmbeddingConfig{
@@ -731,6 +751,18 @@ func mergeConfig(dest, src *Config) {
 	}
 	if src.HTTP.Auth.RateLimitMaxAttempts > 0 {
 		dest.HTTP.Auth.RateLimitMaxAttempts = src.HTTP.Auth.RateLimitMaxAttempts
+	}
+
+	// Client IP resolution
+	if src.HTTP.ClientIP.Source != "" {
+		dest.HTTP.ClientIP.Source = src.HTTP.ClientIP.Source
+	}
+	if src.HTTP.ClientIP.Header != "" {
+		dest.HTTP.ClientIP.Header = src.HTTP.ClientIP.Header
+	}
+	// Replace rather than append, so a config file can narrow an inherited list
+	if len(src.HTTP.ClientIP.TrustedProxies) > 0 {
+		dest.HTTP.ClientIP.TrustedProxies = src.HTTP.ClientIP.TrustedProxies
 	}
 
 	// Databases - if source has databases defined, use them (replace, don't merge)
@@ -927,6 +959,24 @@ func setStringFromEnv(dest *string, key string) {
 	}
 }
 
+// setStringSliceFromEnv sets a string slice config value from a comma-separated
+// environment variable if it exists, ignoring empty entries and surrounding
+// whitespace. The variable replaces any configured list rather than adding to it.
+func setStringSliceFromEnv(dest *[]string, key string) {
+	val := os.Getenv(key)
+	if val == "" {
+		return
+	}
+
+	entries := make([]string, 0, strings.Count(val, ",")+1)
+	for _, entry := range strings.Split(val, ",") {
+		if entry = strings.TrimSpace(entry); entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+	*dest = entries
+}
+
 // setStringFromEnvWithFallback sets a string config value from an environment variable,
 // checking multiple environment variable names in priority order
 func setStringFromEnvWithFallback(dest *string, keys ...string) {
@@ -1007,6 +1057,11 @@ func applyEnvironmentVariables(cfg *Config) {
 	setIntFromEnv(&cfg.HTTP.Auth.MaxFailedAttemptsBeforeLockout, "PGEDGE_AUTH_MAX_FAILED_ATTEMPTS_BEFORE_LOCKOUT")
 	setIntFromEnv(&cfg.HTTP.Auth.RateLimitWindowMinutes, "PGEDGE_AUTH_RATE_LIMIT_WINDOW_MINUTES")
 	setIntFromEnv(&cfg.HTTP.Auth.RateLimitMaxAttempts, "PGEDGE_AUTH_RATE_LIMIT_MAX_ATTEMPTS")
+
+	// Client IP resolution
+	setStringFromEnv(&cfg.HTTP.ClientIP.Source, "PGEDGE_HTTP_CLIENT_IP_SOURCE")
+	setStringFromEnv(&cfg.HTTP.ClientIP.Header, "PGEDGE_HTTP_CLIENT_IP_HEADER")
+	setStringSliceFromEnv(&cfg.HTTP.ClientIP.TrustedProxies, "PGEDGE_HTTP_CLIENT_IP_TRUSTED_PROXIES")
 
 	// Database environment variables apply to the first database in the list
 	// If no databases configured yet, create a default one from env vars

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -909,6 +909,150 @@ func TestSetStringFromEnv(t *testing.T) {
 	}
 }
 
+func TestSetStringSliceFromEnv(t *testing.T) {
+	const key = "TEST_STRING_SLICE_VAR"
+
+	tests := []struct {
+		name     string
+		envValue string
+		initial  []string
+		expected []string
+	}{
+		{
+			name:     "single entry",
+			envValue: "192.0.2.1",
+			expected: []string{"192.0.2.1"},
+		},
+		{
+			name:     "multiple entries",
+			envValue: "192.0.2.1,192.0.2.2",
+			expected: []string{"192.0.2.1", "192.0.2.2"},
+		},
+		{
+			name:     "surrounding whitespace is trimmed",
+			envValue: " 192.0.2.1 , 192.0.2.0/24 ",
+			expected: []string{"192.0.2.1", "192.0.2.0/24"},
+		},
+		{
+			name:     "empty entries are dropped",
+			envValue: "192.0.2.1,,192.0.2.2,",
+			expected: []string{"192.0.2.1", "192.0.2.2"},
+		},
+		{
+			name:     "the variable replaces a configured list",
+			envValue: "192.0.2.9",
+			initial:  []string{"198.51.100.1", "198.51.100.2"},
+			expected: []string{"192.0.2.9"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(key, tt.envValue)
+			defer os.Unsetenv(key)
+
+			dest := tt.initial
+			setStringSliceFromEnv(&dest, key)
+
+			if len(dest) != len(tt.expected) {
+				t.Fatalf("expected %v, got %v", tt.expected, dest)
+			}
+			for i, want := range tt.expected {
+				if dest[i] != want {
+					t.Errorf("entry %d: expected %q, got %q", i, want, dest[i])
+				}
+			}
+		})
+	}
+
+	// An unset variable must leave any configured list alone
+	os.Unsetenv(key)
+	dest := []string{"198.51.100.1"}
+	setStringSliceFromEnv(&dest, key)
+	if len(dest) != 1 || dest[0] != "198.51.100.1" {
+		t.Errorf("expected the configured list to be unchanged, got %v", dest)
+	}
+}
+
+func TestClientIPConfigDefaults(t *testing.T) {
+	cfg := defaultConfig()
+
+	if cfg.HTTP.ClientIP.Source != "socket" {
+		t.Errorf("expected the default client IP source to be 'socket', got %q", cfg.HTTP.ClientIP.Source)
+	}
+	if cfg.HTTP.ClientIP.Header != "X-Real-IP" {
+		t.Errorf("expected the default client IP header to be 'X-Real-IP', got %q", cfg.HTTP.ClientIP.Header)
+	}
+	if len(cfg.HTTP.ClientIP.TrustedProxies) != 0 {
+		t.Errorf("expected no trusted proxies by default, got %v", cfg.HTTP.ClientIP.TrustedProxies)
+	}
+}
+
+func TestMergeClientIPConfig(t *testing.T) {
+	dest := defaultConfig()
+	src := &Config{
+		HTTP: HTTPConfig{
+			ClientIP: ClientIPConfig{
+				Source:         "header",
+				Header:         "X-Forwarded-For",
+				TrustedProxies: []string{"192.0.2.1", "192.0.2.0/24"},
+			},
+		},
+	}
+
+	mergeConfig(dest, src)
+
+	if dest.HTTP.ClientIP.Source != "header" {
+		t.Errorf("expected source 'header', got %q", dest.HTTP.ClientIP.Source)
+	}
+	if dest.HTTP.ClientIP.Header != "X-Forwarded-For" {
+		t.Errorf("expected header 'X-Forwarded-For', got %q", dest.HTTP.ClientIP.Header)
+	}
+	if len(dest.HTTP.ClientIP.TrustedProxies) != 2 {
+		t.Fatalf("expected 2 trusted proxies, got %v", dest.HTTP.ClientIP.TrustedProxies)
+	}
+
+	// An empty source must not clear a value already merged in
+	mergeConfig(dest, &Config{})
+	if dest.HTTP.ClientIP.Source != "header" {
+		t.Errorf("expected source to remain 'header', got %q", dest.HTTP.ClientIP.Source)
+	}
+	if len(dest.HTTP.ClientIP.TrustedProxies) != 2 {
+		t.Errorf("expected trusted proxies to remain, got %v", dest.HTTP.ClientIP.TrustedProxies)
+	}
+}
+
+func TestApplyEnvironmentVariables_ClientIP(t *testing.T) {
+	vars := map[string]string{
+		"PGEDGE_HTTP_CLIENT_IP_SOURCE":          "header",
+		"PGEDGE_HTTP_CLIENT_IP_HEADER":          "X-Forwarded-For",
+		"PGEDGE_HTTP_CLIENT_IP_TRUSTED_PROXIES": "192.0.2.1, 192.0.2.0/24",
+	}
+	for key, value := range vars {
+		os.Setenv(key, value)
+		defer os.Unsetenv(key)
+	}
+
+	cfg := defaultConfig()
+	applyEnvironmentVariables(cfg)
+
+	if cfg.HTTP.ClientIP.Source != "header" {
+		t.Errorf("expected source 'header', got %q", cfg.HTTP.ClientIP.Source)
+	}
+	if cfg.HTTP.ClientIP.Header != "X-Forwarded-For" {
+		t.Errorf("expected header 'X-Forwarded-For', got %q", cfg.HTTP.ClientIP.Header)
+	}
+	expected := []string{"192.0.2.1", "192.0.2.0/24"}
+	if len(cfg.HTTP.ClientIP.TrustedProxies) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, cfg.HTTP.ClientIP.TrustedProxies)
+	}
+	for i, want := range expected {
+		if cfg.HTTP.ClientIP.TrustedProxies[i] != want {
+			t.Errorf("entry %d: expected %q, got %q", i, want, cfg.HTTP.ClientIP.TrustedProxies[i])
+		}
+	}
+}
+
 func TestSetBoolFromEnv(t *testing.T) {
 	tests := []struct {
 		envValue string

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -39,6 +39,7 @@ type HTTPConfig struct {
 	AuthEnabled   bool                           // Enable API token authentication
 	TokenStore    *auth.TokenStore               // Token store for authentication
 	UserStore     *auth.UserStore                // User store for session token authentication
+	ClientIP      *auth.ClientIPResolver         // Resolves the client address; nil means socket only
 	SetupHandlers func(mux *http.ServeMux) error // Optional callback to add custom handlers before auth middleware
 	Debug         bool                           // Enable debug logging
 }
@@ -73,6 +74,10 @@ func (s *Server) buildHandler(config *HTTPConfig) (http.Handler, error) {
 
 	// Wrap with security headers middleware
 	handler = securityHeadersMiddleware(config.TLSEnable)(handler)
+
+	// Resolve the client address once, outside authentication, so that the rate
+	// limiter and the request log attribute a request to the same address
+	handler = auth.ClientIPMiddleware(config.ClientIP)(handler)
 
 	// Wrap with panic recovery so a handler panic always yields a JSON
 	// 500 response instead of an abruptly closed connection with no body.
@@ -229,9 +234,15 @@ func (s *Server) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract IP address and add to context
-	ipAddress := auth.ExtractIPAddress(r)
-	ctx := context.WithValue(r.Context(), auth.IPAddressContextKey, ipAddress)
+	// The client address is resolved by ClientIPMiddleware; fall back to the
+	// connection's peer for callers that invoke this handler directly, such as
+	// tests that bypass the middleware chain
+	ctx := r.Context()
+	ipAddress := auth.GetIPAddressFromContext(ctx)
+	if ipAddress == "" {
+		ipAddress = auth.ExtractIPAddress(r)
+		ctx = context.WithValue(ctx, auth.IPAddressContextKey, ipAddress)
+	}
 
 	// Limit request body size to prevent memory exhaustion attacks
 	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodySize)

--- a/internal/mcp/http_server_test.go
+++ b/internal/mcp/http_server_test.go
@@ -19,6 +19,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"pgedge-postgres-mcp/internal/auth"
 )
 
 func TestHandleHealthCheck(t *testing.T) {
@@ -1148,6 +1150,76 @@ func TestBuildHandler_KnownRouteStillWorks(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected the JSON 404 catch-all to not shadow /health; got status %d", w.Code)
+	}
+}
+
+// TestBuildHandler_ClientIPResolution checks that the handler chain resolves the
+// client address once and makes it available to handlers, so that the login rate
+// limiter and the request log agree on where a request came from.
+func TestBuildHandler_ClientIPResolution(t *testing.T) {
+	resolver, err := auth.NewClientIPResolver("header", "X-Forwarded-For", []string{"192.0.2.1"})
+	if err != nil {
+		t.Fatalf("failed to build client IP resolver: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		resolver   *auth.ClientIPResolver
+		remoteAddr string
+		forwarded  string
+		want       string
+	}{
+		{
+			name:       "trusted proxy chain yields the appended client address",
+			resolver:   resolver,
+			remoteAddr: "192.0.2.1:44444",
+			forwarded:  "9.9.9.9, 198.51.100.7",
+			want:       "198.51.100.7",
+		},
+		{
+			name:       "a direct caller cannot choose its own address",
+			resolver:   resolver,
+			remoteAddr: "203.0.113.5:44444",
+			forwarded:  "9.9.9.9",
+			want:       "203.0.113.5",
+		},
+		{
+			name:       "no resolver configured means the connection peer is used",
+			resolver:   nil,
+			remoteAddr: "203.0.113.5:44444",
+			forwarded:  "9.9.9.9",
+			want:       "203.0.113.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tools := &mockToolProvider{}
+			server := NewServer(tools)
+
+			var seen string
+			handler, err := server.buildHandler(&HTTPConfig{
+				ClientIP: tt.resolver,
+				SetupHandlers: func(mux *http.ServeMux) error {
+					mux.HandleFunc("/client-ip", func(w http.ResponseWriter, r *http.Request) {
+						seen = auth.GetIPAddressFromContext(r.Context())
+					})
+					return nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error building handler: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/client-ip", nil)
+			req.RemoteAddr = tt.remoteAddr
+			req.Header.Set("X-Forwarded-For", tt.forwarded)
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			if seen != tt.want {
+				t.Errorf("resolved client address = %q, want %q", seen, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #204.

`ExtractIPAddress` read the leftmost entry of `X-Forwarded-For`, which is
precisely the part of that header a caller can set for itself, and nothing
checked which peer the request had arrived from. The login rate limiter therefore
keyed on an address chosen by whoever sent the request: rotating the value on
each attempt meant `rate_limit_max_attempts` never counted more than one attempt
per key, and since `max_failed_attempts_before_lockout` defaults to `0`, the
default configuration had nothing else bounding password guessing. Sending
someone else's address whilst failing on purpose had their attempts counted
against them until the window rolled off. Our own nginx examples used
`$proxy_add_x_forwarded_for`, which appends to the caller's value rather than
replacing it, so none of this needed a misconfiguration to reproduce.

## What changed

Client addresses now come from the connection by default, which is correct for a
server clients reach directly and cannot be influenced by the caller. Deployments
behind a proxy opt in through a new `http.client_ip` block:

```yaml
http:
  client_ip:
    source: header          # socket (the default) | header
    header: X-Real-IP       # read when source is header
    trusted_proxies:        # addresses or CIDRs allowed to set that header
      - 192.0.2.0/24
```

The header is honoured only when the peer matches `trusted_proxies`, and
`X-Forwarded-For` is then walked from right to left, past trusted entries, taking
the first that is not. Each proxy appends the address it received the request
from, so anything a caller invents ends up at the far left and everything the
infrastructure adds lands to the right of it; counting from the right is the only
reliable direction. Every instance of the header is treated as one list in order,
because `Header.Get` returns only the first, which is the one an attacker can
send. Starting with `source: header` and no trusted proxies is a startup error
rather than a silent fallback, since a header carries no authority unless the
server knows which peer may set it.

Alongside that, candidates are validated as addresses, so arbitrary strings can
no longer become distinct rate limiter keys, and `net.SplitHostPort` replaces the
last-colon port stripping that left IPv6 peers bracketed as `[::1]` whilst
header-derived values were unbracketed, which had let one client occupy two keys
depending on which path produced its address. IPv4-mapped IPv6 addresses collapse
to their IPv4 form for the same reason. Resolution happens once per request in
middleware, so the rate limiter and the request log agree.

Names follow established practice: `header` is nginx's `real_ip_header` and
Apache's `RemoteIPHeader`, `trusted_proxies` is the modern spelling of
`set_real_ip_from`, and the right-to-left walk past trusted entries is what nginx
does as `real_ip_recursive on`. `source` is a value rather than a boolean so that
`proxy_protocol` can join it later without another flag. I have deliberately left
out an Envoy-style `num_trusted_hops`; it is the right answer for CDN deployments
whose ranges rotate, but it can follow once someone asks, rather than committing
now to counting semantics we have no deployment to check against.

## Notes

Account lockout is keyed on the username and was never affected by this, so it is
untouched here. The separate targeted-lockout problem, where anyone knowing a
username can lock that account and it never expires on its own, remains recorded
as a documentation caveat in #202.

Two of the `X-Forwarded-For` items on the #202 documentation checklist describe
this as a known limitation and should be dropped once this merges; the reverse
proxy examples and the configuration reference are updated here.

## Testing

`make test` passes in full (21 packages, exit 0) and `make lint-server` reports
no issues. The new resolver has 100% statement coverage from 30-odd cases
covering the spoofed-prefix chain, untrusted peers, repeated header instances,
lists of only trusted proxies, unparseable and adversarial entries, ported and
bracketed forms, IPv6 CIDR matching, and the rotation case that previously evaded
the limiter, plus handler-chain tests that the resolved address reaches handlers
and config tests for the defaults, merge, and environment variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP client IP resolution (`http.client_ip`) with either socket-based IPs or trusted-proxy forwarding-header extraction.
  * Server resolves the effective client IP once per request for consistent logging and rate limiting.
  * Startup fails fast when the client IP configuration is invalid.
* **Documentation**
  * Updated nginx and service/Helm examples plus guides/changelog security notes to align with the new client-IP and rate-limiting behavior.
* **Bug Fixes**
  * Prevented client IP spoofing by honoring forwarding headers only from trusted proxies; forwarding headers are interpreted from right-to-left and malformed values are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->