### PR TITLE
fix: infer tool_use stop reason from streamed content blocks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -155,6 +155,19 @@ and this project adheres to
 
 ### Fixed
 
+- Tool calls made over the streaming chat endpoint are no longer silently
+  dropped, which showed up in the web client as "No response received"
+  whenever a provider decided to call a tool. The terminating `done` frame
+  of that stream carries a chunk structure with no field for a stop
+  reason, so the client had nothing to read and fell back to assuming
+  `end_turn`; the agentic loop then looked only for text blocks and
+  ignored the `tool_use` block sitting alongside them. The OpenAI
+  provider hit this on every tool call, because it reports a distinct
+  `tool_calls` finish reason that had no way of reaching the client. The
+  client now infers `tool_use` when the assembled response contains a
+  `tool_use` block and the server reported `end_turn` or nothing at all,
+  leaving a more specific reason such as `max_tokens` untouched.
+
 - `make test` now runs every package that has tests. Ten packages were absent
   from the server target and so were never exercised by the suite or by
   continuous integration: `api`, `compactor`, `conversations`, `definitions`,

--- a/web/src/utils/sseChat.js
+++ b/web/src/utils/sseChat.js
@@ -262,6 +262,21 @@ export async function sseChat(body, options = {}) {
         throw streamError;
     }
 
+    // The streaming done frame carries a StreamChunk, which has no
+    // stop_reason field, so the proxy cannot tell us why the model
+    // stopped; providers that report finish_reason "tool_calls" (such
+    // as OpenAI) therefore arrive here indistinguishable from a plain
+    // text turn. A response carrying tool_use blocks is by definition
+    // a tool_use turn, so infer that rather than leaving the default
+    // "end_turn", which would make callers ignore the tool call. A
+    // more specific server-reported reason (max_tokens, for instance)
+    // is left alone.
+    if (assembled.stop_reason === 'end_turn' &&
+        Array.isArray(assembled.content) &&
+        assembled.content.some((block) => block && block.type === 'tool_use')) {
+        assembled.stop_reason = 'tool_use';
+    }
+
     return assembled;
 }
 

--- a/web/src/utils/sseChat.test.js
+++ b/web/src/utils/sseChat.test.js
@@ -152,6 +152,74 @@ describe('sseChat', () => {
         expect(result.stop_reason).toBe('end_turn');
     });
 
+    it('infers tool_use when the done frame reports end_turn', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'data: {"type":"tool_use_start","tool_use":{"id":"tu_1","name":"count_rows"}}\n\n',
+            'data: {"type":"tool_use_delta","partial":"{\\"table\\":\\"test_users\\"}"}\n\n',
+            'event: done\ndata: {"stop_reason":"end_turn","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.stop_reason).toBe('tool_use');
+        expect(result.content).toEqual([
+            {
+                type: 'tool_use',
+                tool_use: {
+                    id: 'tu_1',
+                    name: 'count_rows',
+                    input: { table: 'test_users' },
+                },
+            },
+        ]);
+    });
+
+    it('infers tool_use when the done frame omits stop_reason', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'data: {"type":"text","text":"Counting."}\n\n',
+            'data: {"type":"tool_use_start","tool_use":{"id":"tu_1","name":"count_rows"}}\n\n',
+            'data: {"type":"tool_use_delta","partial":"{}"}\n\n',
+            'event: done\ndata: {"type":"done","usage":{"total_tokens":3}}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.stop_reason).toBe('tool_use');
+    });
+
+    it('infers tool_use from tool_use blocks in the done payload content', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'event: done\ndata: {"stop_reason":"end_turn","content":[{"type":"tool_use","tool_use":{"id":"tu_1","name":"count_rows","input":{}}}]}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.stop_reason).toBe('tool_use');
+    });
+
+    it('leaves a more specific stop_reason untouched', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'data: {"type":"tool_use_start","tool_use":{"id":"tu_1","name":"count_rows"}}\n\n',
+            'data: {"type":"tool_use_delta","partial":"{\\"table\\":"}\n\n',
+            'event: done\ndata: {"stop_reason":"max_tokens"}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.stop_reason).toBe('max_tokens');
+    });
+
+    it('keeps end_turn for a text-only response', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'data: {"type":"text","text":"All done."}\n\n',
+            'event: done\ndata: {"stop_reason":"end_turn"}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.stop_reason).toBe('end_turn');
+    });
+
     it('prefers content array from done payload when present', async () => {
         globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
             'data: {"type":"text","text":"streamed"}\n\n',


### PR DESCRIPTION
## Summary

- The streaming chat endpoint's terminating `done` frame carries a `StreamChunk`, and that structure has no field for a stop reason, so `sseChat` had nothing to read and fell back to its `end_turn` default. `ChatInterface`'s agentic loop branches on the stop reason first, so on `end_turn` it collected only text blocks and ignored the `tool_use` block sitting alongside them; the tool was never executed and the user saw "No response received".
- This bites the OpenAI provider on every tool call, because it reports a distinct `tool_calls` finish reason (correctly mapped for the non-streaming path by the library's `normalizeStopReason`) that has no route through the streaming wire format at all.
- `sseChat` now infers `stop_reason: "tool_use"` when the assembled response contains a `tool_use` block and the server reported `end_turn` or nothing; a more specific server-reported reason such as `max_tokens` is left untouched, so a truncated partial tool call still surfaces as truncation. The inference covers both the locally assembled content and the case where the `done` payload supplies its own content array.

Worth noting for the record: the issue asks for the fix in `pgedge-go-llm-lib`'s OpenAI translator, and the library will eventually want a stop reason on `StreamChunk` so the proxy can report it honestly. That is a wire-format addition in another repository, and this client-side inference is correct on its own terms (a response carrying `tool_use` blocks is a tool-use turn), so it stands whether or not the library later starts sending the field.

## Test plan

- [x] Five new cases in `web/src/utils/sseChat.test.js`: inference from streamed `tool_use` blocks when `done` says `end_turn`, inference when `done` omits `stop_reason` entirely, inference from `tool_use` blocks in a server-supplied `done` content array, and two negative controls confirming `max_tokens` survives and a text-only turn stays `end_turn`.
- [x] Three of those five fail against the unfixed `sseChat.js` and pass with it; the two controls pass either way, as intended.
- [x] Full web suite green: 127 tests across 13 files.
- [ ] Manual check against a live OpenAI provider using the reproduction from the issue (`Use the count_rows tool on test_users with this exact where clause: email IS NOT NULL`).

No Go code is touched, so the Go suite is unaffected by this change.

Closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming chat responses so tool calls are correctly detected when tool-use content is present, even if the stream ends without a specific stop reason.
  - Preserved explicit stop reasons, such as token-limit completions, and maintained normal behavior for text-only responses.

- **Documentation**
  - Added a changelog entry describing the streaming-chat fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->