### PR TITLE
fix(web): derive the client version from package.json

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -207,6 +207,56 @@ At the end of each README:
 
 - Update `changelog.md` with notable changes since the last release.
 
+## Versioning
+
+A release must update the version in every place below. **Treat this list
+as a starting point and not as authoritative**; it records where versions
+lived when it was written, and a new one can appear at any time without
+this file being updated. Always finish with a manual check, searching the
+tree for the outgoing version string and reading what each hit means:
+
+```bash
+git grep -n "1\.2\.3"   # the version being replaced
+```
+
+The minimal set of places to update:
+
+- `web/package.json`, along with the `version` fields in
+  `web/package-lock.json`. Run `npm version <version> --no-git-tag-version`
+  in `web/` rather than editing them by hand.
+
+- `internal/mcp/server.go`, in the `ServerVersion` constant. The server
+  reports it over MCP `initialize`, on `/health`, and in the OpenAPI
+  specification.
+
+- `internal/chat/mcp_client.go`, in the `ClientVersion` constant. The CLI
+  reports it in `--version` and its welcome banner.
+
+- `docs/changelog.md`, which needs a new release heading with the date, and
+  the entries moved out of `[Unreleased]`.
+
+- `examples/helm/pgedge-nla/Chart.yaml`, in both `version` and
+  `appVersion`.
+
+- The git tag itself, which is what the release workflow and the RPM and
+  Debian packaging derive their version from: `pkg/build-rpm.sh` and
+  `pkg/build-deb.sh` read it out of the tag, so neither needs editing.
+  Note that `pkg/common.sh` carries a hardcoded fallback for when
+  `COMPONENT_VERSION` is unset, which affects local package builds only;
+  update it if you rely on those.
+
+Two things deliberately need no update, and should not be given one:
+
+- The web client's `CLIENT_VERSION` in `web/src/lib/mcp-client.js` is
+  injected from `web/package.json` by the `define` in `vite.config.js` and
+  `vitest.config.js`. Bumping the manifest is enough. It was previously a
+  literal, which is exactly how it came to sit at `1.0.0-alpha5` through
+  five subsequent releases whilst every other version moved on.
+
+- The `version` label in `Dockerfile.cli`, `Dockerfile.server`, and
+  `Dockerfile.web` carries only `major.minor`, so a patch release leaves it
+  alone.
+
 ## Tests
 
 - Provide unit and integration tests for Go packages.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,6 +78,16 @@ and this project adheres to
   the leader join synchronously rather than being raced into place. The
   behaviour under test is unchanged, and no production code is touched.
 
+- The web client reports its real version again. `CLIENT_VERSION` was a
+  literal in `web/src/lib/mcp-client.js` and had sat at `1.0.0-alpha5`
+  since that release, through alpha6, beta1, beta2, beta3 and 1.0.0, so the
+  help panel showed `Web Client: v1.0.0-alpha5` alongside `Server: v1.0.0`.
+  The stale value also went out as `clientInfo.version` in every MCP
+  `initialize` handshake, which is what the server's logs and traces
+  recorded. It is now injected from `web/package.json`, the manifest a
+  release already has to bump, so the two cannot drift apart; a test
+  asserts the two agree.
+
 ### Security
 
 - `release.yml`'s `build-web`, `build-amd64`, and `build-arm64` jobs run on

--- a/web/src/lib/__tests__/version.test.js
+++ b/web/src/lib/__tests__/version.test.js
@@ -1,0 +1,32 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - Client Version Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CLIENT_VERSION } from '../mcp-client';
+import pkg from '../../../package.json';
+
+// CLIENT_VERSION was a literal in mcp-client.js and sat at 1.0.0-alpha5
+// through five subsequent releases, showing a stale version in the help
+// panel and, more importantly, sending one as clientInfo.version in every
+// MCP initialize handshake. It is now injected from package.json, and these
+// tests fail if anyone reintroduces a literal that can drift from it.
+describe('CLIENT_VERSION', () => {
+    it('matches the version in package.json', () => {
+        expect(CLIENT_VERSION).toBe(pkg.version);
+    });
+
+    it('is a non-empty semver-shaped string', () => {
+        // Guards against the define being dropped from a config, which would
+        // otherwise surface as undefined in the handshake rather than failing
+        // anything.
+        expect(typeof CLIENT_VERSION).toBe('string');
+        expect(CLIENT_VERSION).toMatch(/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/);
+    });
+});

--- a/web/src/lib/mcp-client.js
+++ b/web/src/lib/mcp-client.js
@@ -8,8 +8,13 @@
  *-------------------------------------------------------------------------
  */
 
-// Web client version - keep in sync with server releases
-export const CLIENT_VERSION = '1.0.0-alpha5';
+// Web client version, injected from web/package.json by the define in
+// vite.config.js and vitest.config.js. It is deliberately not a literal
+// here: this constant is shown in the help panel and sent as
+// clientInfo.version in the MCP initialize handshake, and as a literal it
+// sat at 1.0.0-alpha5 through five subsequent releases because nothing
+// tied it to anything that a release already had to touch.
+export const CLIENT_VERSION = __APP_VERSION__;
 
 /**
  * MCP Client for communicating with MCP server via JSON-RPC

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,8 +1,19 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// The client's version comes from package.json rather than a literal in the
+// source, so that a release bumps it in one place. Keep this define in step
+// with vitest.config.js, which needs it for the same reason.
+const { version } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf8')
+);
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   server: {
     port: 5173,
     proxy: {

--- a/web/vitest.config.js
+++ b/web/vitest.config.js
@@ -8,12 +8,22 @@
  *-------------------------------------------------------------------------
  */
 
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
 
+// Mirrors the define in vite.config.js: the tests exercise the same source,
+// so they need the version injected the same way.
+const { version } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf8')
+);
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

`CLIENT_VERSION` was a literal in `web/src/lib/mcp-client.js`, under the comment
"keep in sync with server releases", and it had sat at `1.0.0-alpha5` ever since
that release: alpha6, beta1, beta2, beta3 and 1.0.0 all shipped without it
moving, whilst `ServerVersion`, the CLI's `ClientVersion` and `web/package.json`
were each carried along. Hence the help panel reading `Web Client:
v1.0.0-alpha5  |  Server: v1.0.0`.

It is more than cosmetic: `mcp-client.js:106` sends the same constant as
`clientInfo.version` in every MCP `initialize` handshake, so the server's logs
and traces have been recording this client as five releases older than it is.

It is now injected from `web/package.json` by a `define` in `vite.config.js`,
mirrored in `vitest.config.js` so the tests exercise the same value. A release
that bumps the manifest, which it must do anyway, now bumps this with it.

## Also: a documented list of version locations

`.claude/CLAUDE.md` gains a Versioning section recording the minimal set of
places a release must update, which I established by auditing the tree rather
than by guessing: `web/package.json` (+ lockfile), `ServerVersion`,
`ClientVersion`, `docs/changelog.md`, the Helm chart's `version` and
`appVersion`, and the git tag that the RPM and Debian builds derive from. It
also records what deliberately needs no update: this newly-derived
`CLIENT_VERSION`, and the Dockerfile `version` labels, which carry only
`major.minor`.

Per your request it states plainly that the list is a starting point rather than
authoritative, and that a manual `git grep` for the outgoing version is still
required. A list like that going stale is the same failure mode as the constant
it describes, so it should not be trusted on its own.

## Test plan

- [x] Two new tests: `CLIENT_VERSION` equals `package.json`'s version, and is a
      non-empty semver-shaped string. The first fails if a literal is
      reintroduced and drifts (verified: reverting to `'1.0.0-alpha5'` fails
      with `expected '1.0.0-alpha5' to be '1.0.0'`); the second catches the
      define being dropped from a config, which would otherwise surface as
      `undefined` in the handshake rather than failing anything.
- [x] `npm test`: 129 tests pass. `npm run build` clean.
- [x] Inspected the built bundle: no `1.0.0-alpha5` anywhere, and the manifest
      version is inlined (`mh="1.0.0"`).
- [x] Verified in a browser against a running server: the help panel now reads
      `Web Client: v1.0.0  |  Server: v1.0.0`.

## Note on the Go side

The CLI and server have the same class of hazard, and I have deliberately left
it out of this PR: see the comment below, since it needs a decision rather than
just a patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronized the web client’s displayed version and MCP handshake version with the application release version.
  * Ensured version information is generated consistently for production builds and tests.

* **Tests**
  * Added validation confirming the client version matches the application version and follows semantic versioning.

* **Documentation**
  * Documented the release versioning process and updated the changelog with the version synchronization fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->