### PR TITLE
docs: pre-RC catch-up for undocumented and stale behaviour

### DIFF
--- a/docs/advanced/custom-definitions.md
+++ b/docs/advanced/custom-definitions.md
@@ -565,11 +565,32 @@ tools:
 #### PL/* Function Tools
 
 The `pl-func` type creates temporary PL/* functions with
-proper return types. These tools require `CREATE` permission
-on the database. The server creates the function, calls the
+proper return types. The server creates the function, calls the
 function, and drops the function automatically. Arguments
 arrive as a single `args` JSONB parameter. The `returns`
 field specifies the SQL return type.
+
+A `pl-func` tool has two separate requirements, and both must be
+met before it will run:
+
+- The database role the server connects as needs `CREATE`
+  permission on the schema, because the tool creates and drops a
+  function on each call.
+
+- The tool's `language` must be listed in the
+  `allowed_pl_languages` setting for the target database, which is
+  a server-side configuration rather than a database privilege. The
+  default permits `plpgsql` only, so a tool written in any other
+  language is silently withheld until an operator adds that
+  language; see [Configuring Allowed
+  Languages](#configuring-allowed-languages) below.
+
+Granting the privilege without allowing the language, or allowing
+the language without granting the privilege, leaves the tool
+unusable. A tool whose language is not allowed does not appear in
+`tools/list` at all, rather than appearing and then failing, so
+check the configuration first if a `pl-func` tool you have defined
+is missing.
 
 In the following example, the `pl-func` tool creates a
 temporary function that returns a table of row counts.

--- a/docs/advanced/custom-definitions.md
+++ b/docs/advanced/custom-definitions.md
@@ -570,8 +570,8 @@ function, and drops the function automatically. Arguments
 arrive as a single `args` JSONB parameter. The `returns`
 field specifies the SQL return type.
 
-A `pl-func` tool has two separate requirements, and both must be
-met before it will run:
+A `pl-func` tool has three separate requirements, and all three
+must be met before it will run:
 
 - The database role the server connects as needs `CREATE`
   permission on the schema, because the tool creates and drops a
@@ -585,12 +585,20 @@ met before it will run:
   language; see [Configuring Allowed
   Languages](#configuring-allowed-languages) below.
 
-Granting the privilege without allowing the language, or allowing
-the language without granting the privilege, leaves the tool
-unusable. A tool whose language is not allowed does not appear in
-`tools/list` at all, rather than appearing and then failing, so
-check the configuration first if a `pl-func` tool you have defined
-is missing.
+- The database connection itself needs `allow_writes: true`,
+  because creating and dropping the function is a catalogue write
+  regardless of what the tool's own SQL does. A `pl-func` tool
+  defined against a connection without `allow_writes` is refused
+  when called, naming that setting as the fix; use a `pl-do` tool
+  instead where the connection must stay read-only.
+
+Missing any one of the three leaves the tool unusable, and not
+always in the same way. A tool whose language is not allowed does
+not appear in `tools/list` at all, rather than appearing and then
+failing, so check the configuration first if a `pl-func` tool you
+have defined is missing. A tool that fails the `allow_writes`
+check behaves differently: it does appear in `tools/list`, and
+only fails, with the reason above, once something calls it.
 
 In the following example, the `pl-func` tool creates a
 temporary function that returns a table of row counts.

--- a/docs/advanced/llm-proxy.md
+++ b/docs/advanced/llm-proxy.md
@@ -9,8 +9,8 @@ The following diagram illustrates the LLM proxy architecture and how clients int
 │   Browser   │
 │  (Port 8081)│
 └──────┬──────┘
-       │ 1. Fetch providers/models via /api/llm/*
-       │ 2. Send chat via /api/llm/chat
+       │ 1. Fetch providers/models via /api/llm/v1/*
+       │ 2. Send chat via /api/llm/v1/chat/stream
        ▼
 ┌────────────────┐
 │  Web Client    │ (nginx + React)
@@ -37,9 +37,75 @@ The LLM proxy provides the following key benefits:
 
 ## LLM Proxy Endpoints
 
-The LLM proxy provides three REST API endpoints:
+The proxy is provided by the
+[pgedge-go-llm-lib](https://github.com/pgEdge/pgedge-go-llm-lib)
+`llm/proxy` package, which the server mounts at `/api/llm/`. The
+library registers its own routes beneath a version segment, so every
+endpoint sits under `/api/llm/v1/`. The following five endpoints make
+up the documented surface, and each requires a session token unless
+authentication is disabled.
 
-### GET /api/llm/providers
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/llm/v1/health` | Report reachability of each configured provider |
+| GET | `/api/llm/v1/providers` | List configured providers |
+| GET | `/api/llm/v1/models` | List the models a provider offers |
+| POST | `/api/llm/v1/chat` | Send a chat request and wait for the full response |
+| POST | `/api/llm/v1/chat/stream` | Send a chat request and receive the response as it is generated |
+
+The library also serves `/api/llm/v1/embed`,
+`/api/llm/v1/embed/multimodal` and `/api/llm/v1/rerank` through the
+same handler. These are reachable but are not part of the surface this
+server documents or advertises in its OpenAPI specification; use the
+`generate_embedding` tool for embedding work instead.
+
+!!! note
+
+    Earlier releases served `/api/llm/providers`, `/api/llm/models` and
+    `/api/llm/chat` without the version segment. Those paths now return
+    404\. Callers written against them need the `/v1` segment added, and
+    the chat request and response bodies use typed content blocks; see
+    the [changelog](../changelog.md) for the details of that move.
+
+### GET /api/llm/v1/health
+
+Reports whether each configured provider is reachable. The server
+builds a client for every configured provider and pings it with a five
+second deadline, so a hanging provider cannot stall the check.
+
+The response `status` is `ok` when every provider answers, and
+`degraded` when at least one does not; a degraded response also carries
+the HTTP status `503 Service Unavailable`, which makes the endpoint
+usable as a load balancer health check for LLM availability. Note that
+this is separate from the server's own `/health` endpoint, which
+reports on the server rather than on its providers.
+
+In the following example, the request checks provider health.
+
+**Request:**
+```http
+GET /api/llm/v1/health HTTP/1.1
+Host: localhost:8080
+Authorization: Bearer <session-token>
+```
+
+**Response:**
+```json
+{
+  "status": "degraded",
+  "providers": {
+    "anthropic": {
+      "status": "ok"
+    },
+    "ollama": {
+      "status": "down",
+      "error": "dial tcp 127.0.0.1:11434: connect: connection refused"
+    }
+  }
+}
+```
+
+### GET /api/llm/v1/providers
 
 Returns the list of configured LLM providers based on which API keys are available.
 
@@ -47,7 +113,7 @@ In the following example, the request retrieves the list of available LLM provid
 
 **Request:**
 ```http
-GET /api/llm/providers HTTP/1.1
+GET /api/llm/v1/providers HTTP/1.1
 Host: localhost:8080
 Authorization: Bearer <session-token>
 ```
@@ -58,27 +124,28 @@ Authorization: Bearer <session-token>
   "providers": [
     {
       "name": "anthropic",
-      "display": "Anthropic Claude",
-      "isDefault": true
+      "display_name": "Anthropic",
+      "model": "claude-sonnet-4-5",
+      "default": true
     },
     {
       "name": "openai",
-      "display": "OpenAI",
-      "isDefault": false
+      "display_name": "OpenAI"
     },
     {
       "name": "ollama",
-      "display": "Ollama",
-      "isDefault": false
+      "display_name": "Ollama"
     }
   ],
-  "defaultModel": "claude-sonnet-4-5"
+  "default_provider": "anthropic"
 }
 ```
 
-**Implementation:** [internal/llmproxy/proxy.go:93-136](https://github.com/pgEdge/pgedge-postgres-mcp/blob/main/internal/llmproxy/proxy.go#L93-L136)
+The `default` and `model` fields are omitted rather than sent as false
+or empty, so a provider that is neither the default nor carrying a
+configured model appears with just its name and display name.
 
-### GET /api/llm/models?provider=<provider>
+### GET /api/llm/v1/models?provider=<provider>
 
 Lists available models for the specified provider.
 
@@ -86,7 +153,7 @@ In the following example, the request retrieves the list of available models for
 
 **Request:**
 ```http
-GET /api/llm/models?provider=ollama HTTP/1.1
+GET /api/llm/v1/models?provider=ollama HTTP/1.1
 Host: localhost:8080
 Authorization: Bearer <session-token>
 ```
@@ -95,12 +162,15 @@ Authorization: Bearer <session-token>
 ```json
 {
   "models": [
-    { "name": "llama3" },
-    { "name": "mistral" },
-    { "name": "codellama:13b" }
+    "llama3",
+    "mistral",
+    "codellama:13b"
   ]
 }
 ```
+
+Adding `&metadata=true` to the request returns objects carrying each
+model's metadata in place of the plain identifiers.
 
 **Provider-specific behavior:**
 
@@ -108,11 +178,16 @@ Authorization: Bearer <session-token>
 - **OpenAI**: Calls the OpenAI models API.
 - **Ollama**: Calls the Ollama `/api/tags` endpoint at the configured PGEDGE_OLLAMA_URL.
 
-**Implementation:** [internal/llmproxy/proxy.go:138-200](https://github.com/pgEdge/pgedge-postgres-mcp/blob/main/internal/llmproxy/proxy.go#L138-L200)
+### POST /api/llm/v1/chat
 
-### POST /api/llm/chat
+Sends a chat request to the configured LLM provider with tool support,
+and returns the complete response once the provider has finished
+generating it.
 
-Sends a chat request to the configured LLM provider with tool support.
+Message content is a list of typed blocks rather than a bare string;
+the block `type` selects which payload field applies, so a text block
+carries `text` and a tool call carries `tool_use`. The recognised types
+are `text`, `image`, `document`, `tool_use` and `tool_result`.
 
 In the following example, the request sends a chat message with tools to the LLM provider.
 
@@ -123,14 +198,19 @@ In the following example, the request sends a chat message with tools to the LLM
   "messages": [
     {
       "role": "user",
-      "content": "List the tables in the database"
+      "content": [
+        {
+          "type": "text",
+          "text": "List the tables in the database"
+        }
+      ]
     }
   ],
   "tools": [
     {
       "name": "list_tables",
       "description": "Lists all tables in the database",
-      "inputSchema": {
+      "input_schema": {
         "type": "object",
         "properties": {}
       }
@@ -148,16 +228,81 @@ In the following example, the request sends a chat message with tools to the LLM
   "content": [
     {
       "type": "tool_use",
-      "id": "toolu_123",
-      "name": "list_tables",
-      "input": {}
+      "tool_use": {
+        "id": "toolu_123",
+        "name": "list_tables",
+        "input": {}
+      }
     }
   ],
-  "stop_reason": "tool_use"
+  "stop_reason": "tool_use",
+  "usage": {
+    "prompt_tokens": 1284,
+    "completion_tokens": 47,
+    "total_tokens": 1331
+  }
 }
 ```
 
-**Implementation:** [internal/llmproxy/proxy.go:202-295](https://github.com/pgEdge/pgedge-postgres-mcp/blob/main/internal/llmproxy/proxy.go#L202-L295)
+The `stop_reason` is one of `end_turn`, `max_tokens`, `stop_sequence`,
+`tool_use`, `content_filter` or `error`. A client running an agentic
+loop watches for `tool_use`, executes the requested tool, and sends the
+result back as a `tool_result` block whose `tool_use_id` matches the
+`id` above.
+
+### POST /api/llm/v1/chat/stream
+
+Sends the same request body as `/api/llm/v1/chat`, but returns the
+response as [Server-Sent
+Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+so a client can render text as it is generated. The web chat interface
+uses this endpoint; the non-streaming endpoint remains available for
+callers that would rather wait for a complete response.
+
+Each event carries one JSON-encoded chunk whose `type` describes what it
+contains:
+
+- The `text` type carries an incremental text fragment in `text`;
+  concatenating these fragments reconstructs the reply.
+- The `tool_use_start` type announces a tool call, populating
+  `tool_use.id` and `tool_use.name`. Some providers send the arguments
+  in one piece here, whilst others follow with deltas.
+- The `tool_use_delta` type carries a fragment of the current tool
+  call's JSON arguments in `partial`; a client concatenates these
+  fragments to rebuild the argument object.
+
+Ordinary chunks arrive as `data:` lines on their own. The final chunk
+arrives as an event named `done`, which normally carries the token
+`usage` for the request; a stream that fails part way through emits an
+event named `error` instead. A client always sees a `done` event, since
+the proxy synthesises one when a provider closes the stream without
+sending its own, in which case the `usage` field is absent.
+
+In the following example, the response streams a short reply and then
+closes with usage totals.
+
+**Request:**
+```http
+POST /api/llm/v1/chat/stream HTTP/1.1
+Host: localhost:8080
+Authorization: Bearer <session-token>
+Content-Type: application/json
+```
+
+**Response:**
+```
+data: {"type":"text","text":"The database contains"}
+
+data: {"type":"text","text":" three tables."}
+
+event: done
+data: {"type":"done","usage":{"prompt_tokens":1284,"completion_tokens":12,"total_tokens":1296}}
+
+```
+
+Because an error can arrive before, during, or after the content
+chunks, a client should treat the `error` event as authoritative
+regardless of how much it has already rendered.
 
 ## Configuring the LLM Proxy
 
@@ -328,7 +473,7 @@ const processQuery = async (userMessage) => {
     // Agentic loop (max 10 iterations)
     for (let iteration = 0; iteration < 10; iteration++) {
         // Get LLM response via proxy
-        const response = await fetch('/api/llm/chat', {
+        const response = await fetch('/api/llm/v1/chat', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/docs/advanced/llm-proxy.md
+++ b/docs/advanced/llm-proxy.md
@@ -290,7 +290,7 @@ Content-Type: application/json
 ```
 
 **Response:**
-```
+```text
 data: {"type":"text","text":"The database contains"}
 
 data: {"type":"text","text":" three tables."}

--- a/docs/advanced/llm-proxy.md
+++ b/docs/advanced/llm-proxy.md
@@ -70,8 +70,8 @@ server documents or advertises in its OpenAPI specification; use the
 ### GET /api/llm/v1/health
 
 Reports whether each configured provider is reachable. The server
-builds a client for every configured provider and pings it with a five
-second deadline, so a hanging provider cannot stall the check.
+builds a client for every configured provider and pings it with a
+five-second deadline, so a hanging provider cannot stall the check.
 
 The response `status` is `ok` when every provider answers, and
 `degraded` when at least one does not; a degraded response also carries

--- a/docs/advanced/llm-proxy.md
+++ b/docs/advanced/llm-proxy.md
@@ -314,7 +314,7 @@ In the following example, the configuration file specifies the LLM provider, mod
 # Configuration file: pgedge-pg-mcp-web.yaml
 llm:
     enabled: true
-    provider: "anthropic"  # anthropic, openai, or ollama
+    provider: "anthropic"  # anthropic, openai, gemini, or ollama
     model: "claude-sonnet-4-5"
 
     # API key configuration (priority: env vars > key files > direct values)
@@ -322,9 +322,11 @@ llm:
     # Option 2: API key files (recommended for production)
     anthropic_api_key_file: "~/.anthropic-api-key"
     openai_api_key_file: "~/.openai-api-key"
+    gemini_api_key_file: "~/.gemini-api-key"
     # Option 3: Direct values (not recommended - use env vars or files)
     # anthropic_api_key: "your-key-here"
     # openai_api_key: "your-key-here"
+    # gemini_api_key: "your-key-here"
 
     # Optional: Custom base URLs for API proxies
     # Leave empty to use default provider URLs
@@ -339,28 +341,36 @@ llm:
     temperature: 0.7
 ```
 
+The proxy is disabled unless `enabled` (or `PGEDGE_LLM_ENABLED`) is
+set to `true`; at least one provider's API key, or a reachable
+`ollama_url`, must also be configured, or the server refuses to
+start with the proxy enabled.
+
 **API Key Priority:**
 
 API keys are loaded in the following order (highest to lowest):
 
-1. Environment variables (`PGEDGE_ANTHROPIC_API_KEY`, `PGEDGE_OPENAI_API_KEY`).
-2. API key files (`anthropic_api_key_file`, `openai_api_key_file`).
+1. Environment variables (`PGEDGE_ANTHROPIC_API_KEY`,
+   `PGEDGE_OPENAI_API_KEY`, `PGEDGE_GEMINI_API_KEY`).
+2. API key files (`anthropic_api_key_file`, `openai_api_key_file`,
+   `gemini_api_key_file`).
 3. Direct configuration values (not recommended).
 
 **Environment variables:**
 
-- `PGEDGE_LLM_ENABLED`: Enable/disable the LLM proxy (default: true).
+- `PGEDGE_LLM_ENABLED`: Enable/disable the LLM proxy (default: false).
 - `PGEDGE_LLM_PROVIDER`: The default provider.
 - `PGEDGE_LLM_MODEL`: The default model.
 - `PGEDGE_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY`: The Anthropic API key.
 - `PGEDGE_ANTHROPIC_BASE_URL`: Custom Anthropic API base URL (for proxies).
 - `PGEDGE_OPENAI_API_KEY` or `OPENAI_API_KEY`: The OpenAI API key.
 - `PGEDGE_OPENAI_BASE_URL`: Custom OpenAI API base URL (for proxies).
+- `PGEDGE_GEMINI_API_KEY` or `GEMINI_API_KEY`: The Google Gemini API key.
 - `PGEDGE_OLLAMA_URL`: The Ollama server URL (used for both embeddings and LLM).
 - `PGEDGE_LLM_MAX_TOKENS`: The maximum tokens per response.
 - `PGEDGE_LLM_TEMPERATURE`: The LLM temperature (0.0-1.0).
 
-**Implementation:** [internal/config/config.go:459-489](https://github.com/pgEdge/pgedge-postgres-mcp/blob/main/internal/config/config.go#L459-L489)
+**Implementation:** [internal/config/config.go:497-513](https://github.com/pgEdge/pgedge-postgres-mcp/blob/main/internal/config/config.go#L497-L513)
 
 ## Building Web Clients with JSON-RPC
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -471,97 +471,175 @@
         "type": "object"
       },
       "LLMChatRequest": {
-        "description": "Request to send a chat completion to an LLM provider.",
         "properties": {
-          "debug": {
-            "default": false,
-            "description": "Whether to include debug information in the response.",
-            "type": "boolean"
+          "max_tokens": {
+            "type": "integer"
           },
           "messages": {
-            "description": "The conversation messages to send.",
             "items": {
-              "$ref": "#/components/schemas/ChatMessage"
+              "$ref": "#/components/schemas/LLMMessage"
             },
             "type": "array"
           },
           "model": {
-            "description": "The model to use for completion.",
+            "description": "Override default model",
             "type": "string"
           },
           "provider": {
-            "description": "The LLM provider to use.",
+            "description": "Override default provider",
             "type": "string"
           },
-          "tools": {
-            "description": "Optional tool definitions for function calling.",
+          "stop_sequences": {
             "items": {
-              "description": "A tool definition.",
-              "properties": {
-                "description": {
-                  "description": "A description of what the tool does.",
-                  "type": "string"
-                },
-                "inputSchema": {
-                  "description": "JSON Schema describing the tool's input parameters.",
-                  "type": "object"
-                },
-                "name": {
-                  "description": "The tool name.",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name",
-                "description",
-                "inputSchema"
-              ],
-              "type": "object"
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "system_prompt": {
+            "type": "string"
+          },
+          "temperature": {
+            "type": "number"
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/LLMTool"
             },
             "type": "array"
           }
         },
         "required": [
-          "messages",
-          "provider",
-          "model"
+          "messages"
         ],
         "type": "object"
       },
       "LLMChatResponse": {
-        "description": "Response from an LLM chat completion request.",
         "properties": {
           "content": {
-            "description": "The response content blocks.",
             "items": {
-              "description": "A content block from the LLM response.",
-              "type": "object"
+              "$ref": "#/components/schemas/LLMContentBlock"
             },
             "type": "array"
           },
           "stop_reason": {
-            "description": "The reason the model stopped generating.",
+            "enum": [
+              "end_turn",
+              "max_tokens",
+              "stop_sequence",
+              "tool_use",
+              "content_filter",
+              "error"
+            ],
             "type": "string"
           },
-          "token_usage": {
-            "description": "Token usage statistics for the request.",
-            "properties": {
-              "input_tokens": {
-                "description": "Number of input tokens consumed.",
-                "type": "integer"
-              },
-              "output_tokens": {
-                "description": "Number of output tokens generated.",
-                "type": "integer"
-              }
-            },
-            "type": "object"
+          "usage": {
+            "$ref": "#/components/schemas/LLMTokenUsage"
           }
         },
         "required": [
           "content",
-          "stop_reason",
-          "token_usage"
+          "stop_reason"
+        ],
+        "type": "object"
+      },
+      "LLMContentBlock": {
+        "properties": {
+          "is_error": {
+            "description": "Populated when type=tool_result",
+            "type": "boolean"
+          },
+          "text": {
+            "type": "string"
+          },
+          "tool_use": {
+            "description": "Populated when type=tool_use",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "input": {
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "tool_use_id": {
+            "description": "Populated when type=tool_result",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text",
+              "image",
+              "document",
+              "tool_use",
+              "tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "LLMMessage": {
+        "properties": {
+          "content": {
+            "items": {
+              "$ref": "#/components/schemas/LLMContentBlock"
+            },
+            "type": "array"
+          },
+          "role": {
+            "enum": [
+              "user",
+              "assistant",
+              "system",
+              "tool"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "LLMTokenUsage": {
+        "properties": {
+          "completion_tokens": {
+            "type": "integer"
+          },
+          "prompt_tokens": {
+            "type": "integer"
+          },
+          "total_tokens": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "LLMTool": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "input_schema": {
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "input_schema"
         ],
         "type": "object"
       },
@@ -608,9 +686,9 @@
         "description": "Response listing models for an LLM provider.",
         "properties": {
           "models": {
-            "description": "The available models.",
+            "description": "The available model identifiers.",
             "items": {
-              "$ref": "#/components/schemas/ModelInfo"
+              "type": "string"
             },
             "type": "array"
           }
@@ -623,13 +701,13 @@
       "ProviderInfo": {
         "description": "Information about an LLM provider.",
         "properties": {
-          "display": {
-            "description": "A human-readable display name for the provider.",
-            "type": "string"
-          },
-          "isDefault": {
+          "default": {
             "description": "Whether this provider is the default.",
             "type": "boolean"
+          },
+          "model": {
+            "description": "The default model for this provider.",
+            "type": "string"
           },
           "name": {
             "description": "The provider identifier.",
@@ -638,16 +716,16 @@
         },
         "required": [
           "name",
-          "display",
-          "isDefault"
+          "model",
+          "default"
         ],
         "type": "object"
       },
       "ProvidersResponse": {
         "description": "Response listing available LLM providers.",
         "properties": {
-          "defaultModel": {
-            "description": "The name of the default model.",
+          "default_provider": {
+            "description": "The name of the default provider.",
             "type": "string"
           },
           "providers": {
@@ -660,7 +738,7 @@
         },
         "required": [
           "providers",
-          "defaultModel"
+          "default_provider"
         ],
         "type": "object"
       },
@@ -1384,7 +1462,7 @@
         ]
       }
     },
-    "/api/llm/chat": {
+    "/api/llm/v1/chat": {
       "post": {
         "description": "Proxies a chat completion request to the specified LLM provider and model. Supports tool definitions for function calling.",
         "operationId": "llmChat",
@@ -1442,7 +1520,102 @@
         ]
       }
     },
-    "/api/llm/models": {
+    "/api/llm/v1/chat/stream": {
+      "post": {
+        "description": "Returns Server-Sent Events conforming to pgedge-go-llm-lib's SSE wire format. See https://github.com/pgEdge/pgedge-go-llm-lib for the full chunk/event schema.",
+        "operationId": "llmChatStream",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {}
+            },
+            "description": "SSE stream of chat chunks. Each data line is a JSON-encoded llm.StreamChunk; a terminator 'event: done' or 'event: error' precedes connection close."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Streaming chat (SSE) via the LLM proxy",
+        "tags": [
+          "LLM Proxy"
+        ]
+      }
+    },
+    "/api/llm/v1/health": {
+      "get": {
+        "operationId": "llmHealth",
+        "responses": {
+          "200": {
+            "description": "All providers healthy"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid authentication token."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Insufficient permissions."
+          },
+          "503": {
+            "description": "One or more providers unhealthy"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Check provider connectivity",
+        "tags": [
+          "LLM Proxy"
+        ]
+      }
+    },
+    "/api/llm/v1/models": {
       "get": {
         "description": "Returns the models available for the specified LLM provider.",
         "operationId": "listLLMModels",
@@ -1500,9 +1673,9 @@
         ]
       }
     },
-    "/api/llm/providers": {
+    "/api/llm/v1/providers": {
       "get": {
-        "description": "Returns the available LLM providers and the default model.",
+        "description": "Returns the configured LLM providers (with each provider's default model) and the overall default provider name.",
         "operationId": "listLLMProviders",
         "responses": {
           "200": {

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -637,9 +637,9 @@ curl http://localhost:8080/api/openapi.json
 None of the three exposes database contents or accepts a query, so the
 data they return is limited to the server's own status, whether
 authentication is switched on, and the shape of the API. Treat the
-specification as public information when deciding what to expose a
-server to; if that is not acceptable for your deployment, restrict
-these paths at the reverse proxy rather than in the server.
+specification as public information when deciding what network to
+expose a server to; if that is not acceptable for your deployment,
+restrict these paths at the reverse proxy rather than in the server.
 
 
 ## To Disable Authentication (Development Only)

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -98,6 +98,34 @@ With this configuration:
 - IP addresses are limited to 10 failed attempts per 15-minute window.
 - The server logs show when rate limiting is enabled.
 
+!!! warning "Lockout is permanent and keyed on the username alone"
+
+    Understand two properties of account lockout before enabling it,
+    because together they make it a denial-of-service tool as well as a
+    safety feature.
+
+    A lockout never expires on its own. The server clears the account's
+    `enabled` flag and leaves it clear; there is no timeout after which
+    the account recovers. An administrator must run `-enable-user`, as
+    described below, so a lockout during an out-of-hours incident lasts
+    until someone with shell access attends to it.
+
+    The counter is keyed on the username and takes no account of who is
+    making the attempts. Anyone who can reach the server and who knows
+    or guesses a valid username can therefore lock that account
+    deliberately, by failing authentication against it the configured
+    number of times; the attempts need not come from one address, and
+    the real owner's own address is never consulted. This is why the
+    setting defaults to `0`, which disables lockout entirely and leaves
+    brute-force protection to the per-address rate limiting described
+    above.
+
+    Weigh those properties against your threat model. Lockout is worth
+    enabling where the accounts are few, the administrators are reachable,
+    and the usernames are not widely known; it is a poor fit for a server
+    exposed to untrusted callers, where it hands them a way to disable a
+    known account at will.
+
 You can also configure lockout with the following environment variables:
 
 ```bash
@@ -586,14 +614,32 @@ The following responses may occur as a result of authentication errors:
 **Note:** For security reasons, specific error details are not exposed.
 
 
-## Health Endpoint
+## Endpoints That Skip Authentication
 
-The `/health` endpoint is **always accessible** without authentication:
+Three endpoints are **always accessible** without a token, even when
+authentication is enabled:
+
+| Endpoint | Why it skips authentication |
+|----------|------------------------------|
+| `/health` | Load balancers and orchestrators need to probe liveness before they hold any credential. |
+| `/api/user/info` | The web client calls this to discover whether authentication is enabled at all, which it must do before it can know to ask for a token. |
+| `/api/openapi.json` | The API specification is published for discoverability, so that a client can be written against it before credentials are issued. |
+
+In the following example, each endpoint responds without a token.
 
 ```bash
 # No token required
 curl http://localhost:8080/health
+curl http://localhost:8080/api/user/info
+curl http://localhost:8080/api/openapi.json
 ```
+
+None of the three exposes database contents or accepts a query, so the
+data they return is limited to the server's own status, whether
+authentication is switched on, and the shape of the API. Treat the
+specification as public information when deciding what to expose a
+server to; if that is not acceptable for your deployment, restrict
+these paths at the reverse proxy rather than in the server.
 
 
 ## To Disable Authentication (Development Only)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -110,15 +110,25 @@ details on configuring multiple databases and access control.
 | `databases[].sslrootcert` | `-db-sslrootcert` | `PGEDGE_DB_SSLROOTCERT`, `PGSSLROOTCERT` | Path to the CA certificate file used to verify the server. Takes effect only under `sslmode` `require`, `verify-ca`, or `verify-full`; ignored under other modes, matching libpq. |
 | `databases[].allow_writes` | N/A | `PGEDGE_DB_ALLOW_WRITES`, `PGEDGE_DB_N_ALLOW_WRITES` | Allow write queries such as INSERT, UPDATE, and DELETE (default: false). See [Database Write Access](security.md#database-write-access). |
 | `databases[].allow_llm_switching` | N/A | N/A | Allow LLM to discover and switch to the database (default: true). See [Excluding Databases from LLM Switching](multiple_db_config.md#excluding-databases-from-llm-switching). |
-| `databases[].allowed_pl_languages` | N/A | N/A | PL languages allowed for custom tools, such as `["plpgsql"]`; use `["*"]` for all (default: none). See [Custom Definitions](../advanced/custom-definitions.md). |
+| `databases[].allowed_pl_languages` | N/A | N/A | PL languages allowed for custom tools, such as `["plpgsql"]`; use `["*"]` for all (default: `["plpgsql"]`). See [Custom Definitions](../advanced/custom-definitions.md). |
 | `databases[].available_to_users` | N/A | N/A | Usernames allowed to access the database; empty list means all users (default: `[]`) |
 | `databases[].pool_max_conns` | N/A | N/A | Maximum connections in the pool (default: 4) |
 | `databases[].pool_min_conns` | N/A | N/A | Minimum connections in the pool (default: 0) |
 | `databases[].pool_max_conn_idle_time` | N/A | N/A | Maximum idle time before a connection is closed (default: "30m") |
-| `databases[].pool_health_check_period` | N/A | N/A | Interval for background pool health checks (default: disabled) |
-| `databases[].pool_max_conn_lifetime` | N/A | N/A | Maximum lifetime of a connection before the pool closes the connection (default: "1h") |
+| `databases[].pool_health_check_period` | N/A | N/A | Interval for background pool health checks (default: "1m", or "30s" when multiple hosts are configured) |
+| `databases[].pool_max_conn_lifetime` | N/A | N/A | Maximum lifetime of a connection before the pool closes the connection (default: "1h", or "5m" when multiple hosts are configured) |
 | `databases[].connect_timeout` | N/A | N/A | Timeout for the initial database connection as a Go duration string such as "10s" or "30s" (default: "10s") |
 | `databases[].metadata_ttl` | N/A | N/A | How long cached schema metadata remains valid before automatic refresh as a Go duration string such as "5m" or "30s"; use "0" to refresh on every request (default: "5m") |
+
+The two pool settings above take shorter defaults when a database
+configures more than one host, because a connection to a host that has
+failed is only discovered when something checks it. Recycling
+connections every five minutes and checking idle ones every thirty
+seconds keeps a failed host's connections from lingering in the pool,
+at the cost of reconnecting more often than a single-host deployment
+needs to. The two settings are independent: giving one an explicit value
+overrides only that setting, and the other still takes its multi-host
+default.
 
 CLI flags and single-database environment variables (`PGEDGE_DB_*`,
 `PG*`) apply to the first database in the list. Use numbered

--- a/docs/guide/multiple_db_config.md
+++ b/docs/guide/multiple_db_config.md
@@ -9,7 +9,23 @@ projects.
 ## Configuring Multiple Databases
 
 Each database must have a unique name that users reference when switching
-connections:
+connections. The name doubles as the label the server shows wherever it
+names a database in tool output or an error message, and it is used in
+preference to the real address deliberately, so that an internal-only
+host is not disclosed to a caller who could not reach it anyway.
+
+!!! note "Always configure a name"
+
+    When a connection has no configured name, the label falls back to
+    the connection string with the password masked, which still contains
+    the host, port, database and user. Naming every database therefore
+    keeps the address out of tool output as well as making the output
+    easier to read. A connection built without a name is unusual in a
+    normal deployment, arising mainly from a single database supplied
+    entirely through command-line flags or environment variables.
+
+In the following example, the configuration file defines three named
+databases:
 
 ```yaml
 databases:

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -107,11 +107,19 @@ defense-in-depth:
   read-only mode. These include read-write transaction modes,
   `SET SESSION CHARACTERISTICS`, `RESET ALL`, `DISCARD`,
   transaction control, `SET ROLE`, `SET SESSION AUTHORIZATION`,
-  changes to the `transaction_read_only` or
-  `default_transaction_read_only` settings, and operations whose
-  effects fall outside the transaction altogether, such as `DO`
-  blocks, `COPY ... TO PROGRAM`, server-side file functions, and
-  `dblink`.
+  `ALTER ROLE`, `ALTER USER`, `ALTER DATABASE`, changes to the
+  `transaction_read_only` or `default_transaction_read_only`
+  settings, and operations whose effects fall outside the
+  transaction altogether, such as `DO` blocks,
+  `COPY ... TO PROGRAM`, server-side file functions, and `dblink`.
+  The guard also refuses more than one statement in a single
+  request, since a batch lets a rejected construct travel behind an
+  innocuous leading statement.
+
+  The `ALTER` forms matter because they persist a setting rather
+  than change the current session: `ALTER ROLE ... SET
+  default_transaction_read_only = off` would apply to the next
+  connection the pool opens, outliving the request that issued it.
 
 When the database connection is in read-only mode, the system
 prompt sent to the LLM includes explicit instructions that forbid

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -29,6 +29,87 @@ The tools in the following sections are available through the MCP
 server component.
 
 
+## count_rows
+
+The `count_rows` tool returns the number of rows in a table, with an
+optional filter. It exists so that an agent can size a table before
+querying it, rather than fetching rows to find out how many there are;
+the response is a single number, which costs the LLM very few tokens.
+
+**Use Cases**
+
+* **Sizing a query**: Check how large a table is before choosing a
+  `LIMIT` for `query_database`.
+* **Verifying a filter**: Confirm that a condition matches the expected
+  number of rows before acting on it.
+* **Checking for data**: Establish that rows exist without transferring
+  any of them.
+
+**Parameters**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `table` | Required | The name of the table to count rows in. |
+| `schema` | Optional | The schema holding the table; defaults to `public`. |
+| `where` | Optional | A filter condition, written without the `WHERE` keyword. |
+
+The schema and table names are quoted before use, so a name that needs
+quoting, or one chosen to look like SQL, is treated as an identifier
+rather than as code.
+
+The filter condition is different, because a condition has to reach the
+database as SQL to be of any use. The server therefore screens it with
+the same guard it applies to any caller-supplied SQL, rejecting the
+constructs described in the [Security
+Guide](../guide/security.md#read-only-protection). The count always runs in a
+read-only transaction, so that screening applies even on a connection
+that permits writes elsewhere.
+
+**Examples**
+
+In the following example, the `count_rows` tool counts every row in a
+table:
+
+```json
+{
+  "table": "orders"
+}
+```
+
+The tool returns:
+
+```
+Database: production
+
+SQL Query:
+SELECT COUNT(*) FROM "public"."orders"
+
+Count: 15234
+```
+
+In the following example, the tool counts only the rows matching a
+condition, in a named schema:
+
+```json
+{
+  "table": "orders",
+  "schema": "sales",
+  "where": "status = 'pending'"
+}
+```
+
+The tool returns:
+
+```
+Database: production
+
+SQL Query:
+SELECT COUNT(*) FROM "sales"."orders" WHERE status = 'pending'
+
+Count: 412
+```
+
+
 ## execute_explain
 
 The `execute_explain` tool executes `EXPLAIN ANALYZE` on a SQL query to
@@ -224,6 +305,24 @@ must be enabled in the server configuration.
     This tool requires `llm_connection_selection: true` in the
     `builtins.tools` configuration section.
 
+!!! warning "Connection details are returned verbatim"
+
+    This tool and `select_database_connection` both report the `host`
+    and `port` recorded in the server configuration, along with the
+    full `hosts` array where multi-host failover is configured. These
+    are returned exactly as an operator wrote them, so a private
+    address that no client could reach, such as a Kubernetes pod IP or
+    an internal VPC hostname, is disclosed to whoever can call the
+    tool, and to the LLM behind it.
+
+    This is a known exposure rather than an accident: a client that is
+    permitted to choose between connections needs enough detail to tell
+    them apart. Both tools are nevertheless disabled by default, and
+    where the addresses are sensitive you can leave them that way, or
+    exclude individual databases with `allow_llm_switching: false`.
+    Other tools deliberately avoid the raw address and report the
+    configured name instead.
+
 **Configuration**
 
 To enable this tool, add the following to your server configuration:
@@ -315,6 +414,12 @@ selected database.
     After switching databases, the available schemas, tables, and
     permissions may change. Consider re-examining the schema using
     `get_schema_info` after switching.
+
+!!! warning "Connection details are returned verbatim"
+
+    As the example below shows, the response reports the configured
+    `host`. See the note under `list_database_connections` for what that
+    discloses.
 
 **Configuration**
 
@@ -501,10 +606,24 @@ The `query_database` tool executes a SQL query against the PostgreSQL database.
     translate natural language into SQL queries that are then executed
     by this server.
 
-Note that for security, all queries are executed in read-only
-transactions using `SET TRANSACTION READ ONLY`, preventing `INSERT`,
-`UPDATE`, `DELETE`, and other data modifications. Write operations will
-fail with `cannot execute ... in a read-only transaction`.
+Unless the connection sets `allow_writes`, queries run read-only, so
+`INSERT`, `UPDATE`, `DELETE` and other modifications fail with
+`cannot execute ... in a read-only transaction`.
+
+Read-only mode is enforced in four layers rather than by one statement.
+The server requests read-only access as part of the `BEGIN` that starts
+each transaction, so there is no moment at which the transaction is
+writable and no separate statement that could fail on its own; it also
+applies `default_transaction_read_only` at the session level when a
+connection is established and again when the connection returns to the
+pool, sends every query through the extended query protocol so that a
+request cannot smuggle a second statement past the parser, and screens
+each statement for constructs known to escape read-only mode, such as
+requesting a read-write transaction or changing the settings that
+control it. Earlier releases relied on issuing `SET TRANSACTION READ
+ONLY` after the transaction had begun, which the current approach
+replaces. See [Read-Only Mode](../guide/security.md#read-only-protection) for
+the layers in full, and for what they do and do not guarantee.
 
 When `allow_writes` is enabled for a database connection and the
 query is a write operation, the CLI and Web UI prompt for user

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -78,7 +78,7 @@ table:
 
 The tool returns:
 
-```
+```text
 Database: production
 
 SQL Query:
@@ -100,7 +100,7 @@ condition, in a named schema:
 
 The tool returns:
 
-```
+```text
 Database: production
 
 SQL Query:


### PR DESCRIPTION
Works through the checklist in #202. Every item was verified against the code
before anything was written, and two came out differently from the issue's
wording; those are called out at the bottom.

> **Stacked on #205.** This branches from `security/trusted-proxy-client-ip`
> because two checklist items ask for the `X-Forwarded-For` spoofing to be
> documented as a known limitation, and #205 removes it. Rather than commit a
> limitation we have just fixed, those two items are satisfied by #205's own
> documentation. GitHub will retarget this at `main` once #205 merges.

## Summary

- **LLM proxy guide** — endpoints gained a `/v1` segment when the in-repo
  handlers were replaced by the shared library's `llm/proxy`, so every
  documented path returns 404, and the request/response examples predate the
  move to typed content blocks. The guide now documents the five endpoints the
  OpenAPI generator advertises, including the streaming chat and health
  endpoints that had no write-up at all, and notes that `embed`,
  `embed/multimodal` and `rerank` are reachable without being part of the
  supported surface. Dead links into the deleted `internal/llmproxy` package
  are removed.

- **`docs/api/openapi.json`** — last regenerated at "Release version 1.0.0",
  i.e. before that migration, so `make openapi` brings it back in step. Only
  the LLM paths change: three stale ones out, five current ones in.

- **Account lockout** — documented as a pure safety feature. It never expires
  on its own and is keyed on the username alone, so anyone who knows a username
  can disable that account at will. Both properties are now stated next to the
  example, along with why the setting defaults to `0`.

- **Unauthenticated endpoints** — three, not one. `/api/user/info` and
  `/api/openapi.json` join `/health`, each with the reason it skips
  authentication and a note on what it discloses.

- **Read-only blocklist** — was missing `ALTER ROLE`, `ALTER USER` and
  `ALTER DATABASE`, which persist a setting beyond the current session, and the
  refusal of more than one statement per request.

- **Tools guide** — `count_rows` had no write-up; it now has one covering the
  quoting of identifiers and the screening of the filter condition.
  `query_database` still described read-only enforcement as a
  `SET TRANSACTION READ ONLY` issued after `BEGIN`, which the four-layer
  approach replaced. The two connection tools report the configured host
  verbatim, which is deliberate but was undocumented, and the display name
  falls back to a masked connection string that still carries the host when a
  database has no configured name.

- **`pl-func` requirements** — need both `CREATE` on the schema and the
  language listed in `allowed_pl_languages`; only the privilege was documented,
  and a tool whose language is not allowed never appears in `tools/list` rather
  than failing visibly.

- **Pool defaults** — `pool_health_check_period` was documented as disabled. It
  inherits pgx's one minute, or thirty seconds when a database configures
  multiple hosts, which is also where `pool_max_conn_lifetime` drops from an
  hour to five minutes.

## Where this departs from the issue

The issue's second and fifth items ask for the rate limiter's spoofable client
address to be written up as a known limitation, and for a note saying the
recommended nginx configuration does not solve it. #205 fixes the behaviour and
documents the replacement, so writing those up as limitations would have
committed prose we would immediately have to remove. Nothing else in the
checklist is affected.

The issue also records `allowed_pl_languages` as defaulting to none. It does
not: `context_aware_provider.go` falls back to `plpgsql`, so the existing claim
in the custom definitions guide is correct and stays, whilst the configuration
reference, which said "none", is corrected.

## Test plan

- [x] `mkdocs build --strict` passes.
- [x] Every internal link and heading anchor added by this branch resolves,
      checked programmatically rather than by eye; two anchors were wrong on
      the first pass and are fixed.
- [x] `make test` passes in full (21 packages, exit 0) — the regenerated spec
      is not consumed by any test, so this only confirms nothing else broke.
- [x] Added prose wraps at 79 characters, the exceptions being table rows, the
      generated JSON, and one Server-Sent Events `data:` line that cannot be
      wrapped without misrepresenting the protocol.

Closes #202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation for the new `count_rows` tool to help agents estimate table row counts with optional `where` filtering.

* **Documentation**
  * Updated LLM proxy guide and OpenAPI contract to the versioned `/api/llm/v1/` API, including streaming (SSE), typed content blocks, and structured tool calls; added `/v1/chat/stream` and `/v1/health`, and updated provider/model discovery.
  * Clarified authentication exceptions (including permanent account lockout recovery) and expanded read-only protection behavior.
  * Refreshed database/multi-connection configuration defaults (e.g., `allowed_pl_languages` default to `plpgsql`, pooling defaults) and improved tool/security guidance, including custom tool runtime requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->