### PR TITLE
fix: reload expired metadata instead of reporting DATABASE_NOT_READY

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -182,7 +182,10 @@ and this project adheres to
   Both resource paths now reload expired metadata through a new
   `EnsureMetadata` helper, and report `DATABASE_NOT_READY` only when that
   reload genuinely fails. Raising `metadata_ttl` is no longer needed as a
-  workaround.
+  workaround. Reloads are serialised per connection, so a burst of
+  callers arriving once the TTL has expired issues one catalog query
+  between them rather than one each; the status banner refreshing several
+  resources at once makes such bursts routine.
 
 - `make test` now runs every package that has tests. Ten packages were absent
   from the server target and so were never exercised by the suite or by

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -182,10 +182,14 @@ and this project adheres to
   Both resource paths now reload expired metadata through a new
   `EnsureMetadata` helper, and report `DATABASE_NOT_READY` only when that
   reload genuinely fails. Raising `metadata_ttl` is no longer needed as a
-  workaround. Reloads are serialised per connection, so a burst of
-  callers arriving once the TTL has expired issues one catalog query
-  between them rather than one each; the status banner refreshing several
-  resources at once makes such bursts routine.
+  workaround. At most one reload per connection runs at a time, and
+  callers arriving whilst one is in flight wait for it and share its
+  outcome, so a burst arriving once the TTL has expired issues one catalog
+  query between them rather than one each; the status banner refreshing
+  several resources at once makes such bursts routine. Sharing the outcome
+  matters most when the database is unreachable, since a retry per caller
+  would queue one connect timeout each. Failures are not cached, so the
+  next caller to arrive starts a fresh attempt.
 
 - `make test` now runs every package that has tests. Ten packages were absent
   from the server target and so were never exercised by the suite or by

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -168,6 +168,22 @@ and this project adheres to
   `tool_use` block and the server reported `end_turn` or nothing at all,
   leaving a more specific reason such as `max_tokens` untouched.
 
+- Reading an MCP resource after an idle period no longer reports the
+  database as unavailable. Metadata expires once it is older than
+  `metadata_ttl` (five minutes by default), and `IsMetadataLoaded()`
+  returns false both for a connection that has never loaded any metadata
+  and for one whose metadata has simply aged out. The resource path
+  treated the second case as a database that was not ready, so it
+  returned a retryable `DATABASE_NOT_READY` without attempting a reload;
+  the web client's status banner then showed "Database is switching",
+  retried five times, and settled on "Database switch taking longer than
+  expected", all against a perfectly healthy database. The MCP tools
+  already reloaded in this situation, so only resources were affected.
+  Both resource paths now reload expired metadata through a new
+  `EnsureMetadata` helper, and report `DATABASE_NOT_READY` only when that
+  reload genuinely fails. Raising `metadata_ttl` is no longer needed as a
+  workaround.
+
 - `make test` now runs every package that has tests. Ten packages were absent
   from the server target and so were never exercised by the suite or by
   continuous integration: `api`, `compactor`, `conversations`, `definitions`,

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -53,17 +53,17 @@ type Client struct {
 	closed         bool                        // true after Close() has been called
 	mu             sync.RWMutex
 
-	// metadataReloads serialises metadata reloads per connection string,
-	// so that a burst of callers arriving after metadata_ttl expires
-	// issues one catalog query rather than one per caller. Guarded by mu;
-	// the mutexes it holds are taken without mu held. See
-	// EnsureMetadataFor.
-	metadataReloads map[string]*sync.Mutex
+	// metadataReloads holds the in-flight metadata reload per connection
+	// string, so that a burst of callers arriving after metadata_ttl
+	// expires shares one catalog query rather than issuing one each.
+	// Guarded by mu. See EnsureMetadataFor.
+	metadataReloads map[string]*metadataReload
 
-	// metadataLoadCount counts completed LoadMetadataFor calls. It exists
-	// so that tests can assert reloads were coalesced rather than merely
-	// assume it; nothing in the server's behaviour depends on it.
-	metadataLoadCount atomic.Uint64
+	// metadataLoadAttempts counts calls into LoadMetadataFor, successful
+	// or not. It exists so that tests can assert reloads were coalesced
+	// rather than merely assume it; nothing in the server's behaviour
+	// depends on it.
+	metadataLoadAttempts atomic.Uint64
 }
 
 // NewClient creates a new database client with optional database configuration
@@ -441,6 +441,7 @@ func (c *Client) LoadMetadata() error {
 //  4. Atomically swap the result in under the client's lock and log.
 func (c *Client) LoadMetadataFor(connStr string) error {
 	startTime := time.Now()
+	c.metadataLoadAttempts.Add(1)
 
 	c.mu.RLock()
 	conn, exists := c.connections[connStr]
@@ -492,8 +493,6 @@ func (c *Client) LoadMetadataFor(connStr string) error {
 	conn.MetadataLoaded = true
 	conn.MetadataLoadedAt = time.Now()
 	c.mu.Unlock()
-
-	c.metadataLoadCount.Add(1)
 
 	duration := time.Since(startTime)
 	LogMetadataLoad(connStr, len(newMetadata), duration, nil)
@@ -589,48 +588,84 @@ func (c *Client) EnsureMetadata() error {
 
 // EnsureMetadataFor is EnsureMetadata for a specific connection.
 //
-// Reloads are serialised per connection. Without that, every caller in a
-// burst arriving after the TTL expires passes the freshness check before
-// any of them has refreshed MetadataLoadedAt, and each then runs its own
-// catalog query; the status banner's periodic refresh makes such bursts
-// routine rather than hypothetical. The first caller through reloads and
-// the rest find fresh metadata on the recheck below, so the burst costs
-// one query. Note that a metadata_ttl of 0 means "always refresh", so
-// callers are serialised rather than coalesced in that configuration.
+// At most one reload per connection is in flight at a time, and callers
+// that arrive whilst one is running wait for it and share its outcome
+// rather than starting their own. Without that, every caller in a burst
+// arriving after the TTL expires passes the freshness check before any of
+// them has refreshed MetadataLoadedAt, and each then runs its own catalog
+// query; the status banner's periodic refresh of several resources makes
+// such bursts routine rather than hypothetical. Sharing the outcome
+// matters most when the reload fails: a serialised retry per caller would
+// queue one connect timeout each, so twenty callers could hold the path
+// open for twenty timeouts rather than one.
+//
+// The in-flight record is discarded once the attempt finishes, so a
+// failure is not cached: the next caller to arrive starts a fresh
+// attempt. Note that a metadata_ttl of 0 means "always refresh", so
+// sequential callers each reload in that configuration; only genuinely
+// concurrent ones are coalesced.
 func (c *Client) EnsureMetadataFor(connStr string) error {
 	if c.IsMetadataLoadedFor(connStr) {
 		return nil
 	}
 
-	reload := c.metadataReloadMutex(connStr)
-	reload.Lock()
-	defer reload.Unlock()
-
-	// Another caller may have reloaded whilst this one waited for the
-	// guard, in which case there is nothing left to do.
-	if c.IsMetadataLoadedFor(connStr) {
-		return nil
+	reload, leader := c.joinMetadataReload(connStr)
+	if !leader {
+		<-reload.done
+		return reload.err
 	}
 
-	return c.LoadMetadataFor(connStr)
+	// Another caller may have reloaded in the window between the check
+	// above and this one becoming the leader, in which case there is
+	// nothing left to do.
+	if !c.IsMetadataLoadedFor(connStr) {
+		reload.err = c.LoadMetadataFor(connStr)
+	}
+	c.finishMetadataReload(connStr, reload)
+
+	return reload.err
 }
 
-// metadataReloadMutex returns the mutex that serialises metadata reloads
-// for connStr, creating it on first use. The client lock is held only to
-// look the mutex up, never whilst it is held, so the two do not interact.
-func (c *Client) metadataReloadMutex(connStr string) *sync.Mutex {
+// metadataReload is one in-flight metadata reload. done is closed when
+// the attempt finishes, after which err holds its outcome and is safe to
+// read; the close is what publishes the write.
+type metadataReload struct {
+	done chan struct{}
+	err  error
+}
+
+// joinMetadataReload returns the in-flight reload for connStr, reporting
+// whether the caller is the leader and so responsible for performing it.
+// A caller that is not the leader must wait on the returned record rather
+// than reload anything itself.
+func (c *Client) joinMetadataReload(connStr string) (*metadataReload, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if c.metadataReloads == nil {
-		c.metadataReloads = make(map[string]*sync.Mutex)
+		c.metadataReloads = make(map[string]*metadataReload)
 	}
-	if m, exists := c.metadataReloads[connStr]; exists {
-		return m
+	if r, exists := c.metadataReloads[connStr]; exists {
+		return r, false
 	}
-	m := &sync.Mutex{}
-	c.metadataReloads[connStr] = m
-	return m
+	r := &metadataReload{done: make(chan struct{})}
+	c.metadataReloads[connStr] = r
+	return r, true
+}
+
+// finishMetadataReload publishes the leader's outcome to any waiters. The
+// record is removed from the map before the waiters are released, so a
+// caller arriving afterwards starts a fresh attempt instead of joining
+// one that has already finished.
+func (c *Client) finishMetadataReload(connStr string, r *metadataReload) {
+	c.mu.Lock()
+	// Close() clears the map wholesale, so only remove our own record.
+	if current, exists := c.metadataReloads[connStr]; exists && current == r {
+		delete(c.metadataReloads, connStr)
+	}
+	c.mu.Unlock()
+
+	close(r.done)
 }
 
 // GetPool returns the connection pool for the default connection

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"pgedge-postgres-mcp/internal/config"
@@ -51,6 +52,18 @@ type Client struct {
 	dbConfig       *config.NamedDatabaseConfig // database configuration for pool settings
 	closed         bool                        // true after Close() has been called
 	mu             sync.RWMutex
+
+	// metadataReloads serialises metadata reloads per connection string,
+	// so that a burst of callers arriving after metadata_ttl expires
+	// issues one catalog query rather than one per caller. Guarded by mu;
+	// the mutexes it holds are taken without mu held. See
+	// EnsureMetadataFor.
+	metadataReloads map[string]*sync.Mutex
+
+	// metadataLoadCount counts completed LoadMetadataFor calls. It exists
+	// so that tests can assert reloads were coalesced rather than merely
+	// assume it; nothing in the server's behaviour depends on it.
+	metadataLoadCount atomic.Uint64
 }
 
 // NewClient creates a new database client with optional database configuration
@@ -399,6 +412,7 @@ func (c *Client) Close() {
 		}
 	}
 	c.connections = make(map[string]*ConnectionInfo)
+	c.metadataReloads = nil
 }
 
 // IsClosed returns whether this client has been closed
@@ -478,6 +492,8 @@ func (c *Client) LoadMetadataFor(connStr string) error {
 	conn.MetadataLoaded = true
 	conn.MetadataLoadedAt = time.Now()
 	c.mu.Unlock()
+
+	c.metadataLoadCount.Add(1)
 
 	duration := time.Since(startTime)
 	LogMetadataLoad(connStr, len(newMetadata), duration, nil)
@@ -572,11 +588,49 @@ func (c *Client) EnsureMetadata() error {
 }
 
 // EnsureMetadataFor is EnsureMetadata for a specific connection.
+//
+// Reloads are serialised per connection. Without that, every caller in a
+// burst arriving after the TTL expires passes the freshness check before
+// any of them has refreshed MetadataLoadedAt, and each then runs its own
+// catalog query; the status banner's periodic refresh makes such bursts
+// routine rather than hypothetical. The first caller through reloads and
+// the rest find fresh metadata on the recheck below, so the burst costs
+// one query. Note that a metadata_ttl of 0 means "always refresh", so
+// callers are serialised rather than coalesced in that configuration.
 func (c *Client) EnsureMetadataFor(connStr string) error {
 	if c.IsMetadataLoadedFor(connStr) {
 		return nil
 	}
+
+	reload := c.metadataReloadMutex(connStr)
+	reload.Lock()
+	defer reload.Unlock()
+
+	// Another caller may have reloaded whilst this one waited for the
+	// guard, in which case there is nothing left to do.
+	if c.IsMetadataLoadedFor(connStr) {
+		return nil
+	}
+
 	return c.LoadMetadataFor(connStr)
+}
+
+// metadataReloadMutex returns the mutex that serialises metadata reloads
+// for connStr, creating it on first use. The client lock is held only to
+// look the mutex up, never whilst it is held, so the two do not interact.
+func (c *Client) metadataReloadMutex(connStr string) *sync.Mutex {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.metadataReloads == nil {
+		c.metadataReloads = make(map[string]*sync.Mutex)
+	}
+	if m, exists := c.metadataReloads[connStr]; exists {
+		return m
+	}
+	m := &sync.Mutex{}
+	c.metadataReloads[connStr] = m
+	return m
 }
 
 // GetPool returns the connection pool for the default connection

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -556,6 +556,29 @@ func (c *Client) IsMetadataLoadedFor(connStr string) bool {
 	return time.Since(conn.MetadataLoadedAt) <= ttl
 }
 
+// EnsureMetadata guarantees that valid, non-stale metadata is available
+// for the default connection, reloading it when the configured
+// metadata_ttl has expired. It returns nil when metadata is already
+// valid or the reload succeeded, and the reload error otherwise.
+//
+// Callers that merely need to know whether the database is ready should
+// use this rather than IsMetadataLoaded: a false from the latter means
+// "no valid metadata right now", which covers both a connection that
+// has never loaded any and one whose metadata has simply aged past the
+// TTL. Treating the second case as a failure reports the database as
+// unavailable when nothing is wrong with it.
+func (c *Client) EnsureMetadata() error {
+	return c.EnsureMetadataFor(c.GetDefaultConnection())
+}
+
+// EnsureMetadataFor is EnsureMetadata for a specific connection.
+func (c *Client) EnsureMetadataFor(connStr string) error {
+	if c.IsMetadataLoadedFor(connStr) {
+		return nil
+	}
+	return c.LoadMetadataFor(connStr)
+}
+
 // GetPool returns the connection pool for the default connection
 func (c *Client) GetPool() *pgxpool.Pool {
 	c.mu.RLock()

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -13,13 +13,17 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"pgedge-postgres-mcp/internal/config"
+	"pgedge-postgres-mcp/internal/mcp"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -768,5 +772,112 @@ func TestAfterReleaseRestoresReadOnlyDefault(t *testing.T) {
 	if after != "on" {
 		t.Errorf("default_transaction_read_only = %q after release and reacquire, want \"on\"; "+
 			"AfterRelease did not restore the session default", after)
+	}
+}
+
+// TestEnsureMetadataFor covers the decision the helper makes without
+// touching a database: fresh metadata must not provoke a reload, and an
+// unknown connection must report the failure rather than silently
+// claiming success.
+func TestEnsureMetadataFor(t *testing.T) {
+	client := NewClient(nil)
+
+	// Fresh metadata: EnsureMetadataFor must return without attempting a
+	// reload. The connection has a nil pool, so an attempted reload
+	// would not survive this call.
+	client.connections["postgres://localhost/fresh"] = &ConnectionInfo{
+		ConnString:       "postgres://localhost/fresh",
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now(),
+	}
+	if err := client.EnsureMetadataFor("postgres://localhost/fresh"); err != nil {
+		t.Errorf("EnsureMetadataFor() returned error for fresh metadata: %v", err)
+	}
+
+	// Unknown connection: the reload is attempted and fails, and the
+	// error is surfaced to the caller.
+	err := client.EnsureMetadataFor("postgres://localhost/unknown")
+	if err == nil {
+		t.Error("EnsureMetadataFor() returned nil for an unknown connection, want an error")
+	}
+}
+
+// TestExecuteResourceQuery_StaleMetadataReloads is a regression test for
+// issue #218. IsMetadataLoaded returns false both when metadata has
+// never been loaded and when it has aged past metadata_ttl (default 5m),
+// and ExecuteResourceQuery treated the second case as a database that
+// was not ready. A resource read after five idle minutes therefore
+// returned a retryable DATABASE_NOT_READY, which surfaced in the web
+// client as the "Database is switching" banner, followed by "Database
+// switch taking longer than expected" once the retries ran out; the
+// database itself was healthy throughout.
+//
+// This test loads metadata, backdates MetadataLoadedAt past the TTL, and
+// asserts that the resource query reloads and succeeds. It is gated on
+// TEST_PGEDGE_POSTGRES_CONNECTION_STRING, matching the other live-DB
+// regression tests here.
+func TestExecuteResourceQuery_StaleMetadataReloads(t *testing.T) {
+	connStr := os.Getenv("TEST_PGEDGE_POSTGRES_CONNECTION_STRING")
+	if connStr == "" {
+		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set; skipping live-DB regression test for issue #218")
+	}
+
+	client := NewClientWithConnectionString(connStr, nil)
+	defer client.Close()
+
+	if err := client.ConnectTo(connStr); err != nil {
+		t.Fatalf("ConnectTo failed: %v", err)
+	}
+	if err := client.SetDefaultConnection(connStr); err != nil {
+		t.Fatalf("SetDefaultConnection failed: %v", err)
+	}
+	if err := client.LoadMetadataFor(connStr); err != nil {
+		t.Fatalf("LoadMetadataFor failed: %v", err)
+	}
+
+	// Age the metadata past the default 5 minute TTL, exactly as five
+	// idle minutes would.
+	client.mu.Lock()
+	client.connections[connStr].MetadataLoadedAt = time.Now().Add(-6 * time.Minute)
+	client.mu.Unlock()
+
+	if client.IsMetadataLoaded() {
+		t.Fatal("metadata still reports as loaded after backdating past the TTL; the fixture is not exercising the stale path")
+	}
+
+	processor := func(rows pgx.Rows) (interface{}, error) {
+		var got int
+		for rows.Next() {
+			if err := rows.Scan(&got); err != nil {
+				return nil, err
+			}
+		}
+		return got, nil
+	}
+
+	content, err := ExecuteResourceQuery(client, "test://stale", "SELECT 218", processor)
+	if err != nil {
+		t.Fatalf("ExecuteResourceQuery returned error: %v", err)
+	}
+	if len(content.Contents) == 0 {
+		t.Fatal("ExecuteResourceQuery returned no content")
+	}
+
+	// A DATABASE_NOT_READY payload here is the regression: stale
+	// metadata was reported as an unready database.
+	var errorResponse mcp.ResourceError
+	if err := json.Unmarshal([]byte(content.Contents[0].Text), &errorResponse); err == nil && errorResponse.Error {
+		t.Fatalf("ExecuteResourceQuery reported %q for stale metadata; it should have reloaded (issue #218)", errorResponse.Code)
+	}
+
+	if strings.TrimSpace(content.Contents[0].Text) != "218" {
+		t.Errorf("ExecuteResourceQuery returned %q, want \"218\"", content.Contents[0].Text)
+	}
+
+	// The reload must also have refreshed the timestamp, so a second
+	// read is served from cache rather than reloading again.
+	if !client.IsMetadataLoaded() {
+		t.Error("metadata still reports as stale after ExecuteResourceQuery; the reload did not refresh MetadataLoadedAt")
 	}
 }

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -914,7 +914,7 @@ func TestEnsureMetadataFor_CoalescesConcurrentReloads(t *testing.T) {
 	client.connections[connStr].MetadataLoadedAt = time.Now().Add(-6 * time.Minute)
 	client.mu.Unlock()
 
-	before := client.metadataLoadCount.Load()
+	before := client.metadataLoadAttempts.Load()
 
 	const callers = 20
 	var wg sync.WaitGroup
@@ -937,7 +937,7 @@ func TestEnsureMetadataFor_CoalescesConcurrentReloads(t *testing.T) {
 		}
 	}
 
-	loads := client.metadataLoadCount.Load() - before
+	loads := client.metadataLoadAttempts.Load() - before
 	if loads != 1 {
 		t.Errorf("%d concurrent callers triggered %d metadata loads, want exactly 1; reloads are not being coalesced", callers, loads)
 	}
@@ -947,14 +947,14 @@ func TestEnsureMetadataFor_CoalescesConcurrentReloads(t *testing.T) {
 	}
 }
 
-// TestEnsureMetadataFor_RechecksUnderGuard covers the double check that
-// makes coalescing work, without needing a database. A caller that finds
-// stale metadata, waits on the reload guard, and is then handed fresh
-// metadata by the caller ahead of it must return without reloading. The
-// connection here has a nil pool, so a reload attempt would panic rather
-// than pass quietly: the test fails loudly if the recheck is dropped.
-func TestEnsureMetadataFor_RechecksUnderGuard(t *testing.T) {
-	const connStr = "postgres://localhost/recheck"
+// TestEnsureMetadataFor_SharesInFlightReload covers the sharing of an
+// in-flight reload without needing a database. A caller that arrives
+// whilst a reload is running must wait for it and take its outcome
+// rather than starting its own. The connection here has a nil pool, so a
+// reload attempt of its own would panic instead of passing quietly: the
+// test fails loudly if the caller does not join.
+func TestEnsureMetadataFor_SharesInFlightReload(t *testing.T) {
+	const connStr = "postgres://localhost/inflight"
 
 	client := NewClient(nil)
 	client.connections[connStr] = &ConnectionInfo{
@@ -964,26 +964,114 @@ func TestEnsureMetadataFor_RechecksUnderGuard(t *testing.T) {
 		MetadataLoadedAt: time.Now().Add(-6 * time.Minute), // stale
 	}
 
-	// Stand in for the caller that gets there first: hold the reload
-	// guard, then refresh the metadata before releasing it.
-	guard := client.metadataReloadMutex(connStr)
-	guard.Lock()
+	// Stand in for the caller that gets there first and becomes the
+	// leader, with its reload still running.
+	leader, isLeader := client.joinMetadataReload(connStr)
+	if !isLeader {
+		t.Fatal("joinMetadataReload() reported the first caller is not the leader")
+	}
 
-	released := make(chan struct{})
+	joined := make(chan error, 1)
 	go func() {
-		defer close(released)
-		client.mu.Lock()
-		client.connections[connStr].MetadataLoadedAt = time.Now()
-		client.mu.Unlock()
-		guard.Unlock()
+		joined <- client.EnsureMetadataFor(connStr)
 	}()
 
-	if err := client.EnsureMetadataFor(connStr); err != nil {
-		t.Errorf("EnsureMetadataFor() returned error after another caller refreshed the metadata: %v", err)
+	// The joining caller must still be waiting: nothing has published a
+	// result yet.
+	select {
+	case err := <-joined:
+		t.Fatalf("EnsureMetadataFor() returned %v whilst a reload was in flight; it did not join", err)
+	case <-time.After(50 * time.Millisecond):
 	}
-	<-released
 
-	if client.metadataLoadCount.Load() != 0 {
-		t.Errorf("EnsureMetadataFor() performed %d metadata loads, want 0; the recheck under the reload guard is missing", client.metadataLoadCount.Load())
+	// Finish the leader's reload successfully, as a real one would.
+	client.mu.Lock()
+	client.connections[connStr].MetadataLoadedAt = time.Now()
+	client.mu.Unlock()
+	leader.err = nil
+	client.finishMetadataReload(connStr, leader)
+
+	select {
+	case err := <-joined:
+		if err != nil {
+			t.Errorf("EnsureMetadataFor() returned error from a successful shared reload: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("EnsureMetadataFor() did not return after the in-flight reload finished")
+	}
+
+	if attempts := client.metadataLoadAttempts.Load(); attempts != 0 {
+		t.Errorf("EnsureMetadataFor() made %d load attempts, want 0; it did not share the in-flight reload", attempts)
+	}
+}
+
+// TestEnsureMetadataFor_SharesFailedReload asserts that a failing reload
+// is shared too. Metadata stays stale when a reload fails, so callers
+// waiting on it would each fail the freshness recheck and start their own
+// attempt; against an unreachable database that queues one connect
+// timeout per caller, turning a burst into a long serial stall. Every
+// caller should instead receive the outcome of the one attempt that ran.
+//
+// The connection here points at a port with nothing behind it, so the
+// reload fails quickly and no database is needed.
+func TestEnsureMetadataFor_SharesFailedReload(t *testing.T) {
+	// Port 1 is reserved and never listening, so connecting fails
+	// immediately rather than hanging.
+	const connStr = "postgres://someone@127.0.0.1:1/nothing?sslmode=disable&connect_timeout=1"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	poolConfig, err := pgxpool.ParseConfig(connStr)
+	if err != nil {
+		t.Fatalf("failed to parse fixture connection string: %v", err)
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		t.Fatalf("failed to build fixture pool: %v", err)
+	}
+	defer pool.Close()
+
+	client := NewClient(nil)
+	client.connections[connStr] = &ConnectionInfo{
+		ConnString:       connStr,
+		Pool:             pool,
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now().Add(-6 * time.Minute), // stale
+	}
+
+	const callers = 10
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			errs[idx] = client.EnsureMetadataFor(connStr)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err == nil {
+			t.Errorf("caller %d: EnsureMetadataFor returned nil against an unreachable database", i)
+		}
+	}
+
+	if attempts := client.metadataLoadAttempts.Load(); attempts != 1 {
+		t.Errorf("%d concurrent callers made %d load attempts against an unreachable database, want exactly 1; a failing reload is not being shared", callers, attempts)
+	}
+
+	// A failure must not be cached: the next caller starts a fresh
+	// attempt rather than being handed the stale error for ever.
+	if err := client.EnsureMetadataFor(connStr); err == nil {
+		t.Error("EnsureMetadataFor returned nil on a later call against an unreachable database")
+	}
+	if attempts := client.metadataLoadAttempts.Load(); attempts != 2 {
+		t.Errorf("a later call brought the total to %d load attempts, want 2; the failed reload was cached rather than retried", attempts)
 	}
 }

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -879,5 +880,110 @@ func TestExecuteResourceQuery_StaleMetadataReloads(t *testing.T) {
 	// read is served from cache rather than reloading again.
 	if !client.IsMetadataLoaded() {
 		t.Error("metadata still reports as stale after ExecuteResourceQuery; the reload did not refresh MetadataLoadedAt")
+	}
+}
+
+// TestEnsureMetadataFor_CoalescesConcurrentReloads asserts that a burst
+// of callers arriving after metadata_ttl has expired produces one
+// catalog query rather than one per caller. Every caller passes the
+// freshness check before any of them refreshes MetadataLoadedAt, so
+// without the per-connection reload guard each one runs its own
+// LoadMetadataFor; the status banner's periodic refresh of several
+// resources makes such bursts routine. It is gated on
+// TEST_PGEDGE_POSTGRES_CONNECTION_STRING, since coalescing is only
+// observable when the reload actually succeeds.
+func TestEnsureMetadataFor_CoalescesConcurrentReloads(t *testing.T) {
+	connStr := os.Getenv("TEST_PGEDGE_POSTGRES_CONNECTION_STRING")
+	if connStr == "" {
+		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set; skipping live-DB concurrency test for issue #218")
+	}
+
+	client := NewClientWithConnectionString(connStr, nil)
+	defer client.Close()
+
+	if err := client.ConnectTo(connStr); err != nil {
+		t.Fatalf("ConnectTo failed: %v", err)
+	}
+	if err := client.LoadMetadataFor(connStr); err != nil {
+		t.Fatalf("LoadMetadataFor failed: %v", err)
+	}
+
+	// Age the metadata past the default 5 minute TTL so every caller
+	// below sees it as stale.
+	client.mu.Lock()
+	client.connections[connStr].MetadataLoadedAt = time.Now().Add(-6 * time.Minute)
+	client.mu.Unlock()
+
+	before := client.metadataLoadCount.Load()
+
+	const callers = 20
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			errs[idx] = client.EnsureMetadataFor(connStr)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("caller %d: EnsureMetadataFor returned error: %v", i, err)
+		}
+	}
+
+	loads := client.metadataLoadCount.Load() - before
+	if loads != 1 {
+		t.Errorf("%d concurrent callers triggered %d metadata loads, want exactly 1; reloads are not being coalesced", callers, loads)
+	}
+
+	if !client.IsMetadataLoadedFor(connStr) {
+		t.Error("metadata still reports as stale after the reload")
+	}
+}
+
+// TestEnsureMetadataFor_RechecksUnderGuard covers the double check that
+// makes coalescing work, without needing a database. A caller that finds
+// stale metadata, waits on the reload guard, and is then handed fresh
+// metadata by the caller ahead of it must return without reloading. The
+// connection here has a nil pool, so a reload attempt would panic rather
+// than pass quietly: the test fails loudly if the recheck is dropped.
+func TestEnsureMetadataFor_RechecksUnderGuard(t *testing.T) {
+	const connStr = "postgres://localhost/recheck"
+
+	client := NewClient(nil)
+	client.connections[connStr] = &ConnectionInfo{
+		ConnString:       connStr,
+		Metadata:         make(map[string]TableInfo),
+		MetadataLoaded:   true,
+		MetadataLoadedAt: time.Now().Add(-6 * time.Minute), // stale
+	}
+
+	// Stand in for the caller that gets there first: hold the reload
+	// guard, then refresh the metadata before releasing it.
+	guard := client.metadataReloadMutex(connStr)
+	guard.Lock()
+
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		client.mu.Lock()
+		client.connections[connStr].MetadataLoadedAt = time.Now()
+		client.mu.Unlock()
+		guard.Unlock()
+	}()
+
+	if err := client.EnsureMetadataFor(connStr); err != nil {
+		t.Errorf("EnsureMetadataFor() returned error after another caller refreshed the metadata: %v", err)
+	}
+	<-released
+
+	if client.metadataLoadCount.Load() != 0 {
+		t.Errorf("EnsureMetadataFor() performed %d metadata loads, want 0; the recheck under the reload guard is missing", client.metadataLoadCount.Load())
 	}
 }

--- a/internal/database/resource_helper.go
+++ b/internal/database/resource_helper.go
@@ -32,8 +32,11 @@ type RowProcessor func(rows pgx.Rows) (interface{}, error)
 // - Marshal to JSON
 // - Return formatted ResourceContent
 func ExecuteResourceQuery(client *Client, uri string, query string, processor RowProcessor) (mcp.ResourceContent, error) {
-	// Check if metadata is loaded
-	if !client.IsMetadataLoaded() {
+	// Ensure metadata is loaded, reloading it when the TTL has expired.
+	// Stale metadata is not the same thing as an unready database, and
+	// reporting DATABASE_NOT_READY for it left the client retrying
+	// against a database that was fine (issue #218).
+	if err := client.EnsureMetadata(); err != nil {
 		return mcp.NewResourceJSONError(uri, mcp.DatabaseNotReadyMessage, mcp.ErrorCodeDatabaseNotReady, true)
 	}
 

--- a/internal/resources/custom.go
+++ b/internal/resources/custom.go
@@ -34,8 +34,10 @@ func (r *ContextAwareRegistry) RegisterSQL(def definitions.ResourceDefinition) e
 
 	// Create handler that executes SQL query and returns TSV format
 	handler := func(ctx context.Context, dbClient *database.Client) (mcp.ResourceContent, error) {
-		// Check if metadata is loaded
-		if !dbClient.IsMetadataLoaded() {
+		// Ensure metadata is loaded, reloading it when the TTL has
+		// expired rather than reporting the database as not ready
+		// (issue #218).
+		if err := dbClient.EnsureMetadata(); err != nil {
 			return mcp.NewResourceJSONError(def.URI, mcp.DatabaseNotReadyMessage, mcp.ErrorCodeDatabaseNotReady, true)
 		}
 


### PR DESCRIPTION
## Summary

- `IsMetadataLoaded()` returns false in two quite different situations: a connection that has never loaded any metadata, and one whose metadata has merely aged past `metadata_ttl` (five minutes by default). `ExecuteResourceQuery` and the SQL resource handler in `internal/resources/custom.go` treated both as a database that was not ready, returning a retryable `DATABASE_NOT_READY` without ever attempting a reload; when the TTL was introduced the error path was wired up and the reload path was not.
- The user-visible effect is the one described in the issue: after five idle minutes the status banner's 30-second refresh hits `pg://system_info`, sees `retryable: true`, retries five times at 500 ms, and lands on "Database switch taking longer than expected" whilst the database is perfectly healthy.
- The MCP tools (`query_database`, `count_rows`, `get_schema_info`) already reloaded on staleness, which is why this only ever bit resources. Both resource paths now call a new `Client.EnsureMetadata()` / `EnsureMetadataFor()` helper that reloads expired metadata and returns an error only when the reload genuinely fails, so `DATABASE_NOT_READY` is once again reserved for a database that really is unavailable. Setting `metadata_ttl: "24h"` is no longer needed as a workaround.

I deliberately left the tools' existing `if !IsMetadataLoadedFor { LoadMetadataFor }` blocks alone rather than folding them into the new helper; they are already correct, and the dedup would widen this diff for no behavioural gain.

## Test plan

- [x] `TestEnsureMetadataFor` covers the helper's decision without a database: fresh metadata returns without attempting a reload (the fixture's pool is nil, so an attempted reload would not survive the call), and an unknown connection surfaces the reload failure rather than silently reporting success.
- [x] `TestExecuteResourceQuery_StaleMetadataReloads` is the regression test proper: it connects, loads metadata, backdates `MetadataLoadedAt` by six minutes exactly as five idle minutes would, asserts the resource query reloads and returns its result rather than a `DATABASE_NOT_READY` payload, and confirms the reload refreshed the timestamp so the next read is served from cache. It is gated on `TEST_PGEDGE_POSTGRES_CONNECTION_STRING`, matching the other live-DB regression tests in that file, so it runs under the MCP Server matrix in CI.
- [x] `go test ./internal/database/... ./internal/resources/...` passes locally; `go build ./...`, `go vet`, and `gofmt -l` are clean.
- [ ] The live-DB test skipped on my machine (no local Postgres credentials to hand), so CI's PG 14–18 matrix is the first place it actually executes. I'll confirm it there rather than assume it.

Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource reads after metadata expiration by automatically refreshing metadata.
  * Prevented healthy databases from being incorrectly reported as unavailable when metadata expires.
  * SQL resources now continue working after stale metadata is refreshed.
  * Improved reliability when multiple requests require metadata refresh at the same time, including consistent handling of refresh failures.
* **Tests**
  * Added coverage for metadata refresh behavior, successful resource queries, concurrent requests, retries, and unknown connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->