### PR TITLE
fix(security): validate the Origin header to prevent DNS rebinding

### DIFF
--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -815,18 +815,30 @@ func main() {
 				cfg.HTTP.ClientIP.Header, len(cfg.HTTP.ClientIP.TrustedProxies))
 		}
 
+		// Fail at startup rather than at the first request if an origin
+		// is malformed, and report the effective policy either way, so an
+		// operator can see whether the bundled web client will be
+		// accepted from wherever it is actually served.
+		originPolicy, originErr := mcp.NewOriginPolicy(cfg.HTTP.AllowedOrigins)
+		if originErr != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Invalid Origin configuration: %v\n", originErr)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Accepting browser requests from: %s\n", originPolicy.Describe())
+
 		// Create HTTP server configuration
 		httpConfig := &mcp.HTTPConfig{
-			Addr:        cfg.HTTP.Address,
-			TLSEnable:   cfg.HTTP.TLS.Enabled,
-			CertFile:    cfg.HTTP.TLS.CertFile,
-			KeyFile:     cfg.HTTP.TLS.KeyFile,
-			ChainFile:   cfg.HTTP.TLS.ChainFile,
-			AuthEnabled: cfg.HTTP.Auth.Enabled,
-			TokenStore:  tokenStore,
-			UserStore:   userStore,
-			ClientIP:    clientIPResolver,
-			Debug:       *debug,
+			Addr:           cfg.HTTP.Address,
+			TLSEnable:      cfg.HTTP.TLS.Enabled,
+			CertFile:       cfg.HTTP.TLS.CertFile,
+			KeyFile:        cfg.HTTP.TLS.KeyFile,
+			ChainFile:      cfg.HTTP.TLS.ChainFile,
+			AuthEnabled:    cfg.HTTP.Auth.Enabled,
+			TokenStore:     tokenStore,
+			UserStore:      userStore,
+			ClientIP:       clientIPResolver,
+			AllowedOrigins: cfg.HTTP.AllowedOrigins,
+			Debug:          *debug,
 		}
 
 		// Setup additional HTTP handlers

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -97,6 +97,34 @@ and this project adheres to
   now gated on `github.ref_type == 'tag'`, matching the existing
   snapshot-mode gate on the GoReleaser step itself.
 
+- The server now validates the `Origin` header on HTTP requests and
+  refuses an unexpected origin with `403 Forbidden`, closing a DNS
+  rebinding exposure. A page on any site the user was visiting could
+  previously drive a locally running server: the attacker points their
+  own domain at `127.0.0.1`, the browser then treats the local server
+  as belonging to that domain, and the page reads the responses, which
+  here means the schemas and query results of every configured
+  database. The check reads `Origin` alone and never `Host`, because
+  under rebinding the attacker controls the hostname the browser
+  connects to, so the two agree and comparing them would admit the very
+  request being guarded against. Validation covers every HTTP route,
+  not just the MCP endpoint, and runs ahead of authentication.
+
+  **This can require configuration when upgrading.** With no origins
+  configured the server accepts loopback origins only (`localhost`,
+  `127.0.0.1`, `::1`, either scheme, any port), which covers local use
+  and the bundled web client unchanged. A deployment that serves the
+  web client under a real hostname must now list that origin in the new
+  `http.allowed_origins` setting, or `PGEDGE_HTTP_ALLOWED_ORIGINS`, and
+  will otherwise see its own browser requests refused. Listing any
+  origin replaces the loopback default rather than adding to it. A
+  request that carries no `Origin` header at all is unaffected, so
+  command line clients, scripts and other non-browser callers need no
+  change. The effective policy is reported in the server's startup
+  output, and a malformed entry stops the server rather than being
+  ignored. See [Security](guide/security.md) and
+  [Configuration](guide/configuration.md) for details. Fixes #231.
+
 - Raised the `go.mod` floor from 1.26.1 to 1.26.5. Building this server
   with the actual go1.26.3 toolchain and running `govulncheck` in binary
   mode showed crypto/tls, net/textproto, and crypto/x509 stdlib

--- a/docs/developers/mcp-spec-compliance.md
+++ b/docs/developers/mcp-spec-compliance.md
@@ -153,14 +153,6 @@ Unlike the section above, these are not deliberate choices -- they are
 gaps found during review that this pass did not set out to fix, recorded
 here so nobody has to re-derive them:
 
-* **`Origin` header validation.** The Streamable HTTP transport's
-  security section requires servers to validate the `Origin` header on
-  every incoming connection, to prevent DNS rebinding attacks, and to
-  respond `403 Forbidden` when it is present and invalid. This server
-  does not currently do so anywhere in `internal/mcp`. This predates
-  the `2026-07-28` work and applies equally to the legacy transport;
-  it needs its own fix.
-
 * **`Accept` header.** The transport requires a client to list both
   `application/json` and `text/event-stream`, because a conforming
   server may answer any request with either a single JSON object or a

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -47,6 +47,50 @@ specify property values, grouped by section.
 | `http.client_ip.source` | N/A | `PGEDGE_HTTP_CLIENT_IP_SOURCE` | Where the client address is read from; `socket` or `header` (default: "socket") |
 | `http.client_ip.header` | N/A | `PGEDGE_HTTP_CLIENT_IP_HEADER` | Forwarding header read when the source is `header` (default: "X-Real-IP") |
 | `http.client_ip.trusted_proxies` | N/A | `PGEDGE_HTTP_CLIENT_IP_TRUSTED_PROXIES` | Comma-separated addresses or CIDR blocks permitted to set that header |
+| `http.allowed_origins` | N/A | `PGEDGE_HTTP_ALLOWED_ORIGINS` | Comma-separated web origins accepted in the `Origin` header (default: loopback origins only) |
+
+### Browser Origins
+
+The server validates the `Origin` header that a browser sets on every
+request it makes. The `http.allowed_origins` setting lists the origins
+that the server accepts; a request carrying any other origin is refused
+with `403 Forbidden`.
+
+This check prevents DNS rebinding, in which a page on a site the user
+is merely visiting makes that site's own hostname resolve to a loopback
+address, so that the browser treats requests to a locally running
+server as same-origin and hands the page the responses. The server
+therefore judges a request by the origin the browser reports, and never
+by the `Host` header, which the attacker controls just as freely.
+
+By default, no origins are configured, and the server accepts only
+loopback origins: `localhost`, `127.0.0.1` and `::1`, under either
+scheme and on any port. This suits local use, including the bundled web
+client, without any configuration.
+
+A deployment that publishes the web client under a real hostname must
+name that origin, because the browser reports the address the user
+visited:
+
+```yaml
+http:
+  allowed_origins:
+    - https://mcp.example.com         # The origin users visit
+    - https://mcp.internal.example    # More than one may be listed
+```
+
+Naming any origin replaces the loopback default rather than adding to
+it, so list the loopback origins as well if you also reach the server
+locally. An origin is a scheme, a host and a port; `https://example.com`
+and `http://example.com` are different origins, as are two ports on the
+same host. The server rejects a malformed entry at startup rather than
+ignoring it, and reports the effective policy in its startup output.
+
+Requests that carry no `Origin` header at all are unaffected, so
+command line clients, scripts and other non-browser callers need no
+configuration here. The header is a statement a browser makes about
+itself; an attacker who can set arbitrary headers is not working
+through a browser, and so is not what this control addresses.
 
 ### Client Address Resolution
 

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -43,6 +43,8 @@ You should instead:
 
 - Enable HTTPS with a valid CA certificate.
 - Enable authentication (do not use `-no-auth`).
+- List the origins the web client is served from in
+  `http.allowed_origins`.
 - Configure tokens with expiration dates.
 - Set private keys to 600 permissions.
 - Set token file to 600 permissions.
@@ -325,3 +327,49 @@ belongs in the provider client library, so that a credential never
 reaches an error value at all. Treat this as a safety net beneath
 that, and continue to keep provider keys out of any output you
 publish.
+
+## Browser Origins and DNS Rebinding
+
+A server reachable over HTTP is reachable by any page the user happens
+to be visiting, because a browser will send a request wherever a page
+tells it to. The defence against this is the `Origin` header, which the
+browser sets to the site the request came from and a page cannot forge.
+This server refuses a request whose origin it does not expect, with
+`403 Forbidden`.
+
+The attack this addresses is DNS rebinding. An attacker serves a page
+from a domain they control, then changes that domain's DNS record to
+point at `127.0.0.1`. The browser, having already loaded the page,
+resolves the name again and connects to the user's own machine, whilst
+still regarding the page as belonging to the attacker's domain. Any
+server listening locally is now reachable from that page, and the page
+can read the responses. For this server that means the schemas and
+query results of every configured database, through the tools the MCP
+endpoint exposes.
+
+Two properties of the check are worth understanding.
+
+The server judges a request by `Origin` alone, and never by `Host`.
+Under rebinding, the hostname the browser connects to belongs to the
+attacker, so `Host` and `Origin` agree with each other; a check that
+compared them would admit precisely the request it was meant to stop.
+Only a list of origins the operator expects can tell the two apart.
+
+A request carrying no `Origin` header is allowed through. Browsers set
+the header, and most MCP clients are not browsers, so rejecting its
+absence would break every command line client. It would also prevent
+nothing, because an attacker able to set arbitrary headers is not
+working through a browser and is not subject to this control at all.
+
+By default the server accepts loopback origins only, on any port, which
+covers local use and the bundled web client without configuration. A
+deployment that publishes the web client under a hostname must list
+that origin in `http.allowed_origins`, or the browser's own requests
+will be refused. See
+[Configuration](configuration.md#browser-origins) for the setting.
+
+This control assumes the server is reachable only where you intend.
+Consider also whether the listen address needs to be as broad as it is:
+the default binds every interface, and a server used only from the
+machine it runs on can bind loopback instead, by setting
+`http.address` to `127.0.0.1:8080`.

--- a/examples/pgedge-postgres-mcp-http.yaml.example
+++ b/examples/pgedge-postgres-mcp-http.yaml.example
@@ -34,6 +34,20 @@ http:
         header: X-Real-IP
         trusted_proxies: []
 
+    # Web origins accepted in the Origin header, which browsers set on
+    # every request. Any other origin is refused with 403, which is what
+    # stops a hostile page from driving this server through DNS
+    # rebinding. Leaving the list empty accepts loopback origins only
+    # (localhost, 127.0.0.1 and ::1, on any port), which covers local use
+    # including the bundled web client. Publishing the web client under a
+    # real hostname means naming that origin here, since listing any
+    # origin replaces the loopback default rather than adding to it.
+    # Requests with no Origin header, such as those from command line
+    # clients, are unaffected.
+    allowed_origins: []
+    #allowed_origins:
+    #    - https://mcp.example.com
+
 # Database connection configuration
 # Multiple databases can be configured; each must have a unique name.
 # Use available_to_users to restrict access to specific users (empty = all users)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,6 +150,16 @@ type HTTPConfig struct {
 	TLS      TLSConfig      `yaml:"tls"`
 	Auth     AuthConfig     `yaml:"auth"`
 	ClientIP ClientIPConfig `yaml:"client_ip"`
+
+	// AllowedOrigins lists the web origins the server accepts in the
+	// Origin header, as scheme://host[:port]. A browser sets that header;
+	// a request without one is unaffected, so command line clients need no
+	// configuration here. Leaving this empty accepts loopback origins on
+	// any port and refuses every other origin with 403, which is what
+	// prevents a hostile page from driving a local server through DNS
+	// rebinding. A deployment published under a real hostname must name
+	// that origin here, or its own web client will be refused.
+	AllowedOrigins []string `yaml:"allowed_origins"`
 }
 
 // ClientIPConfig controls how the server decides which address a request came
@@ -659,6 +669,7 @@ func defaultConfig() *Config {
 				Header:         "X-Real-IP", // Only consulted when source is "header"
 				TrustedProxies: nil,         // No proxy is trusted until an operator names one
 			},
+			AllowedOrigins: nil, // Empty means loopback origins only
 		},
 		Databases: []NamedDatabaseConfig{}, // Empty by default, populated from config file
 		Embedding: EmbeddingConfig{
@@ -761,6 +772,9 @@ func mergeConfig(dest, src *Config) {
 	// Replace rather than append, so a config file can narrow an inherited list
 	if len(src.HTTP.ClientIP.TrustedProxies) > 0 {
 		dest.HTTP.ClientIP.TrustedProxies = src.HTTP.ClientIP.TrustedProxies
+	}
+	if len(src.HTTP.AllowedOrigins) > 0 {
+		dest.HTTP.AllowedOrigins = src.HTTP.AllowedOrigins
 	}
 
 	// Databases - if source has databases defined, use them (replace, don't merge)
@@ -1057,6 +1071,7 @@ func applyEnvironmentVariables(cfg *Config) {
 	setStringFromEnv(&cfg.HTTP.ClientIP.Source, "PGEDGE_HTTP_CLIENT_IP_SOURCE")
 	setStringFromEnv(&cfg.HTTP.ClientIP.Header, "PGEDGE_HTTP_CLIENT_IP_HEADER")
 	setStringSliceFromEnv(&cfg.HTTP.ClientIP.TrustedProxies, "PGEDGE_HTTP_CLIENT_IP_TRUSTED_PROXIES")
+	setStringSliceFromEnv(&cfg.HTTP.AllowedOrigins, "PGEDGE_HTTP_ALLOWED_ORIGINS")
 
 	// Database environment variables apply to the first database in the list
 	// If no databases configured yet, create a default one from env vars

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -986,6 +986,32 @@ func setStringSliceFromEnv(dest *[]string, key string) {
 	*dest = entries
 }
 
+// setAllowedOriginsFromEnv sets the allowed origins from an environment
+// variable, keeping blank entries rather than discarding them.
+//
+// setStringSliceFromEnv drops blanks, which is right for a list where a
+// stray comma means nothing, but wrong here. An origin list is validated
+// at startup precisely so a typo is reported rather than acted upon, and
+// dropping the blanks from a value such as "," would leave an empty list,
+// which is not an error but a request for the loopback-only default. The
+// operator would then be running a policy they never chose. Keeping the
+// blanks lets NewOriginPolicy refuse the value and name it.
+//
+// An absent or entirely empty variable still means "unset", so it leaves
+// the configured default alone.
+func setAllowedOriginsFromEnv(dest *[]string, key string) {
+	val := os.Getenv(key)
+	if strings.TrimSpace(val) == "" {
+		return
+	}
+
+	entries := make([]string, 0, strings.Count(val, ",")+1)
+	for _, entry := range strings.Split(val, ",") {
+		entries = append(entries, strings.TrimSpace(entry))
+	}
+	*dest = entries
+}
+
 // setStringFromEnvWithFallback sets a string config value from an environment variable,
 // checking multiple environment variable names in priority order
 func setStringFromEnvWithFallback(dest *string, keys ...string) {
@@ -1071,7 +1097,7 @@ func applyEnvironmentVariables(cfg *Config) {
 	setStringFromEnv(&cfg.HTTP.ClientIP.Source, "PGEDGE_HTTP_CLIENT_IP_SOURCE")
 	setStringFromEnv(&cfg.HTTP.ClientIP.Header, "PGEDGE_HTTP_CLIENT_IP_HEADER")
 	setStringSliceFromEnv(&cfg.HTTP.ClientIP.TrustedProxies, "PGEDGE_HTTP_CLIENT_IP_TRUSTED_PROXIES")
-	setStringSliceFromEnv(&cfg.HTTP.AllowedOrigins, "PGEDGE_HTTP_ALLOWED_ORIGINS")
+	setAllowedOriginsFromEnv(&cfg.HTTP.AllowedOrigins, "PGEDGE_HTTP_ALLOWED_ORIGINS")
 
 	// Database environment variables apply to the first database in the list
 	// If no databases configured yet, create a default one from env vars

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1034,6 +1034,58 @@ func TestClientIPConfigDefaults(t *testing.T) {
 	}
 }
 
+func TestAllowedOriginsDefaults(t *testing.T) {
+	cfg := defaultConfig()
+
+	// Empty is meaningful: it selects the loopback-only policy that keeps
+	// a default deployment safe from DNS rebinding without any
+	// configuration at all.
+	if len(cfg.HTTP.AllowedOrigins) != 0 {
+		t.Errorf("expected no configured origins by default, got %v", cfg.HTTP.AllowedOrigins)
+	}
+}
+
+func TestMergeAllowedOrigins(t *testing.T) {
+	dest := defaultConfig()
+	src := &Config{
+		HTTP: HTTPConfig{
+			AllowedOrigins: []string{"https://mcp.example.com"},
+		},
+	}
+
+	mergeConfig(dest, src)
+
+	if len(dest.HTTP.AllowedOrigins) != 1 || dest.HTTP.AllowedOrigins[0] != "https://mcp.example.com" {
+		t.Fatalf("expected the configured origin to be merged, got %v", dest.HTTP.AllowedOrigins)
+	}
+
+	// An empty list must not clear a value already merged in, or a later
+	// partial config file would silently narrow the policy back to
+	// loopback and lock out the deployment's own web client.
+	mergeConfig(dest, &Config{})
+	if len(dest.HTTP.AllowedOrigins) != 1 {
+		t.Errorf("expected the configured origin to remain, got %v", dest.HTTP.AllowedOrigins)
+	}
+}
+
+func TestApplyEnvironmentVariables_AllowedOrigins(t *testing.T) {
+	os.Setenv("PGEDGE_HTTP_ALLOWED_ORIGINS", "https://a.example, https://b.example")
+	defer os.Unsetenv("PGEDGE_HTTP_ALLOWED_ORIGINS")
+
+	cfg := defaultConfig()
+	applyEnvironmentVariables(cfg)
+
+	expected := []string{"https://a.example", "https://b.example"}
+	if len(cfg.HTTP.AllowedOrigins) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, cfg.HTTP.AllowedOrigins)
+	}
+	for i, want := range expected {
+		if cfg.HTTP.AllowedOrigins[i] != want {
+			t.Errorf("origin %d = %q, want %q", i, cfg.HTTP.AllowedOrigins[i], want)
+		}
+	}
+}
+
 func TestMergeClientIPConfig(t *testing.T) {
 	dest := defaultConfig()
 	src := &Config{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1086,6 +1086,55 @@ func TestApplyEnvironmentVariables_AllowedOrigins(t *testing.T) {
 	}
 }
 
+func TestApplyEnvironmentVariables_AllowedOriginsMalformedValues(t *testing.T) {
+	// A malformed value must reach NewOriginPolicy intact so startup can
+	// refuse it and say why. Silently reducing "," to an empty list would
+	// select the loopback-only default, leaving the operator running a
+	// policy they never asked for; that fails closed rather than open, but
+	// it is still not the policy they configured.
+	malformed := []struct {
+		name  string
+		value string
+	}{
+		{"only a comma", ","},
+		{"trailing comma", "https://a.example,"},
+		{"blank between commas", "https://a.example,,https://b.example"},
+		{"whitespace only", "   "},
+	}
+
+	for _, tt := range malformed {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("PGEDGE_HTTP_ALLOWED_ORIGINS", tt.value)
+			defer os.Unsetenv("PGEDGE_HTTP_ALLOWED_ORIGINS")
+
+			cfg := defaultConfig()
+			applyEnvironmentVariables(cfg)
+
+			if tt.name == "whitespace only" {
+				// Indistinguishable from unset, so the default stands.
+				if len(cfg.HTTP.AllowedOrigins) != 0 {
+					t.Errorf("expected a whitespace-only value to be treated as unset, got %v",
+						cfg.HTTP.AllowedOrigins)
+				}
+				return
+			}
+
+			// Every other case must retain a blank entry, which is what
+			// makes it an error rather than an empty list.
+			blanks := 0
+			for _, origin := range cfg.HTTP.AllowedOrigins {
+				if origin == "" {
+					blanks++
+				}
+			}
+			if blanks == 0 {
+				t.Errorf("expected a blank entry to survive for %q, got %v",
+					tt.value, cfg.HTTP.AllowedOrigins)
+			}
+		})
+	}
+}
+
 func TestMergeClientIPConfig(t *testing.T) {
 	dest := defaultConfig()
 	src := &Config{

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -31,17 +31,18 @@ import (
 
 // HTTPConfig holds configuration for HTTP/HTTPS server mode
 type HTTPConfig struct {
-	Addr          string                         // Server address (e.g., ":8080")
-	TLSEnable     bool                           // Enable HTTPS
-	CertFile      string                         // Path to TLS certificate file
-	KeyFile       string                         // Path to TLS key file
-	ChainFile     string                         // Optional path to certificate chain file
-	AuthEnabled   bool                           // Enable API token authentication
-	TokenStore    *auth.TokenStore               // Token store for authentication
-	UserStore     *auth.UserStore                // User store for session token authentication
-	ClientIP      *auth.ClientIPResolver         // Resolves the client address; nil means socket only
-	SetupHandlers func(mux *http.ServeMux) error // Optional callback to add custom handlers before auth middleware
-	Debug         bool                           // Enable debug logging
+	Addr           string                         // Server address (e.g., ":8080")
+	TLSEnable      bool                           // Enable HTTPS
+	CertFile       string                         // Path to TLS certificate file
+	KeyFile        string                         // Path to TLS key file
+	ChainFile      string                         // Optional path to certificate chain file
+	AuthEnabled    bool                           // Enable API token authentication
+	TokenStore     *auth.TokenStore               // Token store for authentication
+	UserStore      *auth.UserStore                // User store for session token authentication
+	ClientIP       *auth.ClientIPResolver         // Resolves the client address; nil means socket only
+	AllowedOrigins []string                       // Origins accepted in the Origin header; empty means loopback only
+	SetupHandlers  func(mux *http.ServeMux) error // Optional callback to add custom handlers before auth middleware
+	Debug          bool                           // Enable debug logging
 }
 
 // buildHandler assembles the full mux and middleware chain used in HTTP
@@ -71,6 +72,16 @@ func (s *Server) buildHandler(config *HTTPConfig) (http.Handler, error) {
 	if config.AuthEnabled {
 		handler = auth.AuthMiddleware(config.TokenStore, config.UserStore, true)(handler)
 	}
+
+	// Validate the Origin header ahead of authentication, so a request
+	// from an unexpected origin is turned away before any credential is
+	// examined. Wrapping the whole mux rather than the MCP handler alone
+	// covers /health and the LLM proxy routes as well.
+	originPolicy, err := NewOriginPolicy(config.AllowedOrigins)
+	if err != nil {
+		return nil, fmt.Errorf("invalid allowed origins: %w", err)
+	}
+	handler = originValidationMiddleware(originPolicy)(handler)
 
 	// Wrap with security headers middleware
 	handler = securityHeadersMiddleware(config.TLSEnable)(handler)

--- a/internal/mcp/origin.go
+++ b/internal/mcp/origin.go
@@ -1,0 +1,244 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+
+	"pgedge-postgres-mcp/internal/httperror"
+)
+
+// The Streamable HTTP transport requires a server to validate the Origin
+// header on every incoming connection, and to answer 403 when the header
+// is present and invalid, so that a hostile page cannot drive a locally
+// running server through a browser that has been made to resolve the
+// attacker's own domain to a loopback address (DNS rebinding).
+//
+// The check deliberately keys on Origin alone and never on Host. Under
+// rebinding the attacker controls the hostname the browser connects to,
+// so Host carries the attacker's domain just as Origin does; comparing
+// the two would find them equal and let the request through. Only a list
+// of origins the operator expects can distinguish the two cases.
+//
+// A request with no Origin header at all is allowed through. The header
+// is set by browsers, and most MCP clients are not browsers; rejecting
+// its absence would break every command line client without preventing
+// anything, since an attacker who can set arbitrary headers is not
+// working through a browser and is not subject to this control.
+
+// defaultAllowedOrigins matches an origin served from the loopback
+// interface on any port, under either scheme. This is the out-of-the-box
+// policy: the bundled web client, and an MCP client with a browser-based
+// UI, are reached over localhost during ordinary local use, whereas a
+// deployment published under a real hostname is expected to name that
+// hostname in configuration.
+var defaultLoopbackHosts = map[string]bool{
+	"localhost": true,
+	"127.0.0.1": true,
+	"::1":       true,
+}
+
+// OriginPolicy decides whether a request's Origin header is acceptable.
+// The zero value is not usable; build one with NewOriginPolicy.
+type OriginPolicy struct {
+	// allowed holds the operator's configured origins, normalised to
+	// scheme://host:port with the scheme's default port made explicit so
+	// that "https://example.com" and "https://example.com:443" compare
+	// equal.
+	allowed map[string]bool
+
+	// loopback reports whether an origin on the loopback interface is
+	// accepted regardless of port. True when no origins are configured.
+	loopback bool
+}
+
+// NewOriginPolicy builds a policy from the configured origin list. An
+// empty list yields the default loopback-only policy. Every entry must
+// be an absolute http or https origin with no path, query or fragment,
+// so that a typo in configuration fails at startup rather than silently
+// admitting nothing.
+func NewOriginPolicy(configured []string) (*OriginPolicy, error) {
+	policy := &OriginPolicy{allowed: make(map[string]bool)}
+
+	if len(configured) == 0 {
+		policy.loopback = true
+		return policy, nil
+	}
+
+	for _, entry := range configured {
+		trimmed := strings.TrimSpace(entry)
+		if trimmed == "" {
+			return nil, fmt.Errorf("allowed_origins contains an empty entry")
+		}
+
+		normalised, err := normaliseOrigin(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("allowed_origins entry %q: %w", entry, err)
+		}
+		policy.allowed[normalised] = true
+	}
+
+	return policy, nil
+}
+
+// normaliseOrigin parses an origin and renders it as scheme://host:port
+// with the default port for the scheme filled in. Comparing normalised
+// forms means a configured "https://example.com" also matches a browser
+// sending "https://example.com:443", which is the same origin.
+func normaliseOrigin(origin string) (string, error) {
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return "", fmt.Errorf("not a valid URL: %w", err)
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("scheme must be http or https, got %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("no host")
+	}
+	// An origin is a scheme, host and port and nothing else. Anything
+	// further is a URL that has been mistaken for one, and silently
+	// ignoring the extra part would accept a configuration that does not
+	// mean what its author thinks it means.
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", fmt.Errorf("must not include a path")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("must not include a query or fragment")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("must not include user information")
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("no host")
+	}
+
+	port := parsed.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	return scheme + "://" + net.JoinHostPort(host, port), nil
+}
+
+// Allow reports whether an Origin header value is acceptable. An empty
+// value means the header was absent, which is allowed; see the package
+// comment above for why.
+func (p *OriginPolicy) Allow(origin string) bool {
+	if origin == "" {
+		return true
+	}
+
+	// "null" is what a browser sends for an opaque origin: a sandboxed
+	// iframe, a document loaded from file://, or a redirect chain that
+	// has lost its origin. It names no host, so it can never be matched
+	// against an expectation and is refused.
+	if origin == "null" {
+		return false
+	}
+
+	normalised, err := normaliseOrigin(origin)
+	if err != nil {
+		return false
+	}
+
+	if p.allowed[normalised] {
+		return true
+	}
+
+	if p.loopback {
+		parsed, err := url.Parse(origin)
+		if err != nil {
+			return false
+		}
+		return defaultLoopbackHosts[strings.ToLower(parsed.Hostname())]
+	}
+
+	return false
+}
+
+// Describe renders the policy for the startup log, so an operator can
+// see which origins the running server will accept.
+func (p *OriginPolicy) Describe() string {
+	if p.loopback {
+		return "loopback origins only (localhost, 127.0.0.1, ::1; any port)"
+	}
+
+	origins := make([]string, 0, len(p.allowed))
+	for origin := range p.allowed {
+		origins = append(origins, origin)
+	}
+	sort.Strings(origins)
+	return strings.Join(origins, ", ")
+}
+
+// originValidationMiddleware rejects a request whose Origin header is
+// present and not permitted by the policy. It sits ahead of
+// authentication so a hostile page is turned away before any credential
+// handling, and it wraps the whole mux rather than the MCP handler alone
+// so that the health endpoint and the LLM proxy routes are covered too.
+func originValidationMiddleware(policy *OriginPolicy) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if policy.Allow(origin) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			writeForbiddenOrigin(w, r, origin)
+		})
+	}
+}
+
+// writeForbiddenOrigin answers a rejected request with 403. The MCP
+// endpoint gets a JSON-RPC error response with a null id, which the
+// transport specification explicitly permits and which lets a client
+// distinguish this refusal from an unrelated proxy denying the request;
+// every other route gets this server's ordinary JSON error body.
+func writeForbiddenOrigin(w http.ResponseWriter, r *http.Request, origin string) {
+	message := fmt.Sprintf("Origin %q is not permitted", origin)
+
+	if r.URL.Path != "/mcp/v1" {
+		httperror.Write(w, http.StatusForbidden, message)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+
+	response := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      nil,
+		Error: &RPCError{
+			Code:    -32600,
+			Message: message,
+		},
+	}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to encode response: %v\n", err)
+	}
+}

--- a/internal/mcp/origin_test.go
+++ b/internal/mcp/origin_test.go
@@ -1,0 +1,326 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewOriginPolicy_RejectsMalformedEntries(t *testing.T) {
+	// A typo in configuration must stop the server at startup. Accepting
+	// it and silently matching nothing would leave an operator believing
+	// an origin is permitted when every request from it is refused.
+	tests := []struct {
+		name       string
+		configured []string
+	}{
+		{"empty entry", []string{""}},
+		{"whitespace only", []string{"   "}},
+		{"no scheme", []string{"example.com"}},
+		{"unsupported scheme", []string{"ftp://example.com"}},
+		{"file scheme", []string{"file:///etc/passwd"}},
+		{"no host", []string{"https://"}},
+		{"includes a path", []string{"https://example.com/app"}},
+		{"includes a query", []string{"https://example.com?a=1"}},
+		{"includes a fragment", []string{"https://example.com#frag"}},
+		{"includes credentials", []string{"https://user:pass@example.com"}},
+		{"one bad among good", []string{"https://good.example", "nonsense"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewOriginPolicy(tt.configured); err == nil {
+				t.Errorf("NewOriginPolicy(%q) succeeded, want an error", tt.configured)
+			}
+		})
+	}
+}
+
+func TestOriginPolicy_DefaultAllowsLoopbackOnly(t *testing.T) {
+	policy, err := NewOriginPolicy(nil)
+	if err != nil {
+		t.Fatalf("NewOriginPolicy(nil) failed: %v", err)
+	}
+
+	allowed := []string{
+		"",                       // no header at all: a non-browser client
+		"http://localhost",       // implicit port 80
+		"http://localhost:8080",  // the bundled web client's usual port
+		"https://localhost:8443", // the same over TLS
+		"http://127.0.0.1:3000",  // a development server
+		"http://[::1]:8080",      // IPv6 loopback
+		"HTTP://LOCALHOST:8080",  // case is not significant
+	}
+	for _, origin := range allowed {
+		if !policy.Allow(origin) {
+			t.Errorf("Allow(%q) = false, want true under the default policy", origin)
+		}
+	}
+
+	refused := []string{
+		"https://mcp.example.com",
+		"http://evil.example",
+		"null",                      // opaque origin: sandboxed iframe or file://
+		"http://localhost.evil.com", // suffix trickery, not loopback
+		"http://notlocalhost",
+		"http://127.0.0.1.evil.com",
+		"not a url at all",
+	}
+	for _, origin := range refused {
+		if policy.Allow(origin) {
+			t.Errorf("Allow(%q) = true, want false under the default policy", origin)
+		}
+	}
+}
+
+func TestOriginPolicy_ConfiguredListReplacesLoopbackDefault(t *testing.T) {
+	// Naming an origin is a deliberate act, so the default stops applying:
+	// an operator who lists a production origin has said what this server
+	// serves, and silently keeping localhost would widen that.
+	policy, err := NewOriginPolicy([]string{"https://mcp.example.com"})
+	if err != nil {
+		t.Fatalf("NewOriginPolicy failed: %v", err)
+	}
+
+	if !policy.Allow("https://mcp.example.com") {
+		t.Error("Allow(configured origin) = false, want true")
+	}
+	// The same origin written with its default port explicit is the same
+	// origin, and a browser may send either form.
+	if !policy.Allow("https://mcp.example.com:443") {
+		t.Error("Allow(configured origin with explicit default port) = false, want true")
+	}
+	if policy.Allow("http://localhost:8080") {
+		t.Error("Allow(loopback) = true once origins are configured, want false")
+	}
+	if policy.Allow("http://mcp.example.com") {
+		t.Error("Allow(http against an https origin) = true, want false: scheme is part of an origin")
+	}
+	if policy.Allow("https://mcp.example.com:8443") {
+		t.Error("Allow(wrong port) = true, want false: port is part of an origin")
+	}
+	if !policy.Allow("") {
+		t.Error("Allow(no header) = false, want true: non-browser clients send none")
+	}
+}
+
+func TestOriginPolicy_DescribeNamesTheEffectivePolicy(t *testing.T) {
+	defaultPolicy, err := NewOriginPolicy(nil)
+	if err != nil {
+		t.Fatalf("NewOriginPolicy(nil) failed: %v", err)
+	}
+	if got := defaultPolicy.Describe(); !strings.Contains(got, "loopback") {
+		t.Errorf("Describe() = %q, want it to mention loopback", got)
+	}
+
+	configured, err := NewOriginPolicy([]string{"https://b.example", "https://a.example"})
+	if err != nil {
+		t.Fatalf("NewOriginPolicy failed: %v", err)
+	}
+	got := configured.Describe()
+	for _, want := range []string{"a.example", "b.example"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Describe() = %q, want it to mention %q", got, want)
+		}
+	}
+	// Sorted, so the startup line does not reshuffle between restarts.
+	if strings.Index(got, "a.example") > strings.Index(got, "b.example") {
+		t.Errorf("Describe() = %q, want origins in sorted order", got)
+	}
+}
+
+// newOriginTestHandler builds the middleware over a handler that records
+// whether the request reached it, which is what distinguishes a refusal
+// from a request that was merely answered with an error further in.
+func newOriginTestHandler(t *testing.T, configured []string) (http.Handler, *bool) {
+	t.Helper()
+
+	policy, err := NewOriginPolicy(configured)
+	if err != nil {
+		t.Fatalf("NewOriginPolicy failed: %v", err)
+	}
+
+	reached := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return originValidationMiddleware(policy)(inner), &reached
+}
+
+func TestOriginMiddleware_RefusesDisallowedOriginWithJSONRPCError(t *testing.T) {
+	handler, reached := newOriginTestHandler(t, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", strings.NewReader("{}"))
+	req.Header.Set("Origin", "https://evil.example")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if *reached {
+		t.Error("the request reached the wrapped handler, want it refused by the middleware")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	// The transport specification permits a JSON-RPC error response with
+	// no id here, and it is what lets a client tell this refusal apart
+	// from an unrelated proxy returning a bare 403.
+	var response JSONRPCResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("response body is not JSON: %v (body %q)", err, w.Body.String())
+	}
+	if response.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc = %q, want \"2.0\"", response.JSONRPC)
+	}
+	if response.ID != nil {
+		t.Errorf("id = %v, want null", response.ID)
+	}
+	if response.Error == nil {
+		t.Fatal("response carries no error object")
+	}
+	if !strings.Contains(response.Error.Message, "evil.example") {
+		t.Errorf("error message = %q, want it to name the refused origin", response.Error.Message)
+	}
+}
+
+func TestOriginMiddleware_AllowsPermittedAndAbsentOrigins(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin string
+		set    bool
+	}{
+		{"no Origin header", "", false},
+		{"loopback origin", "http://localhost:8080", true},
+		{"IPv6 loopback origin", "http://[::1]:8080", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, reached := newOriginTestHandler(t, nil)
+
+			req := httptest.NewRequest(http.MethodPost, "/mcp/v1", strings.NewReader("{}"))
+			if tt.set {
+				req.Header.Set("Origin", tt.origin)
+			}
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if !*reached {
+				t.Error("the request did not reach the wrapped handler, want it allowed")
+			}
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+		})
+	}
+}
+
+func TestOriginMiddleware_CoversEveryRouteNotJustMCP(t *testing.T) {
+	// The health endpoint and the LLM proxy routes are as reachable from
+	// a hostile page as the MCP endpoint is, so the middleware wraps the
+	// whole mux. Non-MCP routes get this server's ordinary JSON error
+	// body rather than a JSON-RPC one, since they do not speak JSON-RPC.
+	for _, path := range []string{"/health", "/api/llm/models", "/"} {
+		t.Run(path, func(t *testing.T) {
+			handler, reached := newOriginTestHandler(t, nil)
+
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Origin", "https://evil.example")
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if *reached {
+				t.Errorf("%s reached the wrapped handler, want it refused", path)
+			}
+			if w.Code != http.StatusForbidden {
+				t.Errorf("%s status = %d, want %d", path, w.Code, http.StatusForbidden)
+			}
+
+			var body struct {
+				Error string `json:"error"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("%s body is not JSON: %v", path, err)
+			}
+			if body.Error == "" {
+				t.Errorf("%s body carries no error message", path)
+			}
+		})
+	}
+}
+
+func TestOriginMiddleware_RebindingCannotPassByMatchingHost(t *testing.T) {
+	// The whole point of the control. Under DNS rebinding the attacker
+	// owns the hostname the browser resolves to a loopback address, so
+	// Host and Origin agree with each other; a check that compared them
+	// would admit exactly the request this is meant to stop.
+	handler, reached := newOriginTestHandler(t, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", strings.NewReader("{}"))
+	req.Host = "rebound.attacker.example"
+	req.Header.Set("Origin", "http://rebound.attacker.example")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if *reached {
+		t.Error("a rebinding request whose Host matches its Origin was allowed through")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestBuildHandler_RejectsInvalidConfiguredOrigins(t *testing.T) {
+	// A malformed origin must stop the server rather than degrade to a
+	// policy nobody chose.
+	server := NewServer(&mockToolProvider{})
+	_, err := server.buildHandler(&HTTPConfig{AllowedOrigins: []string{"not-an-origin"}})
+	if err == nil {
+		t.Fatal("buildHandler succeeded with a malformed origin, want an error")
+	}
+	if !strings.Contains(err.Error(), "origin") {
+		t.Errorf("error = %q, want it to mention the origin configuration", err)
+	}
+}
+
+func TestBuildHandler_OriginCheckRunsBeforeAuthentication(t *testing.T) {
+	// A hostile page must be turned away before any credential handling,
+	// so the refusal is a 403 about the origin rather than a 401 that
+	// would invite a credentialed retry.
+	server := NewServer(&mockToolProvider{})
+	handler, err := server.buildHandler(&HTTPConfig{AuthEnabled: true})
+	if err != nil {
+		t.Fatalf("buildHandler failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1", strings.NewReader("{}"))
+	req.Header.Set("Origin", "https://evil.example")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d (the origin check must precede auth)", w.Code, http.StatusForbidden)
+	}
+}


### PR DESCRIPTION
## Summary

The Streamable HTTP transport requires a server to validate the `Origin`
header on every incoming connection and to answer `403 Forbidden` when it is
present and invalid. This server did not do so anywhere: `buildHandler`
assembled auth, security headers, client IP resolution and panic recovery, and
none of it read the header. The gap predates the `2026-07-28` work that
recorded it under "Known gaps", and applied equally to the legacy transport.

The exposure is DNS rebinding. An attacker serves a page from a domain they
control, then repoints that domain at `127.0.0.1`; the browser connects to the
user's own machine whilst still regarding the page as belonging to the
attacker's domain, so a locally running server becomes reachable and the page
can read the responses. Here that means the schemas and query results of every
configured database, through the tools the MCP endpoint exposes.

It is tempting to think the absent CORS configuration already prevents this. It
does not: the rebound request is same-origin as far as the browser is
concerned, so no preflight is sent and nothing is blocked.

## Two properties worth reviewing carefully

**The check reads `Origin` alone and never `Host`.** Under rebinding the
attacker owns the hostname the browser connects to, so `Host` carries the
attacker's domain just as `Origin` does; a check comparing the two would find
them equal and admit exactly the request it exists to stop. Only a list of
origins the operator expects distinguishes the cases.
`TestOriginMiddleware_RebindingCannotPassByMatchingHost` pins this.

**A request with no `Origin` header is allowed through.** Browsers set the
header and most MCP clients are not browsers, so rejecting its absence would
break every command line client whilst preventing nothing: an attacker able to
set arbitrary headers is not working through a browser and is not subject to
this control at all.

## Shape of the fix

Validation is middleware wrapping the whole mux, so `/health` and the LLM proxy
routes are covered rather than the MCP endpoint alone, and it sits ahead of
authentication so a hostile page is refused before any credential is examined.
The MCP endpoint's refusal is a JSON-RPC error response with a null `id`, which
the transport explicitly permits and which lets a client tell this apart from
an unrelated proxy returning a bare `403`; other routes get the usual JSON
error body.

Origin comparison covers scheme, host and port, with default ports normalised
so `https://example.com` matches `https://example.com:443`. A malformed
configured entry stops the server at startup rather than silently matching
nothing, and the effective policy is printed at startup.

## Upgrade impact

With nothing configured the policy is loopback-only (`localhost`, `127.0.0.1`,
`::1`, either scheme, any port), so local use and the bundled web client keep
working untouched, including the Docker Compose demo, where the browser reaches
the web client on `localhost:8081`.

**A deployment that publishes the web client under a real hostname must name
that origin** in the new `http.allowed_origins` setting, or
`PGEDGE_HTTP_ALLOWED_ORIGINS`, and will otherwise see its own browser requests
refused. Naming any origin replaces the loopback default rather than adding to
it. This is called out as an upgrade step in the changelog.

## Test plan

- [x] New `internal/mcp/origin_test.go`: policy parsing and rejection of
      malformed configuration, the loopback default, configured lists replacing
      it, scheme and port significance, opaque `null` origins, suffix trickery
      (`localhost.evil.com`, `127.0.0.1.evil.com`), IPv6 loopback, the
      rebinding case, coverage of non-MCP routes, and ordering against auth.
- [x] New config tests for the default, merge semantics and the environment
      variable.
- [x] Mutation-tested: making `Allow` permissive fails six tests; moving the
      middleware behind authentication fails
      `TestBuildHandler_OriginCheckRunsBeforeAuthentication` with 401 where 403
      is required.
- [x] `gofmt`, `go vet`, `golangci-lint` (0 issues), `go test ./internal/...`
      all clean.
- [x] `go test ./test/...` clean apart from `CallGetSchemaInfo`, which needs a
      real PostgreSQL and fails identically on an unmodified tree in this
      environment; CI runs it against a service container.

Closes #231.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added browser-origin validation across HTTP routes to help prevent unauthorized cross-origin access and DNS-rebinding attacks.
  * Disallowed origins receive `403 Forbidden`; requests without an `Origin` header remain unaffected.
  * Invalid origin settings prevent server startup.

* **Configuration**
  * Added `http.allowed_origins` and `PGEDGE_HTTP_ALLOWED_ORIGINS` support.
  * Empty configuration allows loopback origins by default; configured origins replace that default.

* **Documentation**
  * Updated configuration, security guidance, changelog, and HTTP examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->