### PR TITLE
fix: return tools/prompts/resources in a deterministic sorted order

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -161,6 +161,21 @@ and this project adheres to
   `httperror`, `llmtracing`, `logging`, `prompts`, `search` and `tsv`. All of
   them pass; they were simply never run.
 
+- `tools/list`, `prompts/list`, and `resources/list` now return their
+  entries in a stable, sorted order on every call. Each registry stored
+  its entries in a Go map and built the response by iterating it
+  directly, so the order was randomised by the runtime and changed from
+  one call to the next even when the underlying set was unchanged. Tool,
+  prompt, and resource definitions sit at the front of the prompt sent to
+  the model, so the reshuffling invalidated the provider-side prompt
+  cache on every request rather than only when the set actually changed,
+  and it defeated client-side diffing of the advertised list for the
+  same reason. `Registry.List()` in each of `internal/tools`,
+  `internal/prompts`, and `internal/resources` now sorts by name (tools,
+  prompts) or URI (resources) before returning; `ContextAwareRegistry.List()`
+  in `internal/resources`, which merges a fixed built-in entry with a map
+  of custom resources, sorts its combined result the same way. Fixes #211.
+
 ### Added
 
 - A `make vulncheck` target runs `govulncheck` over the module, using

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -174,7 +174,15 @@ and this project adheres to
   `internal/prompts`, and `internal/resources` now sorts by name (tools,
   prompts) or URI (resources) before returning; `ContextAwareRegistry.List()`
   in `internal/resources`, which merges a fixed built-in entry with a map
-  of custom resources, sorts its combined result the same way. Fixes #211.
+  of custom resources, sorts its combined result the same way. Every
+  registration is keyed by its own name or URI in this codebase today,
+  so the sort has no ties to break in practice, but the comparison also
+  falls back to the registration key, which is unique by construction:
+  `sort.Slice` gives no ordering guarantee between two entries that
+  compare equal, so a future entry whose Definition happened to
+  advertise the same name or URI as another under a different key would
+  otherwise be exactly as nondeterministic as before this fix. Fixes
+  #211.
 
 ### Added
 

--- a/internal/prompts/registry.go
+++ b/internal/prompts/registry.go
@@ -46,12 +46,17 @@ func (r *Registry) Get(name string) (Prompt, bool) {
 	return prompt, exists
 }
 
-// List returns all registered prompt definitions
+// List returns all registered prompt definitions, sorted by name for a
+// deterministic order across calls; see the tool registry's List for why
+// this matters for prompt caching.
 func (r *Registry) List() []mcp.Prompt {
 	prompts := make([]mcp.Prompt, 0, len(r.prompts))
 	for _, prompt := range r.prompts {
 		prompts = append(prompts, prompt.Definition)
 	}
+	sort.Slice(prompts, func(i, j int) bool {
+		return prompts[i].Name < prompts[j].Name
+	})
 	return prompts
 }
 

--- a/internal/prompts/registry.go
+++ b/internal/prompts/registry.go
@@ -49,14 +49,30 @@ func (r *Registry) Get(name string) (Prompt, bool) {
 // List returns all registered prompt definitions, sorted by name for a
 // deterministic order across calls; see the tool registry's List for why
 // this matters for prompt caching.
+//
+// The registration key breaks ties, since it is unique by construction
+// even in the case, not exercised by any caller today, of two entries
+// advertising the same Definition.Name under different keys: sort.Slice
+// gives no ordering guarantee for elements that compare equal.
 func (r *Registry) List() []mcp.Prompt {
-	prompts := make([]mcp.Prompt, 0, len(r.prompts))
-	for _, prompt := range r.prompts {
-		prompts = append(prompts, prompt.Definition)
+	type keyed struct {
+		key    string
+		prompt mcp.Prompt
 	}
-	sort.Slice(prompts, func(i, j int) bool {
-		return prompts[i].Name < prompts[j].Name
+	entries := make([]keyed, 0, len(r.prompts))
+	for key, prompt := range r.prompts {
+		entries = append(entries, keyed{key, prompt.Definition})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].prompt.Name != entries[j].prompt.Name {
+			return entries[i].prompt.Name < entries[j].prompt.Name
+		}
+		return entries[i].key < entries[j].key
 	})
+	prompts := make([]mcp.Prompt, len(entries))
+	for i, e := range entries {
+		prompts[i] = e.prompt
+	}
 	return prompts
 }
 

--- a/internal/prompts/registry_test.go
+++ b/internal/prompts/registry_test.go
@@ -125,8 +125,12 @@ func TestList_DeterministicOrder(t *testing.T) {
 // by construction.
 func TestList_DeterministicOrder_EqualNames(t *testing.T) {
 	registry := NewRegistry()
-	registry.prompts["key_b"] = Prompt{Definition: mcp.Prompt{Name: "dup", Description: "second"}}
-	registry.prompts["key_a"] = Prompt{Definition: mcp.Prompt{Name: "dup", Description: "first"}}
+	// Descriptions are deliberately the inverse of key order ("key_a" <
+	// "key_b", but its Description, "second", sorts after "first"), so a
+	// tiebreak that accidentally used Description instead of the
+	// registration key would produce the opposite -- and wrong -- order.
+	registry.prompts["key_b"] = Prompt{Definition: mcp.Prompt{Name: "dup", Description: "first"}}
+	registry.prompts["key_a"] = Prompt{Definition: mcp.Prompt{Name: "dup", Description: "second"}}
 	registry.prompts["zzz"] = Prompt{Definition: mcp.Prompt{Name: "zzz"}}
 
 	descOrder := func(prompts []mcp.Prompt) []string {
@@ -139,13 +143,11 @@ func TestList_DeterministicOrder_EqualNames(t *testing.T) {
 		return out
 	}
 
-	first := registry.List()
-	firstOrder := descOrder(first)
+	want := []string{"second", "first"} // key_a, key_b
 	for i := 0; i < 50; i++ {
-		next := registry.List()
-		nextOrder := descOrder(next)
-		if len(nextOrder) != 2 || nextOrder[0] != firstOrder[0] || nextOrder[1] != firstOrder[1] {
-			t.Fatalf("relative order of equal-Name entries changed between calls: %v vs %v", firstOrder, nextOrder)
+		got := descOrder(registry.List())
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("relative order of equal-Name entries: got %v, want %v (key-sorted)", got, want)
 		}
 	}
 }

--- a/internal/prompts/registry_test.go
+++ b/internal/prompts/registry_test.go
@@ -13,6 +13,8 @@ package prompts
 import (
 	"strings"
 	"testing"
+
+	"pgedge-postgres-mcp/internal/mcp"
 )
 
 func TestNewRegistry(t *testing.T) {
@@ -110,6 +112,40 @@ func TestList_DeterministicOrder(t *testing.T) {
 			if first[j].Name != next[j].Name {
 				t.Fatalf("List() order changed between calls at index %d: %q vs %q", j, first[j].Name, next[j].Name)
 			}
+		}
+	}
+}
+
+// TestList_DeterministicOrder_EqualNames covers a case no current caller
+// triggers: two registrations under different keys whose Definitions both
+// advertise the same Name. sort.Slice gives no ordering guarantee between
+// elements that compare equal, so relying on Name alone would leave these
+// two entries' relative order exactly as nondeterministic as before the
+// fix. List() breaks the tie with the registration key, which is unique
+// by construction.
+func TestList_DeterministicOrder_EqualNames(t *testing.T) {
+	registry := NewRegistry()
+	registry.prompts["key_b"] = Prompt{Definition: mcp.Prompt{Name: "dup", Description: "second"}}
+	registry.prompts["key_a"] = Prompt{Definition: mcp.Prompt{Name: "dup", Description: "first"}}
+	registry.prompts["zzz"] = Prompt{Definition: mcp.Prompt{Name: "zzz"}}
+
+	descOrder := func(prompts []mcp.Prompt) []string {
+		out := []string{}
+		for _, prompt := range prompts {
+			if prompt.Name == "dup" {
+				out = append(out, prompt.Description)
+			}
+		}
+		return out
+	}
+
+	first := registry.List()
+	firstOrder := descOrder(first)
+	for i := 0; i < 50; i++ {
+		next := registry.List()
+		nextOrder := descOrder(next)
+		if len(nextOrder) != 2 || nextOrder[0] != firstOrder[0] || nextOrder[1] != firstOrder[1] {
+			t.Fatalf("relative order of equal-Name entries changed between calls: %v vs %v", firstOrder, nextOrder)
 		}
 	}
 }

--- a/internal/prompts/registry_test.go
+++ b/internal/prompts/registry_test.go
@@ -85,6 +85,35 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestList_DeterministicOrder(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register("setup-semantic-search", SetupSemanticSearch())
+	registry.Register("explore-database", ExploreDatabase())
+	registry.Register("diagnose-query-issue", DiagnoseQueryIssue())
+	registry.Register("design-schema", DesignSchema())
+
+	first := registry.List()
+	for i := 1; i < len(first); i++ {
+		if first[i-1].Name > first[i].Name {
+			t.Fatalf("List() is not sorted: %q appears before %q", first[i-1].Name, first[i].Name)
+		}
+	}
+
+	// A single call cannot detect nondeterministic map iteration on its
+	// own; call repeatedly and require every call to match the first.
+	for i := 0; i < 50; i++ {
+		next := registry.List()
+		if len(next) != len(first) {
+			t.Fatalf("List() length changed between calls: %d vs %d", len(first), len(next))
+		}
+		for j := range first {
+			if first[j].Name != next[j].Name {
+				t.Fatalf("List() order changed between calls at index %d: %q vs %q", j, first[j].Name, next[j].Name)
+			}
+		}
+	}
+}
+
 func TestExecute(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register("setup-semantic-search", SetupSemanticSearch())

--- a/internal/resources/context_aware_registry.go
+++ b/internal/resources/context_aware_registry.go
@@ -13,6 +13,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"pgedge-postgres-mcp/internal/auth"
 	"pgedge-postgres-mcp/internal/config"
@@ -68,6 +69,14 @@ func (r *ContextAwareRegistry) List() []mcp.Resource {
 	for _, customRes := range r.customResources {
 		resources = append(resources, customRes.definition)
 	}
+
+	// Sort by URI for a deterministic order across calls: customResources
+	// above is a map, so its iteration order is randomised per call, and an
+	// unsorted list changes on every tools/list, invalidating the
+	// provider-side prompt cache and any client-side diffing of the set.
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].URI < resources[j].URI
+	})
 
 	return resources
 }

--- a/internal/resources/context_aware_registry.go
+++ b/internal/resources/context_aware_registry.go
@@ -52,31 +52,53 @@ func NewContextAwareRegistry(clientManager *database.ClientManager, authEnabled 
 }
 
 // List returns all available resource definitions
+//
+// Sorted by URI for a deterministic order across calls: customResources
+// below is a map, so its iteration order is randomised per call, and an
+// unsorted list changes on every tools/list, invalidating the
+// provider-side prompt cache and any client-side diffing of the set.
+//
+// The registration key (the built-in entry's own URI, or a custom
+// resource's map key) breaks ties, since it is unique by construction
+// even in the case, not exercised by any caller today, of two entries
+// advertising the same URI under different keys: sort.Slice gives no
+// ordering guarantee for elements that compare equal.
 func (r *ContextAwareRegistry) List() []mcp.Resource {
-	// Start with static built-in resources (only include enabled ones)
-	resources := []mcp.Resource{}
+	type keyed struct {
+		key      string
+		resource mcp.Resource
+	}
+	entries := []keyed{}
 
+	// Start with static built-in resources (only include enabled ones)
 	if r.cfg.Builtins.Resources.IsResourceEnabled(URISystemInfo) {
-		resources = append(resources, mcp.Resource{
-			URI:         URISystemInfo,
-			Name:        "postgresql_system_info",
-			Description: "Returns PostgreSQL version, operating system, and build architecture information. Provides a quick way to check server version and platform details.",
-			MimeType:    "application/json",
+		entries = append(entries, keyed{
+			key: URISystemInfo,
+			resource: mcp.Resource{
+				URI:         URISystemInfo,
+				Name:        "postgresql_system_info",
+				Description: "Returns PostgreSQL version, operating system, and build architecture information. Provides a quick way to check server version and platform details.",
+				MimeType:    "application/json",
+			},
 		})
 	}
 
 	// Add custom resources
-	for _, customRes := range r.customResources {
-		resources = append(resources, customRes.definition)
+	for key, customRes := range r.customResources {
+		entries = append(entries, keyed{key: key, resource: customRes.definition})
 	}
 
-	// Sort by URI for a deterministic order across calls: customResources
-	// above is a map, so its iteration order is randomised per call, and an
-	// unsorted list changes on every tools/list, invalidating the
-	// provider-side prompt cache and any client-side diffing of the set.
-	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].URI < resources[j].URI
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].resource.URI != entries[j].resource.URI {
+			return entries[i].resource.URI < entries[j].resource.URI
+		}
+		return entries[i].key < entries[j].key
 	})
+
+	resources := make([]mcp.Resource, len(entries))
+	for i, e := range entries {
+		resources[i] = e.resource
+	}
 
 	return resources
 }

--- a/internal/resources/context_aware_registry_test.go
+++ b/internal/resources/context_aware_registry_test.go
@@ -184,8 +184,12 @@ func TestContextAwareRegistry_List_DeterministicOrder_EqualURIs(t *testing.T) {
 	}
 
 	registry := NewContextAwareRegistry(cm, false, nil, cfg)
-	registry.customResources["key_b"] = customResource{definition: mcp.Resource{URI: "dup", Description: "second"}}
-	registry.customResources["key_a"] = customResource{definition: mcp.Resource{URI: "dup", Description: "first"}}
+	// Descriptions are deliberately the inverse of key order ("key_a" <
+	// "key_b", but its Description, "second", sorts after "first"), so a
+	// tiebreak that accidentally used Description instead of the
+	// registration key would produce the opposite -- and wrong -- order.
+	registry.customResources["key_b"] = customResource{definition: mcp.Resource{URI: "dup", Description: "first"}}
+	registry.customResources["key_a"] = customResource{definition: mcp.Resource{URI: "dup", Description: "second"}}
 	registry.customResources["zzz"] = customResource{definition: mcp.Resource{URI: "zzz"}}
 
 	descOrder := func(resources []mcp.Resource) []string {
@@ -198,13 +202,11 @@ func TestContextAwareRegistry_List_DeterministicOrder_EqualURIs(t *testing.T) {
 		return out
 	}
 
-	first := registry.List()
-	firstOrder := descOrder(first)
+	want := []string{"second", "first"} // key_a, key_b
 	for i := 0; i < 50; i++ {
-		next := registry.List()
-		nextOrder := descOrder(next)
-		if len(nextOrder) != 2 || nextOrder[0] != firstOrder[0] || nextOrder[1] != firstOrder[1] {
-			t.Fatalf("relative order of equal-URI entries changed between calls: %v vs %v", firstOrder, nextOrder)
+		got := descOrder(registry.List())
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("relative order of equal-URI entries: got %v, want %v (key-sorted)", got, want)
 		}
 	}
 }

--- a/internal/resources/context_aware_registry_test.go
+++ b/internal/resources/context_aware_registry_test.go
@@ -18,6 +18,7 @@ import (
 	"pgedge-postgres-mcp/internal/auth"
 	conf "pgedge-postgres-mcp/internal/config"
 	"pgedge-postgres-mcp/internal/database"
+	"pgedge-postgres-mcp/internal/definitions"
 )
 
 // skipIfNoDatabase skips the test if no test database connection is available.
@@ -112,6 +113,56 @@ func TestContextAwareRegistry_List(t *testing.T) {
 			t.Error("expected URISystemInfo to be disabled")
 		}
 	})
+}
+
+func TestContextAwareRegistry_List_DeterministicOrder(t *testing.T) {
+	cm := database.NewClientManager([]conf.NamedDatabaseConfig{
+		{Name: "db1", Host: "localhost", Port: 5432, Database: "test1"},
+	})
+	cfg := &conf.Config{
+		Builtins: conf.BuiltinsConfig{
+			Resources: conf.ResourcesConfig{
+				SystemInfo: boolPtr(true),
+			},
+		},
+	}
+
+	registry := NewContextAwareRegistry(cm, false, nil, cfg)
+
+	uris := []string{"pg://custom/zebra", "pg://custom/apple", "pg://custom/mango", "pg://custom/banana", "pg://custom/cherry"}
+	for _, uri := range uris {
+		def := definitions.ResourceDefinition{
+			URI:      uri,
+			Name:     uri,
+			Type:     "static",
+			MimeType: "application/json",
+			Data:     map[string]interface{}{"key": "value"},
+		}
+		if err := registry.RegisterStatic(def); err != nil {
+			t.Fatalf("RegisterStatic(%q) failed: %v", uri, err)
+		}
+	}
+
+	first := registry.List()
+	for i := 1; i < len(first); i++ {
+		if first[i-1].URI > first[i].URI {
+			t.Fatalf("List() is not sorted: %q appears before %q", first[i-1].URI, first[i].URI)
+		}
+	}
+
+	// A single call cannot detect nondeterministic map iteration on its
+	// own; call repeatedly and require every call to match the first.
+	for i := 0; i < 50; i++ {
+		next := registry.List()
+		if len(next) != len(first) {
+			t.Fatalf("List() length changed between calls: %d vs %d", len(first), len(next))
+		}
+		for j := range first {
+			if first[j].URI != next[j].URI {
+				t.Fatalf("List() order changed between calls at index %d: %q vs %q", j, first[j].URI, next[j].URI)
+			}
+		}
+	}
 }
 
 func TestContextAwareRegistry_Read_DisabledResource(t *testing.T) {

--- a/internal/resources/context_aware_registry_test.go
+++ b/internal/resources/context_aware_registry_test.go
@@ -19,6 +19,7 @@ import (
 	conf "pgedge-postgres-mcp/internal/config"
 	"pgedge-postgres-mcp/internal/database"
 	"pgedge-postgres-mcp/internal/definitions"
+	"pgedge-postgres-mcp/internal/mcp"
 )
 
 // skipIfNoDatabase skips the test if no test database connection is available.
@@ -161,6 +162,49 @@ func TestContextAwareRegistry_List_DeterministicOrder(t *testing.T) {
 			if first[j].URI != next[j].URI {
 				t.Fatalf("List() order changed between calls at index %d: %q vs %q", j, first[j].URI, next[j].URI)
 			}
+		}
+	}
+}
+
+// TestContextAwareRegistry_List_DeterministicOrder_EqualURIs covers a case
+// no current caller triggers: two custom resources registered under
+// different keys whose Definitions both advertise the same URI.
+// sort.Slice gives no ordering guarantee between elements that compare
+// equal, so relying on URI alone would leave these two entries' relative
+// order exactly as nondeterministic as before the fix. List() breaks the
+// tie with the registration key, which is unique by construction.
+func TestContextAwareRegistry_List_DeterministicOrder_EqualURIs(t *testing.T) {
+	cm := database.NewClientManager([]conf.NamedDatabaseConfig{})
+	cfg := &conf.Config{
+		Builtins: conf.BuiltinsConfig{
+			Resources: conf.ResourcesConfig{
+				SystemInfo: boolPtr(false),
+			},
+		},
+	}
+
+	registry := NewContextAwareRegistry(cm, false, nil, cfg)
+	registry.customResources["key_b"] = customResource{definition: mcp.Resource{URI: "dup", Description: "second"}}
+	registry.customResources["key_a"] = customResource{definition: mcp.Resource{URI: "dup", Description: "first"}}
+	registry.customResources["zzz"] = customResource{definition: mcp.Resource{URI: "zzz"}}
+
+	descOrder := func(resources []mcp.Resource) []string {
+		out := []string{}
+		for _, resource := range resources {
+			if resource.URI == "dup" {
+				out = append(out, resource.Description)
+			}
+		}
+		return out
+	}
+
+	first := registry.List()
+	firstOrder := descOrder(first)
+	for i := 0; i < 50; i++ {
+		next := registry.List()
+		nextOrder := descOrder(next)
+		if len(nextOrder) != 2 || nextOrder[0] != firstOrder[0] || nextOrder[1] != firstOrder[1] {
+			t.Fatalf("relative order of equal-URI entries changed between calls: %v vs %v", firstOrder, nextOrder)
 		}
 	}
 }

--- a/internal/resources/registry.go
+++ b/internal/resources/registry.go
@@ -12,6 +12,7 @@ package resources
 
 import (
 	"context"
+	"sort"
 
 	"pgedge-postgres-mcp/internal/mcp"
 )
@@ -48,12 +49,17 @@ func (r *Registry) Get(uri string) (Resource, bool) {
 	return resource, exists
 }
 
-// List returns all registered resource definitions
+// List returns all registered resource definitions, sorted by URI for a
+// deterministic order across calls; see the tool registry's List for why
+// this matters for prompt caching.
 func (r *Registry) List() []mcp.Resource {
 	resources := make([]mcp.Resource, 0, len(r.resources))
 	for _, resource := range r.resources {
 		resources = append(resources, resource.Definition)
 	}
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].URI < resources[j].URI
+	})
 	return resources
 }
 

--- a/internal/resources/registry.go
+++ b/internal/resources/registry.go
@@ -52,14 +52,30 @@ func (r *Registry) Get(uri string) (Resource, bool) {
 // List returns all registered resource definitions, sorted by URI for a
 // deterministic order across calls; see the tool registry's List for why
 // this matters for prompt caching.
+//
+// The registration key breaks ties, since it is unique by construction
+// even in the case, not exercised by any caller today, of two entries
+// advertising the same Definition.URI under different keys: sort.Slice
+// gives no ordering guarantee for elements that compare equal.
 func (r *Registry) List() []mcp.Resource {
-	resources := make([]mcp.Resource, 0, len(r.resources))
-	for _, resource := range r.resources {
-		resources = append(resources, resource.Definition)
+	type keyed struct {
+		key      string
+		resource mcp.Resource
 	}
-	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].URI < resources[j].URI
+	entries := make([]keyed, 0, len(r.resources))
+	for key, resource := range r.resources {
+		entries = append(entries, keyed{key, resource.Definition})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].resource.URI != entries[j].resource.URI {
+			return entries[i].resource.URI < entries[j].resource.URI
+		}
+		return entries[i].key < entries[j].key
 	})
+	resources := make([]mcp.Resource, len(entries))
+	for i, e := range entries {
+		resources[i] = e.resource
+	}
 	return resources
 }
 

--- a/internal/resources/registry_test.go
+++ b/internal/resources/registry_test.go
@@ -157,6 +157,41 @@ func TestList(t *testing.T) {
 	})
 }
 
+func TestList_DeterministicOrder(t *testing.T) {
+	registry := NewRegistry()
+
+	uris := []string{"resource://zebra", "resource://apple", "resource://mango", "resource://banana", "resource://cherry"}
+	for _, uri := range uris {
+		registry.Register(uri, Resource{
+			Definition: mcp.Resource{URI: uri},
+			Handler: func() (mcp.ResourceContent, error) {
+				return mcp.ResourceContent{}, nil
+			},
+		})
+	}
+
+	first := registry.List()
+	for i := 1; i < len(first); i++ {
+		if first[i-1].URI > first[i].URI {
+			t.Fatalf("List() is not sorted: %q appears before %q", first[i-1].URI, first[i].URI)
+		}
+	}
+
+	// A single call cannot detect nondeterministic map iteration on its
+	// own; call repeatedly and require every call to match the first.
+	for i := 0; i < 50; i++ {
+		next := registry.List()
+		if len(next) != len(first) {
+			t.Fatalf("List() length changed between calls: %d vs %d", len(first), len(next))
+		}
+		for j := range first {
+			if first[j].URI != next[j].URI {
+				t.Fatalf("List() order changed between calls at index %d: %q vs %q", j, first[j].URI, next[j].URI)
+			}
+		}
+	}
+}
+
 func TestRead(t *testing.T) {
 	registry := NewRegistry()
 

--- a/internal/resources/registry_test.go
+++ b/internal/resources/registry_test.go
@@ -192,6 +192,40 @@ func TestList_DeterministicOrder(t *testing.T) {
 	}
 }
 
+// TestList_DeterministicOrder_EqualURIs covers a case no current caller
+// triggers: two registrations under different keys whose Definitions both
+// advertise the same URI. sort.Slice gives no ordering guarantee between
+// elements that compare equal, so relying on URI alone would leave these
+// two entries' relative order exactly as nondeterministic as before the
+// fix. List() breaks the tie with the registration key, which is unique
+// by construction.
+func TestList_DeterministicOrder_EqualURIs(t *testing.T) {
+	registry := NewRegistry()
+	registry.resources["key_b"] = Resource{Definition: mcp.Resource{URI: "dup", Description: "second"}}
+	registry.resources["key_a"] = Resource{Definition: mcp.Resource{URI: "dup", Description: "first"}}
+	registry.resources["zzz"] = Resource{Definition: mcp.Resource{URI: "zzz"}}
+
+	descOrder := func(resources []mcp.Resource) []string {
+		out := []string{}
+		for _, resource := range resources {
+			if resource.URI == "dup" {
+				out = append(out, resource.Description)
+			}
+		}
+		return out
+	}
+
+	first := registry.List()
+	firstOrder := descOrder(first)
+	for i := 0; i < 50; i++ {
+		next := registry.List()
+		nextOrder := descOrder(next)
+		if len(nextOrder) != 2 || nextOrder[0] != firstOrder[0] || nextOrder[1] != firstOrder[1] {
+			t.Fatalf("relative order of equal-URI entries changed between calls: %v vs %v", firstOrder, nextOrder)
+		}
+	}
+}
+
 func TestRead(t *testing.T) {
 	registry := NewRegistry()
 

--- a/internal/resources/registry_test.go
+++ b/internal/resources/registry_test.go
@@ -201,8 +201,12 @@ func TestList_DeterministicOrder(t *testing.T) {
 // by construction.
 func TestList_DeterministicOrder_EqualURIs(t *testing.T) {
 	registry := NewRegistry()
-	registry.resources["key_b"] = Resource{Definition: mcp.Resource{URI: "dup", Description: "second"}}
-	registry.resources["key_a"] = Resource{Definition: mcp.Resource{URI: "dup", Description: "first"}}
+	// Descriptions are deliberately the inverse of key order ("key_a" <
+	// "key_b", but its Description, "second", sorts after "first"), so a
+	// tiebreak that accidentally used Description instead of the
+	// registration key would produce the opposite -- and wrong -- order.
+	registry.resources["key_b"] = Resource{Definition: mcp.Resource{URI: "dup", Description: "first"}}
+	registry.resources["key_a"] = Resource{Definition: mcp.Resource{URI: "dup", Description: "second"}}
 	registry.resources["zzz"] = Resource{Definition: mcp.Resource{URI: "zzz"}}
 
 	descOrder := func(resources []mcp.Resource) []string {
@@ -215,13 +219,11 @@ func TestList_DeterministicOrder_EqualURIs(t *testing.T) {
 		return out
 	}
 
-	first := registry.List()
-	firstOrder := descOrder(first)
+	want := []string{"second", "first"} // key_a, key_b
 	for i := 0; i < 50; i++ {
-		next := registry.List()
-		nextOrder := descOrder(next)
-		if len(nextOrder) != 2 || nextOrder[0] != firstOrder[0] || nextOrder[1] != firstOrder[1] {
-			t.Fatalf("relative order of equal-URI entries changed between calls: %v vs %v", firstOrder, nextOrder)
+		got := descOrder(registry.List())
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("relative order of equal-URI entries: got %v, want %v (key-sorted)", got, want)
 		}
 	}
 }

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -12,6 +12,7 @@ package tools
 
 import (
 	"context"
+	"sort"
 
 	"pgedge-postgres-mcp/internal/mcp"
 )
@@ -48,12 +49,19 @@ func (r *Registry) Get(name string) (Tool, bool) {
 	return tool, exists
 }
 
-// List returns all registered tool definitions
+// List returns all registered tool definitions, sorted by name for a
+// deterministic order across calls. tools/list feeds the front of the
+// prompt sent to the model, so a reshuffled list invalidates the
+// provider-side prompt cache and defeats client-side diffing of the
+// advertised set, even when it has not actually changed.
 func (r *Registry) List() []mcp.Tool {
 	tools := make([]mcp.Tool, 0, len(r.tools))
 	for _, tool := range r.tools {
 		tools = append(tools, tool.Definition)
 	}
+	sort.Slice(tools, func(i, j int) bool {
+		return tools[i].Name < tools[j].Name
+	})
 	return tools
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -54,14 +54,33 @@ func (r *Registry) Get(name string) (Tool, bool) {
 // prompt sent to the model, so a reshuffled list invalidates the
 // provider-side prompt cache and defeats client-side diffing of the
 // advertised set, even when it has not actually changed.
+//
+// The registration key breaks ties, since it is unique by construction
+// (it is a map key) even in the case, not exercised by any caller
+// today, of two entries advertising the same Definition.Name under
+// different keys: sort.Slice gives no ordering guarantee for elements
+// that compare equal, so relying on Name alone would leave those two
+// entries' relative order exactly as nondeterministic as before this
+// fix.
 func (r *Registry) List() []mcp.Tool {
-	tools := make([]mcp.Tool, 0, len(r.tools))
-	for _, tool := range r.tools {
-		tools = append(tools, tool.Definition)
+	type keyed struct {
+		key  string
+		tool mcp.Tool
 	}
-	sort.Slice(tools, func(i, j int) bool {
-		return tools[i].Name < tools[j].Name
+	entries := make([]keyed, 0, len(r.tools))
+	for key, tool := range r.tools {
+		entries = append(entries, keyed{key, tool.Definition})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].tool.Name != entries[j].tool.Name {
+			return entries[i].tool.Name < entries[j].tool.Name
+		}
+		return entries[i].key < entries[j].key
 	})
+	tools := make([]mcp.Tool, len(entries))
+	for i, e := range entries {
+		tools[i] = e.tool
+	}
 	return tools
 }
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -189,8 +189,12 @@ func TestList_DeterministicOrder(t *testing.T) {
 // by construction.
 func TestList_DeterministicOrder_EqualNames(t *testing.T) {
 	registry := NewRegistry()
-	registry.tools["key_b"] = Tool{Definition: mcp.Tool{Name: "dup", Description: "second"}}
-	registry.tools["key_a"] = Tool{Definition: mcp.Tool{Name: "dup", Description: "first"}}
+	// Descriptions are deliberately the inverse of key order ("key_a" <
+	// "key_b", but its Description, "second", sorts after "first"), so a
+	// tiebreak that accidentally used Description instead of the
+	// registration key would produce the opposite -- and wrong -- order.
+	registry.tools["key_b"] = Tool{Definition: mcp.Tool{Name: "dup", Description: "first"}}
+	registry.tools["key_a"] = Tool{Definition: mcp.Tool{Name: "dup", Description: "second"}}
 	registry.tools["zzz"] = Tool{Definition: mcp.Tool{Name: "zzz"}}
 
 	descOrder := func(tools []mcp.Tool) []string {
@@ -203,13 +207,11 @@ func TestList_DeterministicOrder_EqualNames(t *testing.T) {
 		return out
 	}
 
-	first := registry.List()
-	firstOrder := descOrder(first)
+	want := []string{"second", "first"} // key_a, key_b
 	for i := 0; i < 50; i++ {
-		next := registry.List()
-		nextOrder := descOrder(next)
-		if len(nextOrder) != 2 || nextOrder[0] != firstOrder[0] || nextOrder[1] != firstOrder[1] {
-			t.Fatalf("relative order of equal-Name entries changed between calls: %v vs %v", firstOrder, nextOrder)
+		got := descOrder(registry.List())
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("relative order of equal-Name entries: got %v, want %v (key-sorted)", got, want)
 		}
 	}
 }

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -149,6 +149,57 @@ func TestList(t *testing.T) {
 	})
 }
 
+func TestList_DeterministicOrder(t *testing.T) {
+	registry := NewRegistry()
+
+	names := []string{"zebra", "apple", "mango", "banana", "cherry", "date", "elder", "fig", "grape", "honey"}
+	for _, name := range names {
+		registry.Register(name, Tool{
+			Definition: mcp.Tool{Name: name},
+			Handler: func(args map[string]interface{}) (mcp.ToolResponse, error) {
+				return mcp.ToolResponse{}, nil
+			},
+		})
+	}
+
+	first := registry.List()
+	for i := 1; i < len(first); i++ {
+		if first[i-1].Name > first[i].Name {
+			t.Fatalf("List() is not sorted: %q appears before %q", first[i-1].Name, first[i].Name)
+		}
+	}
+
+	// A single call cannot detect nondeterministic map iteration on its
+	// own, since any one iteration order looks fine in isolation; call
+	// repeatedly and require every call to match the first exactly.
+	for i := 0; i < 50; i++ {
+		next := registry.List()
+		if !toolNamesEqual(first, next) {
+			t.Fatalf("List() order changed between calls: %v vs %v", toolNames(first), toolNames(next))
+		}
+	}
+}
+
+func toolNames(tools []mcp.Tool) []string {
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name
+	}
+	return names
+}
+
+func toolNamesEqual(a, b []mcp.Tool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
 func TestExecute(t *testing.T) {
 	registry := NewRegistry()
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -180,6 +180,40 @@ func TestList_DeterministicOrder(t *testing.T) {
 	}
 }
 
+// TestList_DeterministicOrder_EqualNames covers a case no current caller
+// triggers: two registrations under different keys whose Definitions both
+// advertise the same Name. sort.Slice gives no ordering guarantee between
+// elements that compare equal, so relying on Name alone would leave these
+// two entries' relative order exactly as nondeterministic as before the
+// fix. List() breaks the tie with the registration key, which is unique
+// by construction.
+func TestList_DeterministicOrder_EqualNames(t *testing.T) {
+	registry := NewRegistry()
+	registry.tools["key_b"] = Tool{Definition: mcp.Tool{Name: "dup", Description: "second"}}
+	registry.tools["key_a"] = Tool{Definition: mcp.Tool{Name: "dup", Description: "first"}}
+	registry.tools["zzz"] = Tool{Definition: mcp.Tool{Name: "zzz"}}
+
+	descOrder := func(tools []mcp.Tool) []string {
+		out := []string{}
+		for _, tool := range tools {
+			if tool.Name == "dup" {
+				out = append(out, tool.Description)
+			}
+		}
+		return out
+	}
+
+	first := registry.List()
+	firstOrder := descOrder(first)
+	for i := 0; i < 50; i++ {
+		next := registry.List()
+		nextOrder := descOrder(next)
+		if len(nextOrder) != 2 || nextOrder[0] != firstOrder[0] || nextOrder[1] != firstOrder[1] {
+			t.Fatalf("relative order of equal-Name entries changed between calls: %v vs %v", firstOrder, nextOrder)
+		}
+	}
+}
+
 func toolNames(tools []mcp.Tool) []string {
 	names := make([]string, len(tools))
 	for i, tool := range tools {


### PR DESCRIPTION
## Summary

`tools/list`, `prompts/list`, and `resources/list` returned entries in a
different order on every call, because each registry built its response by
iterating a Go map directly. Tool, prompt, and resource definitions sit at
the front of the prompt sent to the model, so the reshuffling invalidated
the provider-side prompt cache on every single request rather than only
when the advertised set actually changed, and it defeated client-side
diffing of the list for the same reason.

Fixes #211.

## Root cause

```go
func (r *Registry) List() []mcp.Tool {
    tools := make([]mcp.Tool, 0, len(r.tools))
    for _, tool := range r.tools {
        tools = append(tools, tool.Definition)
    }
    return tools
}
```

`r.tools` is a `map[string]Tool`. Go deliberately randomizes map iteration
order, so this produced a different slice order on every call. The same
pattern existed in three other places:

- `internal/tools/registry.go`
- `internal/prompts/registry.go`
- `internal/resources/registry.go`
- `internal/resources/context_aware_registry.go` (merges one fixed
  built-in entry with a map of custom resources)

## The fix

`List()` in each of the four places now sorts before returning: by name
for tools/prompts, by URI for resources. A follow-up CodeRabbit review
pointed out that sorting by name/URI alone still leaves the relative order
of two entries undefined if they ever advertised the *same* name/URI under
different registration keys, since `sort.Slice` gives no ordering
guarantee between elements that compare equal. I checked every `Register()`
call site in this codebase (built-in tools, custom tools, custom
resources) and confirmed the registration key is always identical to the
advertised name/URI today, so that scenario can't currently occur — but
added the registration key as a secondary sort field anyway, since it's
free (the tiebreak never activates for any caller today) and makes `List()`
provably deterministic for any future caller too.

## Does this affect the CLI or web client?

No visible output changed. Both clients already defended themselves
against this independently:

- CLI: `/list tools`, `/list resources`, and `/list prompts`
  (`internal/chat/commands.go`) already built a locally sorted copy before
  printing.
- Web: the only visible list is the prompt picker
  (`web/src/components/PromptPopover.jsx`), which already does
  `[...prompts].sort(...)` before rendering. Tools/resources are never
  rendered as a list in the web client at all.

The bug only cost prompt-cache efficiency — full input-token price on every
turn instead of only when the tool set changed — never correctness of what
a user saw on screen.

## Testing

- Added `TestList_DeterministicOrder` and
  `TestList_DeterministicOrder_EqualNames`/`EqualURIs` to all four
  registries, asserting sorted order across 50 repeated calls. Confirmed
  each fails reliably against the unfixed code and passes against the fix.
- Reproduced the bug against the actual running server before fixing it:
  15 real `tools/list` calls over HTTP against the unfixed binary came
  back in a different rotation almost every time. After the fix, 20 calls
  in a row — including with custom tools/resources loaded from a
  definitions file, mixed in among the built-ins — all return
  byte-identical JSON.
- Checked the stdio transport too: 15 independent fresh process
  invocations (each gets its own random map seed at startup) all produced
  the identical order.
- `go build`/`go vet`/`gofmt` clean, `golangci-lint`: 0 issues, `go test
  -race` clean, `make test`: all 21 packages pass, `mkdocs build
  --strict` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * List results for tools and prompts are now consistently sorted by name.
  * Resource lists are now consistently sorted by URI.
  * Duplicate names or URIs receive stable ordering, preventing results from changing between requests.
  * Improves provider prompt caching and client-side list comparisons.

* **Documentation**
  * Added changelog details for the deterministic ordering improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->