### PR TITLE
fix(security): refresh nla-cli Trivy ignore list

### DIFF
--- a/.trivy/nla-cli.trivyignore.yaml
+++ b/.trivy/nla-cli.trivyignore.yaml
@@ -1,17 +1,56 @@
 vulnerabilities:
   # coreutils-single - Present in UBI9 micro base image.
-  - id: CVE-2025-5278
+  - id: CVE-2026-56391
     statement: >-
-      Heap buffer under-read in coreutils sort. No fix available. The
-      CLI container does not invoke sort with untrusted input.
+      GNU coreutils uniq out-of-bounds read with multibyte input via -w.
+      No fix available. The CLI does not invoke coreutils uniq.
+  - id: CVE-2026-56392
+    statement: >-
+      GNU coreutils unexpand heap buffer overflow via crafted -t tab stop
+      values. No fix available. The CLI does not invoke coreutils
+      unexpand.
 
-  # glibc - Core C library in UBI9 base image.
-  - id: CVE-2026-4046
+  # libattr - Present in UBI9 micro base image.
+  - id: CVE-2026-54371
     statement: >-
-      glibc DoS via iconv() with specific character sets. Under
-      investigation by Red Hat. Risk accepted; the CLI uses the Go
-      runtime for string processing, not glibc iconv.
-  - id: CVE-2026-4437
+      attr symlink traversal privilege escalation via getfattr/setfattr.
+      No fix available. The CLI does not invoke getfattr or setfattr and
+      requires local attacker access to a shared pathname component to
+      exploit, which does not apply to this container.
+
+  # libgcc - Present in UBI9 micro base image.
+  - id: CVE-2021-46195
     statement: >-
-      glibc incorrect DNS response parsing. No fix available. Risk
-      accepted; DNS resolution is handled by the Go runtime, not glibc.
+      GCC libiberty uncontrolled recursion in rust-demangle.c. No fix
+      available. The CLI is a statically linked Go binary and does not
+      invoke libiberty demangling.
+  - id: CVE-2022-27943
+    statement: >-
+      GCC libiberty stack exhaustion in demangle_const. No fix available.
+      The CLI is a statically linked Go binary and does not invoke
+      libiberty demangling.
+
+  # ncurses-base / ncurses-libs - Present in UBI9 micro base image.
+  - id: CVE-2023-50495
+    statement: >-
+      ncurses segmentation fault via _nc_wrap_entry(). No fix available.
+      The CLI does not use ncurses or terminfo APIs.
+
+  # pcre2 / pcre2-syntax - Present in UBI9 micro base image.
+  - id: CVE-2022-41409
+    statement: >-
+      pcre2test integer overflow via negative repeat value. No fix
+      available. The CLI does not invoke pcre2test or link against
+      pcre2 directly; it is a statically linked Go binary.
+
+  # golang.org/x/crypto - openpgp package flagged as unmaintained.
+  - id: GO-2026-5932
+    purls:
+      - "pkg:golang/golang.org/x/crypto@v0.54.0"
+    statement: >-
+      golang.org/x/crypto/openpgp is unmaintained and flagged unsafe by
+      design. Not a CVE with a fix version; it is an advisory against the
+      package's continued use. The CLI only imports golang.org/x/crypto/
+      bcrypt (internal/auth/users.go); it does not import or call the
+      openpgp package. Verified with `govulncheck ./cmd/pgedge-pg-mcp-cli/
+      ...`: 0 reachable vulnerabilities.

--- a/.trivy/nla-cli.trivyignore.yaml
+++ b/.trivy/nla-cli.trivyignore.yaml
@@ -1,10 +1,16 @@
 vulnerabilities:
   # coreutils-single - Present in UBI9 micro base image.
   - id: CVE-2026-56391
+    purls:
+      - "pkg:rpm/redhat/coreutils-single@8.32-41.el9_8"
+    expired_at: 2026-11-02T00:00:00Z
     statement: >-
       GNU coreutils uniq out-of-bounds read with multibyte input via -w.
       No fix available. The CLI does not invoke coreutils uniq.
   - id: CVE-2026-56392
+    purls:
+      - "pkg:rpm/redhat/coreutils-single@8.32-41.el9_8"
+    expired_at: 2026-11-02T00:00:00Z
     statement: >-
       GNU coreutils unexpand heap buffer overflow via crafted -t tab stop
       values. No fix available. The CLI does not invoke coreutils
@@ -12,6 +18,9 @@ vulnerabilities:
 
   # libattr - Present in UBI9 micro base image.
   - id: CVE-2026-54371
+    purls:
+      - "pkg:rpm/redhat/libattr@2.5.1-3.el9"
+    expired_at: 2026-11-02T00:00:00Z
     statement: >-
       attr symlink traversal privilege escalation via getfattr/setfattr.
       No fix available. The CLI does not invoke getfattr or setfattr and
@@ -20,11 +29,17 @@ vulnerabilities:
 
   # libgcc - Present in UBI9 micro base image.
   - id: CVE-2021-46195
+    purls:
+      - "pkg:rpm/redhat/libgcc@11.5.0-14.el9"
+    expired_at: 2026-11-02T00:00:00Z
     statement: >-
       GCC libiberty uncontrolled recursion in rust-demangle.c. No fix
       available. The CLI is a statically linked Go binary and does not
       invoke libiberty demangling.
   - id: CVE-2022-27943
+    purls:
+      - "pkg:rpm/redhat/libgcc@11.5.0-14.el9"
+    expired_at: 2026-11-02T00:00:00Z
     statement: >-
       GCC libiberty stack exhaustion in demangle_const. No fix available.
       The CLI is a statically linked Go binary and does not invoke
@@ -32,12 +47,20 @@ vulnerabilities:
 
   # ncurses-base / ncurses-libs - Present in UBI9 micro base image.
   - id: CVE-2023-50495
+    purls:
+      - "pkg:rpm/redhat/ncurses-base@6.2-12.20210508.el9"
+      - "pkg:rpm/redhat/ncurses-libs@6.2-12.20210508.el9"
+    expired_at: 2026-11-02T00:00:00Z
     statement: >-
       ncurses segmentation fault via _nc_wrap_entry(). No fix available.
       The CLI does not use ncurses or terminfo APIs.
 
   # pcre2 / pcre2-syntax - Present in UBI9 micro base image.
   - id: CVE-2022-41409
+    purls:
+      - "pkg:rpm/redhat/pcre2@10.40-6.el9"
+      - "pkg:rpm/redhat/pcre2-syntax@10.40-6.el9"
+    expired_at: 2026-11-02T00:00:00Z
     statement: >-
       pcre2test integer overflow via negative repeat value. No fix
       available. The CLI does not invoke pcre2test or link against
@@ -47,6 +70,7 @@ vulnerabilities:
   - id: GO-2026-5932
     purls:
       - "pkg:golang/golang.org/x/crypto@v0.54.0"
+    expired_at: 2026-11-02T00:00:00Z
     statement: >-
       golang.org/x/crypto/openpgp is unmaintained and flagged unsafe by
       design. Not a CVE with a fix version; it is an advisory against the


### PR DESCRIPTION
## What this fixes

A security scan of the published command-line tool image flagged 27
High, 32 Medium, and 10 Low warnings.

Rebuilding the tool from the current version, with no code changes,
already fixes every one of these — they were all caused by software
updates that had already happened but hadn't made it into a new build
of this image yet.

## What was left

A fresh scan of the rebuilt image shows only 10 minor warnings left:

- 9 are in small pieces of the base operating system that this tool
  doesn't actually use (no fix is available for these from the vendor
  yet, and none apply here).
- 1 is an advisory flagging an old, unmaintained piece of an encryption
  library as something people shouldn't use going forward. It's not a
  security bug with a fix — it's a "don't use this anymore" notice.
  Checked the tool's code directly: it only uses a different, unrelated
  part of that same library, never the flagged part.

Each of these is documented with a specific, checkable reason rather
than a generic one.

## Results

Scanning the newly built image against the updated list of "checked,
doesn't apply" items shows zero warnings, at every severity level.

## What this doesn't do

This doesn't publish a new version of the image — that's a separate
release step. The already-published image is unaffected until that
happens.
https://pgedge.atlassian.net/browse/PLAT-703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scan exceptions for several packages and components.
  * Added expiration dates, vulnerability details, and usage rationale to the updated entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->