### PR TITLE
fix: list configured databases in a deterministic sorted order

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -52,6 +52,20 @@ and this project adheres to
   Callers of the LLM proxy API may still pass a per-request `temperature`,
   which is forwarded only when present.
 
+### Fixed
+
+- The configured databases are now listed in a deterministic order, sorted
+  by name. `ClientManager` holds them in a map and both accessors iterated
+  it directly, so the order was randomised by the Go runtime on every call:
+  the web client's database selector reshuffled between sessions, which is
+  awkward to read with more than a handful of instances configured, and the
+  `list_database_connections` tool returned its entries in a fresh order
+  each time, invalidating the provider-side prompt cache on every request
+  in the same way that `tools/list` did before (#213). The
+  `/api/databases` endpoint and the database resources share the accessor,
+  so all of them are stable now. The sort key is the map key, so no two
+  entries can tie.
+
 ### Security
 
 - `release.yml`'s `build-web`, `build-amd64`, and `build-arm64` jobs run on

--- a/internal/database/client_manager.go
+++ b/internal/database/client_manager.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"sync"
 
 	"pgedge-postgres-mcp/internal/config"
@@ -224,7 +225,10 @@ func (cm *ClientManager) GetDatabaseConfig(name string) *config.NamedDatabaseCon
 	return cm.dbConfigs[name]
 }
 
-// ListDatabaseNames returns the names of all configured databases
+// ListDatabaseNames returns the names of all configured databases, sorted by
+// name. dbConfigs is a map, so iterating it yields a different order on every
+// call; the sort makes the result stable for callers that surface or compare
+// it. The sort key is the map key itself, so no two entries can tie.
 func (cm *ClientManager) ListDatabaseNames() []string {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
@@ -233,10 +237,15 @@ func (cm *ClientManager) ListDatabaseNames() []string {
 	for name := range cm.dbConfigs {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }
 
-// GetDatabaseConfigs returns all database configurations
+// GetDatabaseConfigs returns all database configurations, sorted by name, for
+// the same reason as ListDatabaseNames: every caller either shows this list to
+// a person or hands it to a model, and neither wants it reshuffled between
+// otherwise identical calls. Names are unique because they are the dbConfigs
+// keys, so sort.Slice has no tied elements to order arbitrarily.
 func (cm *ClientManager) GetDatabaseConfigs() []config.NamedDatabaseConfig {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
@@ -245,6 +254,9 @@ func (cm *ClientManager) GetDatabaseConfigs() []config.NamedDatabaseConfig {
 	for _, cfg := range cm.dbConfigs {
 		configs = append(configs, *cfg)
 	}
+	sort.Slice(configs, func(i, j int) bool {
+		return configs[i].Name < configs[j].Name
+	})
 	return configs
 }
 

--- a/internal/database/client_manager_unit_test.go
+++ b/internal/database/client_manager_unit_test.go
@@ -267,7 +267,9 @@ func TestClientManager_ListDatabaseNames(t *testing.T) {
 
 	names := cm.ListDatabaseNames()
 	if len(names) != 3 {
-		t.Errorf("expected 3 names, got %d", len(names))
+		// Fatal, not just an error: the ordering check below indexes names
+		// and would panic rather than report on a short result.
+		t.Fatalf("expected 3 names, got %d", len(names))
 	}
 
 	// Every name is present, in sorted order.

--- a/internal/database/client_manager_unit_test.go
+++ b/internal/database/client_manager_unit_test.go
@@ -270,14 +270,73 @@ func TestClientManager_ListDatabaseNames(t *testing.T) {
 		t.Errorf("expected 3 names, got %d", len(names))
 	}
 
-	// Check all names are present (order may vary)
-	nameSet := make(map[string]bool)
-	for _, name := range names {
-		nameSet[name] = true
+	// Every name is present, in sorted order.
+	expected := []string{"db1", "db2", "db3"}
+	for i, want := range expected {
+		if names[i] != want {
+			t.Errorf("expected name %q at index %d, got %q", want, i, names[i])
+		}
 	}
-	for _, expected := range []string{"db1", "db2", "db3"} {
-		if !nameSet[expected] {
-			t.Errorf("expected name '%s' to be in list", expected)
+}
+
+// TestClientManager_ListDatabaseNames_DeterministicOrder asserts the sorted
+// order holds across repeated calls. dbConfigs is a map, so an unsorted
+// implementation returns a different rotation almost every call and this test
+// fails within the first few iterations.
+func TestClientManager_ListDatabaseNames_DeterministicOrder(t *testing.T) {
+	// Registered out of alphabetical order, so returning the insertion order
+	// would not accidentally pass.
+	cm := NewClientManager([]config.NamedDatabaseConfig{
+		{Name: "pg18-spock2", Host: "h", Port: 5432, Database: "pgedge"},
+		{Name: "pg14-node1", Host: "h", Port: 5432, Database: "pgedge"},
+		{Name: "pg16-primary", Host: "h", Port: 5432, Database: "pgedge"},
+		{Name: "pg15-standby1", Host: "h", Port: 5432, Database: "pgedge"},
+		{Name: "pg18-spock1", Host: "h", Port: 5432, Database: "pgedge"},
+	})
+
+	want := []string{
+		"pg14-node1", "pg15-standby1", "pg16-primary",
+		"pg18-spock1", "pg18-spock2",
+	}
+
+	for i := 0; i < 50; i++ {
+		got := cm.ListDatabaseNames()
+		if len(got) != len(want) {
+			t.Fatalf("call %d: expected %d names, got %d", i, len(want), len(got))
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("call %d: expected %q at index %d, got %q",
+					i, want[j], j, got[j])
+			}
+		}
+	}
+}
+
+// TestClientManager_GetDatabaseConfigs_DeterministicOrder is the same
+// assertion for the config accessor, which is what the /api/databases
+// endpoint, the resource registry, and the LLM database-switching tools all
+// build their output from.
+func TestClientManager_GetDatabaseConfigs_DeterministicOrder(t *testing.T) {
+	cm := NewClientManager([]config.NamedDatabaseConfig{
+		{Name: "pg17-node3", Host: "h3", Port: 5432, Database: "pgedge"},
+		{Name: "pg14-node1", Host: "h1", Port: 5432, Database: "pgedge"},
+		{Name: "pg17-node1", Host: "h2", Port: 5432, Database: "pgedge"},
+	})
+
+	want := []string{"pg14-node1", "pg17-node1", "pg17-node3"}
+
+	for i := 0; i < 50; i++ {
+		configs := cm.GetDatabaseConfigs()
+		if len(configs) != len(want) {
+			t.Fatalf("call %d: expected %d configs, got %d",
+				i, len(want), len(configs))
+		}
+		for j := range want {
+			if configs[j].Name != want[j] {
+				t.Fatalf("call %d: expected %q at index %d, got %q",
+					i, want[j], j, configs[j].Name)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `ClientManager` keeps the configured databases in a map, and both
  `ListDatabaseNames()` and `GetDatabaseConfigs()` built their result by
  iterating it directly, so the Go runtime randomised the order on every call.
  Both now sort by name.

- Two visible consequences. The web client's database selector reshuffled
  between sessions, which is genuinely hard to read with sixteen instances
  configured; and `list_database_connections` handed the model its entries in a
  fresh order each time, invalidating the provider-side prompt cache on every
  request for exactly the reason `tools/list` did before #213. The
  `/api/databases` endpoint and the database resources share the same accessor,
  so they were affected too and are fixed by the same change.

- Unlike the registries in #213, there is no tie-break to worry about: the sort
  key is the `dbConfigs` map key, so two entries cannot compare equal.

## Test plan

- [x] `TestClientManager_ListDatabaseNames_DeterministicOrder` and
      `TestClientManager_GetDatabaseConfigs_DeterministicOrder`, each asserting
      sorted order across 50 repeated calls with the databases registered out
      of alphabetical order. I confirmed both fail against the unfixed
      accessors (first or second iteration, e.g. `expected "pg14-node1" at
      index 0, got "pg18-spock2"`) and pass against the fix.
- [x] `TestClientManager_ListDatabaseNames` asserted only set membership,
      under an "order may vary" comment that this change makes untrue, so it
      now asserts the order.
- [x] `go build`, `go vet`, `gofmt`, `make lint` (0 issues), `go test -race` on
      the affected package, and `make test`: 907 tests pass.
- [x] Observed the original symptom in a live environment with sixteen
      instances configured, where the selector listed them in a different
      order on each session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database names and configurations now appear in consistent alphabetical order.
  * Stabilized ordering across the web database selector, API responses, connection listings, and database resources.
  * Repeated requests now produce predictable results, making database selection and integration workflows more reliable.

* **Documentation**
  * Added an unreleased changelog entry describing the deterministic database ordering improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->