### PR TITLE
fix(web): label the header conversation action as Clear, not Delete

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -155,6 +155,15 @@ and this project adheres to
 
 ### Fixed
 
+- The conversation actions menu in the status banner header no longer
+  offers a "Delete conversation" item that does not delete anything. That
+  action resets the chat window and starts a new conversation; it never
+  removed the conversation from the conversation list, so a selected
+  conversation appeared to survive the delete. The item is now labelled
+  "Clear conversation", and its confirmation dialog explains that the
+  conversation stays in the list, where the per-conversation delete button
+  removes it for good. (#223)
+
 - Tool calls made over the streaming chat endpoint are no longer silently
   dropped, which showed up in the web client as "No response received"
   whenever a provider decided to call a tool. The terminating `done` frame

--- a/web/src/components/StatusBanner.jsx
+++ b/web/src/components/StatusBanner.jsx
@@ -42,7 +42,7 @@ import {
     Warning as WarningIcon,
     MoreVert as MoreVertIcon,
     SaveAlt as SaveIcon,
-    Delete as DeleteIcon,
+    ClearAll as ClearIcon,
 } from '@mui/icons-material';
 import { useAuth } from '../contexts/AuthContext';
 import { useLLMProcessing } from '../contexts/LLMProcessingContext';
@@ -68,7 +68,7 @@ const StatusBanner = () => {
     const [dbPopoverAnchor, setDbPopoverAnchor] = useState(null);
     const [isSwitchingDatabase, setIsSwitchingDatabase] = useState(false);
     const [actionsMenuAnchor, setActionsMenuAnchor] = useState(null);
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [clearDialogOpen, setClearDialogOpen] = useState(false);
 
     const isDark = theme.palette.mode === 'dark';
 
@@ -86,18 +86,18 @@ const StatusBanner = () => {
         onSave?.();
     };
 
-    const handleDeleteClick = () => {
+    const handleClearClick = () => {
         handleActionsMenuClose();
-        setDeleteDialogOpen(true);
+        setClearDialogOpen(true);
     };
 
-    const handleConfirmDelete = () => {
+    const handleConfirmClear = () => {
         onClear?.();
-        setDeleteDialogOpen(false);
+        setClearDialogOpen(false);
     };
 
-    const handleCancelDelete = () => {
-        setDeleteDialogOpen(false);
+    const handleCancelClear = () => {
+        setClearDialogOpen(false);
     };
 
     const dialogPaperProps = {
@@ -486,19 +486,19 @@ const StatusBanner = () => {
                             <ListItemText primary="Save conversation" />
                         </MenuItem>
                         <MenuItem
-                            onClick={handleDeleteClick}
+                            onClick={handleClearClick}
                             disabled={!hasMessages || !onClear}
                             sx={{
-                                color: isDark ? '#F87171' : '#DC2626',
+                                color: isDark ? '#F1F5F9' : '#1F2937',
                                 '&:hover': {
-                                    bgcolor: isDark ? alpha('#EF4444', 0.08) : alpha('#EF4444', 0.04),
+                                    bgcolor: isDark ? alpha('#22B8CF', 0.08) : alpha('#15AABF', 0.04),
                                 },
                             }}
                         >
                             <ListItemIcon sx={{ color: 'inherit', minWidth: 36 }}>
-                                <DeleteIcon fontSize="small" />
+                                <ClearIcon fontSize="small" />
                             </ListItemIcon>
-                            <ListItemText primary="Delete conversation" />
+                            <ListItemText primary="Clear conversation" />
                         </MenuItem>
                     </Menu>
                     <IconButton
@@ -787,24 +787,25 @@ const StatusBanner = () => {
                 error={dbError}
             />
 
-            {/* Delete Conversation Confirmation Dialog */}
+            {/* Clear Conversation Confirmation Dialog */}
             <Dialog
-                open={deleteDialogOpen}
-                onClose={handleCancelDelete}
+                open={clearDialogOpen}
+                onClose={handleCancelClear}
                 PaperProps={dialogPaperProps}
             >
                 <DialogTitle sx={{ color: isDark ? '#F1F5F9' : '#1F2937' }}>
-                    Delete conversation
+                    Clear conversation
                 </DialogTitle>
                 <DialogContent>
                     <DialogContentText sx={{ color: isDark ? '#94A3B8' : '#6B7280' }}>
-                        This clears the entire current conversation and starts a
-                        new one. This action cannot be undone.
+                        This clears the chat window and starts a new
+                        conversation. The current conversation stays in the
+                        conversation list, where you can reopen or delete it.
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions sx={{ p: 2, pt: 0 }}>
                     <Button
-                        onClick={handleCancelDelete}
+                        onClick={handleCancelClear}
                         sx={{
                             color: isDark ? '#94A3B8' : '#6B7280',
                             textTransform: 'none',
@@ -813,18 +814,18 @@ const StatusBanner = () => {
                         Cancel
                     </Button>
                     <Button
-                        onClick={handleConfirmDelete}
+                        onClick={handleConfirmClear}
                         variant="contained"
                         sx={{
-                            bgcolor: '#EF4444',
+                            bgcolor: '#15AABF',
                             color: '#FFFFFF',
                             textTransform: 'none',
                             '&:hover': {
-                                bgcolor: '#DC2626',
+                                bgcolor: '#0C8599',
                             },
                         }}
                     >
-                        Delete
+                        Clear
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/web/src/components/__tests__/StatusBanner.test.jsx
+++ b/web/src/components/__tests__/StatusBanner.test.jsx
@@ -79,13 +79,21 @@ describe('StatusBanner conversation actions', () => {
         ).toBeInTheDocument();
     });
 
-    it('opens the menu with Save and Delete items', () => {
+    it('opens the menu with Save and Clear items', () => {
         renderBanner();
         fireEvent.click(
             screen.getByRole('button', { name: /conversation actions/i })
         );
         expect(screen.getByText('Save conversation')).toBeInTheDocument();
-        expect(screen.getByText('Delete conversation')).toBeInTheDocument();
+        expect(screen.getByText('Clear conversation')).toBeInTheDocument();
+    });
+
+    it('does not offer a delete action in the header menu', () => {
+        renderBanner();
+        fireEvent.click(
+            screen.getByRole('button', { name: /conversation actions/i })
+        );
+        expect(screen.queryByText(/delete/i)).not.toBeInTheDocument();
     });
 
     it('calls onSave when Save is clicked', () => {
@@ -102,16 +110,20 @@ describe('StatusBanner conversation actions', () => {
         fireEvent.click(
             screen.getByRole('button', { name: /conversation actions/i })
         );
-        fireEvent.click(screen.getByText('Delete conversation'));
+        fireEvent.click(screen.getByText('Clear conversation'));
 
-        // Confirmation dialog appears.
+        // Confirmation dialog appears, and explains that the conversation
+        // itself is not removed from the conversation list.
         expect(
-            screen.getByText(/clears the entire current conversation/i)
+            screen.getByText(/clears the chat window/i)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/stays in the conversation list/i)
         ).toBeInTheDocument();
         expect(onClear).not.toHaveBeenCalled();
 
-        // Confirm the delete.
-        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        // Confirm the clear.
+        fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
         expect(onClear).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Summary

- The "Delete conversation" item in the status banner's conversation
  actions menu was wired to the chat interface's clear handler, which
  empties the chat window and starts a new conversation but never removes
  the conversation from the conversation list, so the reported failure was
  a mislabelled action rather than a broken delete. The dialog body
  already admitted as much ("This clears the entire current conversation
  and starts a new one") whilst the menu item, its icon, and its confirm
  button all promised a deletion.

- Deletion already exists per conversation in the conversation list, so
  this renames the header action to "Clear conversation", swaps the bin
  icon for a clear-all icon, drops the destructive red styling for the
  ordinary menu and confirm colours used elsewhere, and rewords the dialog
  to say that the conversation stays in the list where it can be reopened
  or deleted.

## Test plan

- [x] `web`: existing `StatusBanner` tests updated for the new label,
      dialog text, and confirm button, plus a new test asserting the
      header menu offers no delete action at all.
- [x] `npm test` in `web/`: 128 tests across 13 files pass.
- [x] `npm run build` and `make lint-client` clean.

Closes #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renamed the chat action from “Delete conversation” to “Clear conversation.”
  - Clearing now resets the chat and starts a new conversation while preserving the saved conversation.
  - Permanent deletion remains available through the conversation’s delete control.

- **Bug Fixes**
  - Updated confirmation messaging and controls to clearly distinguish clearing from permanent deletion.

- **Documentation**
  - Updated the changelog to describe the revised conversation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->