### PR TITLE
fix: negotiate protocolVersion instead of echoing the client's request

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -181,11 +181,15 @@ and this project adheres to
   and web client are unaffected, since both already request
   `2024-11-05` exactly.
 
-  `initialize` over HTTP also now rejects a `protocolVersion` of the
-  wrong JSON type with a proper `-32602 Invalid params` error, matching
-  every other HTTP handler in this file and the stdio transport's
-  existing behaviour, instead of silently falling back to the server's
-  default as if the field had been omitted.
+  `initialize` over HTTP also now rejects malformed parameters with a
+  proper `-32602 Invalid params` error, matching every other HTTP handler
+  and the stdio transport's existing behaviour. The HTTP handler
+  previously never read the client's parameters at all, so it accepted
+  anything; it now parses them, and a field of the wrong JSON type, such
+  as a numeric `protocolVersion` or a `clientInfo` that is not an object,
+  fails the handshake instead of silently falling back to the server's
+  default. Omitting the parameters entirely still succeeds and yields
+  that default.
 
 ### Added
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -161,6 +161,32 @@ and this project adheres to
   `httperror`, `llmtracing`, `logging`, `prompts`, `search` and `tsv`. All of
   them pass; they were simply never run.
 
+- `initialize` no longer echoes back whatever `protocolVersion` a client
+  requests. Version negotiation is the server's half of the MCP
+  handshake: the client proposes a revision, and the server is supposed
+  to reply with the revision it will actually speak, which the client
+  then checks against what it supports. Echoing the request answers
+  with no information at all, so a client asking for a revision this
+  server does not implement was told that revision was accepted, and
+  found out otherwise later, against a missing capability, rather than
+  at the version check meant to catch exactly this case. `initialize`
+  (stdio) and `initialize` over HTTP now both call a shared
+  `NegotiateProtocolVersion`, which returns the newest revision this
+  server supports at or below the client's request, or the oldest
+  supported revision if the request predates everything the server
+  implements. This server currently implements one revision,
+  `2024-11-05`, so today every negotiation converges on that value
+  regardless of what a client asked for; the function is structured to
+  extend cleanly if a second revision is added later. The bundled CLI
+  and web client are unaffected, since both already request
+  `2024-11-05` exactly.
+
+  `initialize` over HTTP also now rejects a `protocolVersion` of the
+  wrong JSON type with a proper `-32602 Invalid params` error, matching
+  every other HTTP handler in this file and the stdio transport's
+  existing behaviour, instead of silently falling back to the server's
+  default as if the field had been omitted.
+
 ### Added
 
 - A `make vulncheck` target runs `govulncheck` over the module, using

--- a/docs/developers/mcp-protocol.md
+++ b/docs/developers/mcp-protocol.md
@@ -6,6 +6,15 @@ This document describes how the Natural Language Agent implements the Model Cont
 
 This server implements **MCP version `2024-11-05`**.
 
+The server negotiates the version during the `initialize` handshake; it
+never simply echoes the version a client requests. A client that asks for
+a revision the server does not implement receives `2024-11-05` in the
+`initialize` response, and it should then decide whether to continue or
+disconnect. A client that omits `protocolVersion` also receives
+`2024-11-05`. An `initialize` request whose parameters are malformed, such
+as a `protocolVersion` that is not a string, fails with a `-32602 Invalid
+params` error on both transports.
+
 ## Transport Modes
 
 The server supports two transport modes:

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -382,6 +382,15 @@ func (s *Server) handleRequestHTTP(ctx context.Context, req JSONRPCRequest) JSON
 // HTTP-specific handlers that return responses instead of sending them
 
 func (s *Server) handleInitializeHTTP(req JSONRPCRequest) JSONRPCResponse {
+	var params InitializeParams
+	paramsJSON, err := json.Marshal(req.Params)
+	if err != nil {
+		return createErrorResponse(req.ID, -32602, "Invalid params", err.Error())
+	}
+	if err := json.Unmarshal(paramsJSON, &params); err != nil {
+		return createErrorResponse(req.ID, -32602, "Invalid params", err.Error())
+	}
+
 	capabilities := map[string]interface{}{
 		"tools": map[string]interface{}{},
 	}
@@ -397,7 +406,7 @@ func (s *Server) handleInitializeHTTP(req JSONRPCRequest) JSONRPCResponse {
 	}
 
 	result := InitializeResult{
-		ProtocolVersion: ProtocolVersion,
+		ProtocolVersion: NegotiateProtocolVersion(params.ProtocolVersion),
 		Capabilities:    capabilities,
 		ServerInfo: Implementation{
 			Name:    ServerName,

--- a/internal/mcp/http_server_test.go
+++ b/internal/mcp/http_server_test.go
@@ -235,6 +235,121 @@ func TestHandleInitializeHTTP_WithProviders(t *testing.T) {
 	}
 }
 
+// TestHandleInitializeHTTP_NegotiatesProtocolVersion is the regression test
+// for issue #212 on the HTTP transport: a client requesting a revision this
+// server does not implement must get back a revision the server actually
+// speaks, not its own request echoed unchanged.
+func TestHandleInitializeHTTP_NegotiatesProtocolVersion(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	rpcReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: map[string]interface{}{
+			"protocolVersion": "2099-01-01",
+			"clientInfo": map[string]interface{}{
+				"name":    "test-client",
+				"version": "1.0.0",
+			},
+		},
+	}
+
+	body, _ := json.Marshal(rpcReq)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	server.handleHTTPRequest(w, req)
+
+	var response JSONRPCResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("unexpected error: %v", response.Error)
+	}
+
+	result, ok := response.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result to be a map, got %T", response.Result)
+	}
+	if result["protocolVersion"] == "2099-01-01" {
+		t.Fatal("server echoed back an unsupported protocolVersion instead of negotiating")
+	}
+	if result["protocolVersion"] != ProtocolVersion {
+		t.Errorf("protocolVersion = %v, want %q", result["protocolVersion"], ProtocolVersion)
+	}
+}
+
+// TestHandleInitializeHTTP_MalformedProtocolVersion checks that a
+// protocolVersion of the wrong JSON type is rejected with a proper
+// JSON-RPC error, matching every other *HTTP handler in this file and
+// the stdio transport's handleInitialize -- not silently negotiated as
+// if the field had been omitted.
+func TestHandleInitializeHTTP_MalformedProtocolVersion(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	rpcReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: map[string]interface{}{
+			"protocolVersion": 12345, // wrong type: InitializeParams wants a string
+		},
+	}
+
+	body, _ := json.Marshal(rpcReq)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	server.handleHTTPRequest(w, req)
+
+	var response JSONRPCResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Error == nil {
+		t.Fatal("expected an Invalid params error, got a successful result")
+	}
+	if response.Error.Code != -32602 {
+		t.Errorf("error code = %d, want -32602", response.Error.Code)
+	}
+}
+
+// TestHandleInitializeHTTP_NilParams checks that omitting params
+// entirely -- the common case for a minimal initialize call -- still
+// succeeds and negotiates the server's default, rather than being
+// mistaken for the malformed-params case above.
+func TestHandleInitializeHTTP_NilParams(t *testing.T) {
+	tools := &mockToolProvider{}
+	server := NewServer(tools)
+
+	rpcReq := JSONRPCRequest{JSONRPC: "2.0", ID: 1, Method: "initialize"}
+
+	body, _ := json.Marshal(rpcReq)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	server.handleHTTPRequest(w, req)
+
+	var response JSONRPCResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Error != nil {
+		t.Fatalf("unexpected error for omitted params: %v", response.Error)
+	}
+	result, ok := response.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result to be a map, got %T", response.Result)
+	}
+	if result["protocolVersion"] != ProtocolVersion {
+		t.Errorf("protocolVersion = %v, want %q", result["protocolVersion"], ProtocolVersion)
+	}
+}
+
 func TestHandleToolsListHTTP(t *testing.T) {
 	tools := &mockToolProvider{
 		tools: []Tool{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -30,19 +30,31 @@ const (
 	ServerInstructions = "For PostgreSQL database operations, prefer the tools advertised by this server in tools/list instead of psql or other shell commands. Use the available MCP tools for schema discovery, query execution, performance analysis, row counts, and database management. These tools apply the server's connection handling, authentication, access control, and logging policies automatically."
 )
 
-// SupportedProtocolVersions lists every MCP protocol revision this server
-// implements, oldest first. ProtocolVersion, the server's own default and
-// preferred revision, must be the last (newest) entry; TestSupportedProtocolVersions_NewestIsProtocolVersion
-// in server_test.go enforces that invariant as more revisions are added.
-var SupportedProtocolVersions = []string{
+// supportedProtocolVersions lists the handshake-era ("legacy") MCP protocol
+// revisions this server implements, oldest first. ProtocolVersion, the
+// server's own default and preferred revision, must be the last (newest)
+// entry; TestSupportedProtocolVersions_NewestIsProtocolVersion in
+// server_test.go enforces that invariant as more revisions are added.
+//
+// Only revisions that negotiate through the initialize handshake belong
+// here, which means 2025-11-25 and earlier. Revision 2026-07-28 removed the
+// handshake entirely: a client declares its version in per-request _meta
+// (and the MCP-Protocol-Version header over HTTP), servers must implement
+// server/discover to advertise what they support, and a version mismatch
+// returns UnsupportedProtocolVersionError rather than being settled at
+// connect time. Adding 2026-07-28 or later to this list would make
+// NegotiateProtocolVersion answer a legacy handshake with a revision that
+// has no handshake, so supporting a modern revision needs its own path
+// rather than another entry here.
+var supportedProtocolVersions = []string{
 	"2024-11-05",
 }
 
 // NegotiateProtocolVersion returns the protocol revision this server will
-// actually speak in response to a client's requested revision, per the MCP
-// specification's version negotiation: the newest supported revision at or
-// below the client's request, or the oldest supported revision if the
-// request predates every revision this server implements.
+// actually speak in response to a client's requested revision: the newest
+// supported revision at or below the client's request, or the oldest
+// supported revision if the request predates every revision this server
+// implements.
 //
 // Version negotiation is the server's half of the handshake: the client
 // proposes a revision and the server replies with the revision it will
@@ -53,6 +65,16 @@ var SupportedProtocolVersions = []string{
 // its request was honoured, and fails later against a missing capability
 // rather than at the version check meant to catch exactly this case.
 //
+// The specification's own rule is narrower: reply with the requested
+// revision if it is supported, and otherwise with a supported revision,
+// which SHOULD be the server's latest. Answering with the newest revision
+// at or below the request is a deliberately more conservative reading of
+// that SHOULD, on the grounds that a client asking for an older revision is
+// likelier to cope with something older still than with something newer
+// than it asked for. The two rules coincide exactly whilst this server
+// implements a single revision, so today the distinction is a statement of
+// intent for whoever adds the second one.
+//
 // An empty request (a client that omitted the field) gets the server's own
 // default, ProtocolVersion, rather than falling through the negotiation
 // logic below: an absent preference is not the same as a request for the
@@ -61,8 +83,8 @@ func NegotiateProtocolVersion(requested string) string {
 	if requested == "" {
 		return ProtocolVersion
 	}
-	best := SupportedProtocolVersions[0]
-	for _, v := range SupportedProtocolVersions {
+	best := supportedProtocolVersions[0]
+	for _, v := range supportedProtocolVersions {
 		if v <= requested {
 			best = v
 		}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -30,6 +30,46 @@ const (
 	ServerInstructions = "For PostgreSQL database operations, prefer the tools advertised by this server in tools/list instead of psql or other shell commands. Use the available MCP tools for schema discovery, query execution, performance analysis, row counts, and database management. These tools apply the server's connection handling, authentication, access control, and logging policies automatically."
 )
 
+// SupportedProtocolVersions lists every MCP protocol revision this server
+// implements, oldest first. ProtocolVersion, the server's own default and
+// preferred revision, must be the last (newest) entry; TestSupportedProtocolVersions_NewestIsProtocolVersion
+// in server_test.go enforces that invariant as more revisions are added.
+var SupportedProtocolVersions = []string{
+	"2024-11-05",
+}
+
+// NegotiateProtocolVersion returns the protocol revision this server will
+// actually speak in response to a client's requested revision, per the MCP
+// specification's version negotiation: the newest supported revision at or
+// below the client's request, or the oldest supported revision if the
+// request predates every revision this server implements.
+//
+// Version negotiation is the server's half of the handshake: the client
+// proposes a revision and the server replies with the revision it will
+// actually use, which the client is expected to check against what it can
+// support. Echoing the client's request back unconditionally -- what this
+// function replaces -- answers with no information at all, so a client
+// requesting a revision this server does not implement proceeds believing
+// its request was honoured, and fails later against a missing capability
+// rather than at the version check meant to catch exactly this case.
+//
+// An empty request (a client that omitted the field) gets the server's own
+// default, ProtocolVersion, rather than falling through the negotiation
+// logic below: an absent preference is not the same as a request for the
+// oldest revision.
+func NegotiateProtocolVersion(requested string) string {
+	if requested == "" {
+		return ProtocolVersion
+	}
+	best := SupportedProtocolVersions[0]
+	for _, v := range SupportedProtocolVersions {
+		if v <= requested {
+			best = v
+		}
+	}
+	return best
+}
+
 // ToolProvider is an interface for listing and executing tools
 type ToolProvider interface {
 	List() []Tool
@@ -187,11 +227,7 @@ func (s *Server) handleInitialize(req JSONRPCRequest) {
 		return
 	}
 
-	// Accept the client's protocol version for compatibility
-	protocolVersion := params.ProtocolVersion
-	if protocolVersion == "" {
-		protocolVersion = ProtocolVersion
-	}
+	protocolVersion := NegotiateProtocolVersion(params.ProtocolVersion)
 
 	capabilities := map[string]interface{}{
 		"tools": map[string]interface{}{},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -193,6 +193,83 @@ func TestServerConstants(t *testing.T) {
 	}
 }
 
+// TestSupportedProtocolVersions_NewestIsProtocolVersion enforces the
+// invariant documented on SupportedProtocolVersions: ProtocolVersion, the
+// server's own default, must be its last (newest) entry. NegotiateProtocolVersion
+// relies on this to answer an empty request with the server's actual
+// newest supported revision rather than a stale one left behind when a
+// newer revision was appended.
+func TestSupportedProtocolVersions_NewestIsProtocolVersion(t *testing.T) {
+	if len(SupportedProtocolVersions) == 0 {
+		t.Fatal("SupportedProtocolVersions must not be empty")
+	}
+	newest := SupportedProtocolVersions[len(SupportedProtocolVersions)-1]
+	if newest != ProtocolVersion {
+		t.Errorf("last entry of SupportedProtocolVersions = %q, want ProtocolVersion %q", newest, ProtocolVersion)
+	}
+	for i := 1; i < len(SupportedProtocolVersions); i++ {
+		if SupportedProtocolVersions[i-1] >= SupportedProtocolVersions[i] {
+			t.Errorf("SupportedProtocolVersions is not strictly ascending at index %d: %q >= %q",
+				i, SupportedProtocolVersions[i-1], SupportedProtocolVersions[i])
+		}
+	}
+}
+
+func TestNegotiateProtocolVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		want      string
+	}{
+		{
+			name:      "empty request gets the server's own default",
+			requested: "",
+			want:      ProtocolVersion,
+		},
+		{
+			name:      "exact match",
+			requested: ProtocolVersion,
+			want:      ProtocolVersion,
+		},
+		{
+			name:      "a revision newer than anything supported falls back to the newest supported",
+			requested: "2099-01-01",
+			want:      ProtocolVersion,
+		},
+		{
+			name:      "a revision older than anything supported falls back to the oldest supported",
+			requested: "2020-01-01",
+			want:      SupportedProtocolVersions[0],
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NegotiateProtocolVersion(tt.requested)
+			if got != tt.want {
+				t.Errorf("NegotiateProtocolVersion(%q) = %q, want %q", tt.requested, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNegotiateProtocolVersion_NeverEchoesUnsupported is the regression
+// test for issue #212: the server must never claim to speak a protocol
+// revision it does not actually implement, regardless of what a client
+// asks for.
+func TestNegotiateProtocolVersion_NeverEchoesUnsupported(t *testing.T) {
+	requested := []string{"2025-03-26", "2025-06-18", "2025-11-25", "2026-07-28", "not-even-a-date", ""}
+	supported := make(map[string]bool, len(SupportedProtocolVersions))
+	for _, v := range SupportedProtocolVersions {
+		supported[v] = true
+	}
+	for _, r := range requested {
+		got := NegotiateProtocolVersion(r)
+		if !supported[got] {
+			t.Errorf("NegotiateProtocolVersion(%q) = %q, which is not in SupportedProtocolVersions", r, got)
+		}
+	}
+}
+
 func TestScannerConstants(t *testing.T) {
 	// Verify buffer size constants are reasonable
 	if ScannerInitialBufferSize <= 0 {
@@ -487,6 +564,79 @@ func TestHandlePing_Stdio_WithID(t *testing.T) {
 	}
 	if len(result) != 0 {
 		t.Errorf("expected empty object result, got %v", result)
+	}
+}
+
+// TestHandleInitialize_Stdio_NegotiatesProtocolVersion is the regression
+// test for issue #212 on the stdio transport: a client requesting a
+// revision this server does not implement must get back a revision the
+// server actually speaks, not its own request echoed unchanged.
+func TestHandleInitialize_Stdio_NegotiatesProtocolVersion(t *testing.T) {
+	server := NewServer(&mockToolProvider{})
+	req := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "initialize",
+		Params: map[string]interface{}{
+			"protocolVersion": "2099-01-01",
+			"clientInfo":      map[string]interface{}{"name": "test-client", "version": "1.0.0"},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		server.handleInitialize(req)
+	})
+
+	var resp JSONRPCResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("failed to decode response %q: %v", out, err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error in response: %v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", resp.Result)
+	}
+	if result["protocolVersion"] == "2099-01-01" {
+		t.Fatal("server echoed back an unsupported protocolVersion instead of negotiating")
+	}
+	if result["protocolVersion"] != ProtocolVersion {
+		t.Errorf("protocolVersion = %v, want %q", result["protocolVersion"], ProtocolVersion)
+	}
+}
+
+// TestHandleInitialize_Stdio_MalformedProtocolVersion checks that a
+// protocolVersion of the wrong JSON type is rejected with a proper
+// JSON-RPC error, matching the HTTP transport's handleInitializeHTTP --
+// not silently negotiated as if the field had been omitted. This
+// behavior predates issue #212's fix and is unchanged by it; the test
+// pins it down explicitly since the equivalent HTTP behavior was added
+// as part of that fix and the two transports must stay consistent.
+func TestHandleInitialize_Stdio_MalformedProtocolVersion(t *testing.T) {
+	server := NewServer(&mockToolProvider{})
+	req := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "initialize",
+		Params: map[string]interface{}{
+			"protocolVersion": 12345, // wrong type: InitializeParams wants a string
+		},
+	}
+
+	out := captureStdout(t, func() {
+		server.handleInitialize(req)
+	})
+
+	var resp JSONRPCResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("failed to decode response %q: %v", out, err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected an Invalid params error, got a successful result")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("error code = %d, want -32602", resp.Error.Code)
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -194,23 +194,46 @@ func TestServerConstants(t *testing.T) {
 }
 
 // TestSupportedProtocolVersions_NewestIsProtocolVersion enforces the
-// invariant documented on SupportedProtocolVersions: ProtocolVersion, the
+// invariant documented on supportedProtocolVersions: ProtocolVersion, the
 // server's own default, must be its last (newest) entry. NegotiateProtocolVersion
 // relies on this to answer an empty request with the server's actual
 // newest supported revision rather than a stale one left behind when a
 // newer revision was appended.
 func TestSupportedProtocolVersions_NewestIsProtocolVersion(t *testing.T) {
-	if len(SupportedProtocolVersions) == 0 {
-		t.Fatal("SupportedProtocolVersions must not be empty")
+	if len(supportedProtocolVersions) == 0 {
+		t.Fatal("supportedProtocolVersions must not be empty")
 	}
-	newest := SupportedProtocolVersions[len(SupportedProtocolVersions)-1]
+	newest := supportedProtocolVersions[len(supportedProtocolVersions)-1]
 	if newest != ProtocolVersion {
-		t.Errorf("last entry of SupportedProtocolVersions = %q, want ProtocolVersion %q", newest, ProtocolVersion)
+		t.Errorf("last entry of supportedProtocolVersions = %q, want ProtocolVersion %q", newest, ProtocolVersion)
 	}
-	for i := 1; i < len(SupportedProtocolVersions); i++ {
-		if SupportedProtocolVersions[i-1] >= SupportedProtocolVersions[i] {
-			t.Errorf("SupportedProtocolVersions is not strictly ascending at index %d: %q >= %q",
-				i, SupportedProtocolVersions[i-1], SupportedProtocolVersions[i])
+	for i := 1; i < len(supportedProtocolVersions); i++ {
+		if supportedProtocolVersions[i-1] >= supportedProtocolVersions[i] {
+			t.Errorf("supportedProtocolVersions is not strictly ascending at index %d: %q >= %q",
+				i, supportedProtocolVersions[i-1], supportedProtocolVersions[i])
+		}
+	}
+}
+
+// firstModernProtocolVersion is the earliest MCP revision that abandoned the
+// initialize handshake in favour of per-request version metadata and
+// server/discover. Revisions from here onwards cannot be negotiated through
+// initialize at all, so they must not appear in supportedProtocolVersions.
+const firstModernProtocolVersion = "2026-07-28"
+
+// TestSupportedProtocolVersions_AreAllLegacy guards the boundary documented
+// on supportedProtocolVersions. NegotiateProtocolVersion answers the
+// initialize handshake, which revision 2026-07-28 removed, so appending a
+// modern revision to that list would have the server reply to a legacy
+// handshake with a revision that has no handshake. Supporting a modern
+// revision needs its own path, and this test fails if one is added here
+// instead.
+func TestSupportedProtocolVersions_AreAllLegacy(t *testing.T) {
+	for _, v := range supportedProtocolVersions {
+		if v >= firstModernProtocolVersion {
+			t.Errorf("supportedProtocolVersions contains %q, which is revision %q or later: "+
+				"those negotiate through per-request metadata and server/discover, not the initialize handshake",
+				v, firstModernProtocolVersion)
 		}
 	}
 }
@@ -237,9 +260,13 @@ func TestNegotiateProtocolVersion(t *testing.T) {
 			want:      ProtocolVersion,
 		},
 		{
+			// Deliberately more conservative than the specification, which
+			// says a server SHOULD answer an unsupported request with its
+			// latest revision; see NegotiateProtocolVersion's comment. The
+			// two coincide whilst this server implements one revision.
 			name:      "a revision older than anything supported falls back to the oldest supported",
 			requested: "2020-01-01",
-			want:      SupportedProtocolVersions[0],
+			want:      supportedProtocolVersions[0],
 		},
 	}
 	for _, tt := range tests {
@@ -258,14 +285,14 @@ func TestNegotiateProtocolVersion(t *testing.T) {
 // asks for.
 func TestNegotiateProtocolVersion_NeverEchoesUnsupported(t *testing.T) {
 	requested := []string{"2025-03-26", "2025-06-18", "2025-11-25", "2026-07-28", "not-even-a-date", ""}
-	supported := make(map[string]bool, len(SupportedProtocolVersions))
-	for _, v := range SupportedProtocolVersions {
+	supported := make(map[string]bool, len(supportedProtocolVersions))
+	for _, v := range supportedProtocolVersions {
 		supported[v] = true
 	}
 	for _, r := range requested {
 		got := NegotiateProtocolVersion(r)
 		if !supported[got] {
-			t.Errorf("NegotiateProtocolVersion(%q) = %q, which is not in SupportedProtocolVersions", r, got)
+			t.Errorf("NegotiateProtocolVersion(%q) = %q, which is not in supportedProtocolVersions", r, got)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`initialize` returned whatever `protocolVersion` a client asked for, rather
than a version the server actually implements. Version negotiation is the
server's half of the MCP handshake: the client proposes a revision, the
server replies with the revision it will actually speak, and the client
checks that answer against what it supports. Echoing the request answers
with no information at all, so a client asking for a revision this server
does not implement was told that revision was accepted, and found out
otherwise later — against a missing capability — rather than at the
version check meant to catch exactly this case.

Fixes #212.

## Root cause

```go
// Accept the client's protocol version for compatibility
protocolVersion := params.ProtocolVersion
if protocolVersion == "" {
    protocolVersion = ProtocolVersion
}
```

Reproduced against the actual running server before fixing anything:
stdio echoed a bogus `"2099-01-01"` request back verbatim. The same
request over HTTP already correctly returned `"2024-11-05"` — that
asymmetry turned out to be because `handleInitializeHTTP` never parsed
`req.Params` at all; it just always returned the hardcoded constant,
which only happened to be harmless because this server currently
implements exactly one revision.

## The fix

Added `SupportedProtocolVersions` (oldest to newest) and
`NegotiateProtocolVersion()`: returns the newest supported revision at or
below the client's request, or the oldest supported revision if the
request predates everything this server implements. Wired both
`handleInitialize` (stdio) and `handleInitializeHTTP` through it — the
latter now actually reads the client's request for the first time.

Verified the HTTP-side change has real, if not yet observable, value:
temporarily added a second fake supported version and confirmed
negotiation correctly returns the older one for an old request, where the
previous hardcoded-constant behavior would have kept wrongly returning the
newest regardless of what the client asked for.

## A second bug found while re-verifying

Re-checking every angle turned up a real bug in the fix itself:
`handleInitializeHTTP`'s new params-parsing silently swallowed unmarshal
errors (e.g. `protocolVersion` sent as a number instead of a string),
returning `200` with the default version instead of a proper JSON-RPC
error — inconsistent with stdio's `handleInitialize` and every other
`*HTTP` handler in this file, which all return `-32602` on malformed
params. Fixed to match, and verified by reverting the fix and confirming
the new regression test fails.

Both transports now handle three scenarios identically:

| Request | Result |
|---|---|
| Malformed type (`protocolVersion: 12345`) | `-32602 Invalid params` |
| Unsupported future version (`"2099-01-01"`) | Negotiated down to `2024-11-05` |
| Omitted params entirely | Default (`2024-11-05`) succeeds |

## Does this affect the CLI or web client?

No. Both request `2024-11-05` exactly and get back exactly what they
asked for either way.

## Not done here

Per the issue, explicitly out of scope: reading the `MCP-Protocol-Version`
HTTP header (2025-06-18+), or adopting a newer protocol revision.

## Testing

- Reproduced the original bug live against the real running binary
  (stdio vs. HTTP asymmetry) before writing any fix.
- Added `TestNegotiateProtocolVersion` (table-driven),
  `TestNegotiateProtocolVersion_NeverEchoesUnsupported`,
  `TestSupportedProtocolVersions_NewestIsProtocolVersion` (guards drift
  between the list and the constant), and dedicated regression tests per
  transport for both the negotiation fix and the malformed-params fix.
- Proved every regression test actually catches its own bug: reverted the
  relevant file, confirmed the test fails, restored, confirmed it passes.
- Live-verified all three scenarios above against the real binary on both
  transports after the fix.
- `go build`/`go vet`/`gofmt` clean, `golangci-lint`: 0 issues, `go test
  -race`: all 79 tests in `internal/mcp` pass, `make test`: all 21
  packages pass, `mkdocs build --strict` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MCP protocol version negotiation during initialization for both HTTP and standard input/output connections.
  - Unsupported or omitted client versions now fall back to a compatible server-supported version.

- **Bug Fixes**
  - Malformed initialization parameters now return a clear JSON-RPC `-32602 Invalid params` error.
  - Omitted initialization parameters are accepted using server defaults.

- **Documentation**
  - Documented protocol negotiation, fallback behavior, and initialization validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->