### PR TITLE
test: make the shared-failed-reload test deterministic

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -74,9 +74,9 @@ and this project adheres to
   leaders themselves, and the count came out at two or three. The reload is
   now driven through the leader API, as
   `TestEnsureMetadataFor_SharesInFlightReload` already does, so the
-  in-flight window lasts as long as the test needs and every assertion is
-  deterministic. The behaviour under test is unchanged, and no production
-  code is touched.
+  in-flight window lasts as long as the test needs, and the callers behind
+  the leader join synchronously rather than being raced into place. The
+  behaviour under test is unchanged, and no production code is touched.
 
 ### Security
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -66,6 +66,18 @@ and this project adheres to
   so all of them are stable now. The sort key is the map key, so no two
   entries can tie.
 
+- `TestEnsureMetadataFor_SharesFailedReload` no longer fails at random. It
+  released ten goroutines at once and asserted that exactly one metadata
+  load attempt resulted, but the leader's attempt targets a reserved port
+  and so fails immediately; whenever it finished before the rest of the
+  burst had been scheduled, those callers found no reload to join, became
+  leaders themselves, and the count came out at two or three. The reload is
+  now driven through the leader API, as
+  `TestEnsureMetadataFor_SharesInFlightReload` already does, so the
+  in-flight window lasts as long as the test needs and every assertion is
+  deterministic. The behaviour under test is unchanged, and no production
+  code is touched.
+
 ### Security
 
 - `release.yml`'s `build-web`, `build-amd64`, and `build-arm64` jobs run on

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"os"
 	"reflect"
 	"strings"
@@ -1014,6 +1015,16 @@ func TestEnsureMetadataFor_SharesInFlightReload(t *testing.T) {
 //
 // The connection here points at a port with nothing behind it, so the
 // reload fails quickly and no database is needed.
+//
+// The reload is driven through the leader API rather than by racing a
+// burst of EnsureMetadataFor() calls, which is what the first version of
+// this test did. Connecting to a reserved port fails immediately, so the
+// leader's attempt regularly finished before the rest of the burst had
+// been scheduled; those callers then found no reload to join, became
+// leaders themselves and ran their own attempt, and the "exactly one
+// attempt" assertion saw two or three. Taking leadership explicitly makes
+// the in-flight window last as long as the test wants it to, which is the
+// same approach TestEnsureMetadataFor_SharesInFlightReload takes.
 func TestEnsureMetadataFor_SharesFailedReload(t *testing.T) {
 	// Port 1 is reserved and never listening, so connecting fails
 	// immediately rather than hanging.
@@ -1041,37 +1052,76 @@ func TestEnsureMetadataFor_SharesFailedReload(t *testing.T) {
 		MetadataLoadedAt: time.Now().Add(-6 * time.Minute), // stale
 	}
 
-	const callers = 10
-	var wg sync.WaitGroup
-	errs := make([]error, callers)
-	start := make(chan struct{})
-	for i := 0; i < callers; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			<-start
-			errs[idx] = client.EnsureMetadataFor(connStr)
-		}(i)
+	// Stand in for the caller that gets there first, with its reload still
+	// running, exactly as a real leader would be.
+	leader, isLeader := client.joinMetadataReload(connStr)
+	if !isLeader {
+		t.Fatal("joinMetadataReload() reported the first caller is not the leader")
 	}
-	close(start)
-	wg.Wait()
 
-	for i, err := range errs {
-		if err == nil {
-			t.Errorf("caller %d: EnsureMetadataFor returned nil against an unreachable database", i)
+	// The callers arriving behind it. joinMetadataReload() is called from
+	// this goroutine, so each is known to have joined the leader's record
+	// before anything is published; only the waiting happens concurrently.
+	const joiners = 10
+	results := make(chan error, joiners+1)
+	for i := 0; i < joiners; i++ {
+		r, joinedAsLeader := client.joinMetadataReload(connStr)
+		if joinedAsLeader {
+			t.Fatalf("caller %d became a second leader whilst a reload was in flight", i)
+		}
+		if r != leader {
+			t.Fatalf("caller %d joined a different reload record than the leader's", i)
+		}
+		go func() {
+			<-r.done
+			results <- r.err
+		}()
+	}
+
+	// One caller goes through the public entry point, to keep this test
+	// honest about EnsureMetadataFor() itself joining rather than
+	// reloading.
+	go func() {
+		results <- client.EnsureMetadataFor(connStr)
+	}()
+
+	// Nothing may return whilst the reload is in flight.
+	select {
+	case err := <-results:
+		t.Fatalf("a caller returned %v whilst a reload was in flight; it did not wait for the leader", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Finish the leader's reload as a failing one, which is the case this
+	// test exists for.
+	wantErr := errors.New("dial tcp 127.0.0.1:1: connect: connection refused")
+	leader.err = wantErr
+	client.finishMetadataReload(connStr, leader)
+
+	for i := 0; i < joiners+1; i++ {
+		select {
+		case err := <-results:
+			if !errors.Is(err, wantErr) {
+				t.Errorf("a caller received %v from the shared failing reload, want %v", err, wantErr)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("a caller did not return after the failed reload finished")
 		}
 	}
 
-	if attempts := client.metadataLoadAttempts.Load(); attempts != 1 {
-		t.Errorf("%d concurrent callers made %d load attempts against an unreachable database, want exactly 1; a failing reload is not being shared", callers, attempts)
+	// None of them ran a reload of its own: the leader's attempt is the
+	// only one there would have been, and this test never let it run.
+	if attempts := client.metadataLoadAttempts.Load(); attempts != 0 {
+		t.Errorf("%d callers sharing one failing reload made %d load attempts, want 0; a failing reload is not being shared", joiners+1, attempts)
 	}
 
 	// A failure must not be cached: the next caller starts a fresh
-	// attempt rather than being handed the stale error for ever.
+	// attempt rather than being handed the stale error for ever. This one
+	// runs the real load, against the unreachable port.
 	if err := client.EnsureMetadataFor(connStr); err == nil {
 		t.Error("EnsureMetadataFor returned nil on a later call against an unreachable database")
 	}
-	if attempts := client.metadataLoadAttempts.Load(); attempts != 2 {
-		t.Errorf("a later call brought the total to %d load attempts, want 2; the failed reload was cached rather than retried", attempts)
+	if attempts := client.metadataLoadAttempts.Load(); attempts != 1 {
+		t.Errorf("a later call made %d load attempts, want 1; the failed reload was cached rather than retried", attempts)
 	}
 }

--- a/internal/database/connection_test.go
+++ b/internal/database/connection_test.go
@@ -1063,7 +1063,7 @@ func TestEnsureMetadataFor_SharesFailedReload(t *testing.T) {
 	// this goroutine, so each is known to have joined the leader's record
 	// before anything is published; only the waiting happens concurrently.
 	const joiners = 10
-	results := make(chan error, joiners+1)
+	results := make(chan error, joiners)
 	for i := 0; i < joiners; i++ {
 		r, joinedAsLeader := client.joinMetadataReload(connStr)
 		if joinedAsLeader {
@@ -1078,14 +1078,18 @@ func TestEnsureMetadataFor_SharesFailedReload(t *testing.T) {
 		}()
 	}
 
-	// One caller goes through the public entry point, to keep this test
-	// honest about EnsureMetadataFor() itself joining rather than
-	// reloading.
-	go func() {
-		results <- client.EnsureMetadataFor(connStr)
-	}()
+	// Note that no caller here goes through EnsureMetadataFor(): starting a
+	// goroutine does not prove it reached the join, and a timeout is not
+	// proof either, so such a caller could be scheduled after the outcome
+	// below is published, become a leader and run its own load, which is
+	// the very race this rewrite removes. That the public entry point joins
+	// an in-flight reload rather than reloading is covered by
+	// TestEnsureMetadataFor_SharesInFlightReload, whose assertions hold
+	// whenever its joining caller is scheduled; the call at the end of this
+	// test covers the public path for the retry-after-failure case.
 
-	// Nothing may return whilst the reload is in flight.
+	// The waiters are blocked on a channel that nothing has closed, so this
+	// is a guarantee rather than a timing assumption.
 	select {
 	case err := <-results:
 		t.Fatalf("a caller returned %v whilst a reload was in flight; it did not wait for the leader", err)
@@ -1098,7 +1102,7 @@ func TestEnsureMetadataFor_SharesFailedReload(t *testing.T) {
 	leader.err = wantErr
 	client.finishMetadataReload(connStr, leader)
 
-	for i := 0; i < joiners+1; i++ {
+	for i := 0; i < joiners; i++ {
 		select {
 		case err := <-results:
 			if !errors.Is(err, wantErr) {
@@ -1112,7 +1116,7 @@ func TestEnsureMetadataFor_SharesFailedReload(t *testing.T) {
 	// None of them ran a reload of its own: the leader's attempt is the
 	// only one there would have been, and this test never let it run.
 	if attempts := client.metadataLoadAttempts.Load(); attempts != 0 {
-		t.Errorf("%d callers sharing one failing reload made %d load attempts, want 0; a failing reload is not being shared", joiners+1, attempts)
+		t.Errorf("%d callers sharing one failing reload made %d load attempts, want 0; a failing reload is not being shared", joiners, attempts)
 	}
 
 	// A failure must not be cached: the next caller starts a fresh


### PR DESCRIPTION
## Summary

`TestEnsureMetadataFor_SharesFailedReload` (added in #222) is flaky. It released
ten goroutines at once and asserted that exactly one metadata load attempt
resulted, but the leader's attempt connects to reserved port 1 and fails
immediately: whenever it finished before the remaining callers had been
scheduled, those callers found no in-flight reload to join, became leaders
themselves and ran their own attempt, so the count came out at two or three.

It has failed twice in CI today, on PG 18 in #226 and PG 16 in #227, both times
passing on re-run.

The reload is now driven through `joinMetadataReload`/`finishMetadataReload`,
which is how the sibling `TestEnsureMetadataFor_SharesInFlightReload` already
avoids this class of race. The test takes leadership itself, so the in-flight
window lasts exactly as long as it wants; the callers behind it join
synchronously from the test goroutine, so each is known to have joined the
leader's record before any outcome is published, and only the waiting happens
concurrently. One caller still goes through `EnsureMetadataFor()` so the public
entry point stays covered rather than only the internals.

**No production code is touched**, and every claim the test made is preserved:
all callers receive the leader's error, none runs a reload of its own, and a
later call still starts a fresh attempt rather than being handed a cached
failure.

## Confirming it was flakiness, not a real break

The test lives in a package two of my open PRs touch, so I measured rather than
assumed. With `internal/database` byte-identical between a pristine
`origin/main` worktree and the branch, interleaved rounds of 40 runs gave 1
failure in 8 rounds on main and 2 in 8 on the branch. The test also never
touches anything either PR changes: it exercises `EnsureMetadataFor` and
`metadataLoadAttempts` via `NewClient`, not `ClientManager`.

## Test plan

- [x] 480 runs (12 rounds of `-count=40`) with zero failures, where the old
      test failed 1-2 rounds in 8.
- [x] 30 runs under `-race` and 40 runs under CPU contention (8 busy loops):
      clean.
- [x] Mutation-checked that the test still catches its bug: disabling sharing
      in `joinMetadataReload` fails it immediately with "caller 0 became a
      second leader whilst a reload was in flight".
- [x] `go vet`, `gofmt`, `make lint` (0 issues), `make test`: 905 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when metadata reloads fail, ensuring concurrent requests consistently receive the same error.
  * Confirmed that subsequent reload attempts can retry successfully after a failed attempt.
  * Reduced timing-related inconsistencies in concurrent metadata reload handling.

* **Documentation**
  * Added an unreleased changelog entry describing the improved metadata reload reliability and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->