### PR TITLE
fix(security): confirm writes whose first keyword reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ test: test-server test-client
 # covered by test-client, so they are deliberately absent rather than missing.
 test-server:
 	@echo "Running server tests..."
-	$(GO) test -v ./internal/api/... ./internal/auth/... ./internal/compactor/... ./internal/config/... ./internal/conversations/... ./internal/crypto/... ./internal/database/... ./internal/definitions/... ./internal/httperror/... ./internal/llmtracing/... ./internal/logging/... ./internal/mcp/... ./internal/openapi/... ./internal/prompts/... ./internal/redact/... ./internal/resources/... ./internal/search/... ./internal/tools/... ./internal/tracing/... ./internal/tsv/... ./$(SERVER_CMD_DIR)/...
+	$(GO) test -v ./internal/api/... ./internal/auth/... ./internal/compactor/... ./internal/config/... ./internal/conversations/... ./internal/crypto/... ./internal/database/... ./internal/definitions/... ./internal/httperror/... ./internal/llmtracing/... ./internal/logging/... ./internal/mcp/... ./internal/openapi/... ./internal/prompts/... ./internal/redact/... ./internal/resources/... ./internal/search/... ./internal/sqltext/... ./internal/tools/... ./internal/tracing/... ./internal/tsv/... ./$(SERVER_CMD_DIR)/...
 
 # Run client tests
 test-client:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -145,9 +145,15 @@ and this project adheres to
   rather than an escape ran the literal on to the end of the statement and
   hid whatever followed it, so `SELECT E'\'' INTO backup FROM users`
   classified as a read; a backslash in a plain `'...'` literal is still an
-  ordinary character, as `standard_conforming_strings` requires. The
-  read-only guardrails benefit from the same correction, since a statement
-  that hides its tail from the scanner also hides it from them. Note that this
+  ordinary character, as `standard_conforming_strings` requires. The scanner
+  also no longer lets a `$` that continues an identifier open a dollar-quote
+  tag. PostgreSQL treats `$` as a legal, non-initial identifier character, so
+  `x$tag$` lexes as one identifier; misreading the first `$` as a failed
+  delimiter attempt let the very next `$` open a real, attacker-chosen
+  dollar-quoted block, so `SELECT 1 AS x$tag$; DELETE FROM t -- $tag$` hid
+  the `DELETE` and classified as a read. The read-only guardrails benefit
+  from the same correction, since a statement that hides its tail from the
+  scanner also hides it from them. Note that this
   is a client-side prompt and not a security boundary: a statement whose
   writes happen inside a function it calls still reads as a `SELECT`, and
   nothing textual could tell otherwise. What prevents a write on a read-only

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -139,7 +139,15 @@ and this project adheres to
   are still treated as the reads they are, so the prompt keeps its meaning.
   The scanner the read-only guardrails already used has moved to
   `internal/sqltext` and is now shared with the classifier, with
-  `web/src/utils/sqlText.js` mirroring it for the web client. Note that this
+  `web/src/utils/sqlText.js` mirroring it for the web client. That scanner
+  now also honours backslash escapes inside an `E'...'` escape string
+  constant, and only there. Reading the `\'` in `E'\''` as a doubled quote
+  rather than an escape ran the literal on to the end of the statement and
+  hid whatever followed it, so `SELECT E'\'' INTO backup FROM users`
+  classified as a read; a backslash in a plain `'...'` literal is still an
+  ordinary character, as `standard_conforming_strings` requires. The
+  read-only guardrails benefit from the same correction, since a statement
+  that hides its tail from the scanner also hides it from them. Note that this
   is a client-side prompt and not a security boundary: a statement whose
   writes happen inside a function it calls still reads as a `SELECT`, and
   nothing textual could tell otherwise. What prevents a write on a read-only

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -125,6 +125,26 @@ and this project adheres to
   ignored. See [Security](guide/security.md) and
   [Configuration](guide/configuration.md) for details. Fixes #231.
 
+- The write-confirmation prompt in both clients now recognises a write whose
+  first keyword reads. It classified a statement by that keyword alone, so
+  `SELECT ... INTO`, which creates and populates a table, a CTE carrying an
+  `INSERT`, `UPDATE` or `DELETE`, and `EXPLAIN ANALYZE` of any of those, were
+  all read as ordinary `SELECT`s and ran on a writable connection without the
+  user being asked. This completes the fix that made custom tools confirm
+  their writes: that change corrected which tools are gated, whilst this one
+  corrects which statements are. Classification now runs against the
+  statement's comment-stripped, literal-blanked code, so a keyword inside a
+  string can no longer be mistaken for the real thing and a comment can no
+  longer hide one; `SELECT ... FOR UPDATE` and `EXPLAIN` without `ANALYZE`
+  are still treated as the reads they are, so the prompt keeps its meaning.
+  The scanner the read-only guardrails already used has moved to
+  `internal/sqltext` and is now shared with the classifier, with
+  `web/src/utils/sqlText.js` mirroring it for the web client. Note that this
+  is a client-side prompt and not a security boundary: a statement whose
+  writes happen inside a function it calls still reads as a `SELECT`, and
+  nothing textual could tell otherwise. What prevents a write on a read-only
+  connection remains the transaction access mode set by the server.
+
 - Raised the `go.mod` floor from 1.26.1 to 1.26.5. Building this server
   with the actual go1.26.3 toolchain and running `govulncheck` in binary
   mode showed crypto/tls, net/textproto, and crypto/x509 stdlib

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -148,12 +148,14 @@ and this project adheres to
   ordinary character, as `standard_conforming_strings` requires. The scanner
   also no longer lets a `$` that continues an identifier open a dollar-quote
   tag. PostgreSQL treats `$` as a legal, non-initial identifier character, so
-  `x$tag$` lexes as one identifier; misreading the first `$` as a failed
-  delimiter attempt let the very next `$` open a real, attacker-chosen
-  dollar-quoted block, so `SELECT 1 AS x$tag$; DELETE FROM t -- $tag$` hid
-  the `DELETE` and classified as a read. The read-only guardrails benefit
-  from the same correction, since a statement that hides its tail from the
-  scanner also hides it from them. Note that this
+  `x$tag$` lexes as one identifier, but the scanner read forward from the
+  first `$` and accepted the second one as that tag's own closing mark,
+  mistaking two bytes of an identifier for a tag `$tag$` and then hunting
+  for its next occurrence to close the body. Planting one later in the
+  statement, `SELECT 1 AS x$tag$; DELETE FROM t -- $tag$` hid the `DELETE`
+  and classified as a read. The read-only guardrails benefit from the same
+  correction, since a statement that hides its tail from the scanner also
+  hides it from them. Note that this
   is a client-side prompt and not a security boundary: a statement whose
   writes happen inside a function it calls still reads as a `SELECT`, and
   nothing textual could tell otherwise. What prevents a write on a read-only

--- a/internal/chat/query_classify.go
+++ b/internal/chat/query_classify.go
@@ -37,7 +37,7 @@ var readPrefixes = []string{
 // write outright, whatever follows them.
 var (
 	ddlPrefixes = []string{"CREATE", "DROP", "ALTER", "TRUNCATE"}
-	dmlPrefixes = []string{"INSERT", "UPDATE", "DELETE"}
+	dmlPrefixes = []string{"INSERT", "UPDATE", "DELETE", "MERGE"}
 )
 
 // dmlIndicator and ddlIndicator match a keyword that makes a read-prefixed

--- a/internal/chat/query_classify.go
+++ b/internal/chat/query_classify.go
@@ -10,7 +10,12 @@
 
 package chat
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+
+	"pgedge-postgres-mcp/internal/sqltext"
+)
 
 // QueryType represents the type of SQL query
 type QueryType int
@@ -22,33 +27,125 @@ const (
 	QueryTypeOther
 )
 
-// ClassifyQuery determines if a SQL query is a read or write
-// operation. Returns the query type and whether the query modifies
-// data.
+// readPrefixes are the leading keywords of a statement that reads. Reaching
+// one is not on its own enough to call a statement a read: see writeIndicator.
+var readPrefixes = []string{
+	"SELECT", "WITH", "TABLE", "VALUES", "EXPLAIN", "SHOW",
+}
+
+// ddlPrefixes and dmlPrefixes are the leading keywords that make a statement a
+// write outright, whatever follows them.
+var (
+	ddlPrefixes = []string{"CREATE", "DROP", "ALTER", "TRUNCATE"}
+	dmlPrefixes = []string{"INSERT", "UPDATE", "DELETE"}
+)
+
+// dmlIndicator and ddlIndicator match a keyword that makes a read-prefixed
+// statement write after all.
+//
+// INTO catches SELECT ... INTO, which creates and populates a table. In a
+// statement that begins SELECT or WITH, INTO can only be SELECT ... INTO or
+// the INTO of a data-modifying INSERT, and both are writes. The remaining
+// keywords catch a data-modifying CTE, where the write hides inside a
+// statement whose first word is WITH.
+// The two halves are matched separately so that a statement caught here can
+// still be reported as DML or DDL; dmlIndicator is tried first, so that the
+// INTO of an INSERT is not mistaken for the INTO of a SELECT ... INTO.
+var (
+	dmlIndicator = regexp.MustCompile(`(?i)\b(INSERT|UPDATE|DELETE|MERGE)\b`)
+	ddlIndicator = regexp.MustCompile(
+		`(?i)\b(INTO|CREATE|DROP|ALTER|TRUNCATE|GRANT|REVOKE)\b`)
+)
+
+// rowLockClause matches the locking clauses of an ordinary SELECT. They take
+// row locks but modify nothing, and their UPDATE keyword would otherwise trip
+// writeIndicator, so they are removed before it runs.
+var rowLockClause = regexp.MustCompile(
+	`(?i)\bFOR\s+(NO\s+KEY\s+UPDATE|KEY\s+SHARE|UPDATE|SHARE)\b`)
+
+// analyzeOption matches the ANALYZE option of EXPLAIN, which is what makes
+// EXPLAIN run the statement it is given rather than only plan it.
+var analyzeOption = regexp.MustCompile(`(?i)\bANALYZE\b`)
+
+// ClassifyQuery determines if a SQL query is a read or write operation.
+// Returns the query type and whether the query modifies data.
+//
+// The result drives the confirmation prompt shown before a statement runs on a
+// writable connection, so the cost of the two errors is not symmetric: calling
+// a read a write costs a needless prompt, whilst calling a write a read lets
+// the statement run unannounced. Anything unrecognised is therefore treated as
+// a write, and the checks below lean the same way.
+//
+// Matching is done against the statement's code with comments removed and
+// literals blanked, so that a keyword inside a string cannot be mistaken for
+// the real thing and a comment cannot be used to hide one.
+//
+// This is a client-side prompt and not a security boundary. A statement whose
+// writes happen inside a function it calls still reads as a SELECT here, and
+// nothing textual could tell otherwise. What actually prevents a write on a
+// read-only connection is the transaction access mode set by the server.
 func ClassifyQuery(sql string) (QueryType, bool) {
-	upper := strings.ToUpper(strings.TrimSpace(sql))
+	residue, _ := sqltext.Strip(sql)
+	upper := strings.ToUpper(strings.TrimSpace(residue))
 
 	switch {
-	case strings.HasPrefix(upper, "SELECT"),
-		strings.HasPrefix(upper, "WITH"),
-		strings.HasPrefix(upper, "TABLE"),
-		strings.HasPrefix(upper, "VALUES"),
-		strings.HasPrefix(upper, "EXPLAIN"),
-		strings.HasPrefix(upper, "SHOW"):
-		return QueryTypeSelect, false
-
-	case strings.HasPrefix(upper, "CREATE"),
-		strings.HasPrefix(upper, "DROP"),
-		strings.HasPrefix(upper, "ALTER"),
-		strings.HasPrefix(upper, "TRUNCATE"):
+	case hasPrefix(upper, ddlPrefixes):
 		return QueryTypeDDL, true
 
-	case strings.HasPrefix(upper, "INSERT"),
-		strings.HasPrefix(upper, "UPDATE"),
-		strings.HasPrefix(upper, "DELETE"):
+	case hasPrefix(upper, dmlPrefixes):
 		return QueryTypeDML, true
+
+	case hasPrefix(upper, readPrefixes):
+		return classifyReadPrefixed(upper)
 
 	default:
 		return QueryTypeOther, true
 	}
+}
+
+// classifyReadPrefixed decides whether a statement whose first keyword reads
+// nevertheless writes.
+func classifyReadPrefixed(upper string) (QueryType, bool) {
+	// TABLE, VALUES and SHOW admit no write: TABLE and VALUES have no target
+	// to write to, and SHOW only reports a setting.
+	if hasPrefix(upper, []string{"TABLE", "VALUES", "SHOW"}) {
+		return QueryTypeSelect, false
+	}
+
+	// EXPLAIN only plans its statement unless ANALYZE is given, in which case
+	// it runs it. EXPLAIN INSERT is a read; EXPLAIN ANALYZE INSERT is not.
+	if strings.HasPrefix(upper, "EXPLAIN") && !analyzeOption.MatchString(upper) {
+		return QueryTypeSelect, false
+	}
+
+	scanned := rowLockClause.ReplaceAllString(upper, " ")
+	switch {
+	case dmlIndicator.MatchString(scanned):
+		return QueryTypeDML, true
+	case ddlIndicator.MatchString(scanned):
+		return QueryTypeDDL, true
+	default:
+		return QueryTypeSelect, false
+	}
+}
+
+// hasPrefix reports whether the statement begins with any of the given
+// keywords, requiring a word boundary after the match so that a table called
+// "updates" is not read as an UPDATE.
+func hasPrefix(upper string, keywords []string) bool {
+	for _, kw := range keywords {
+		if !strings.HasPrefix(upper, kw) {
+			continue
+		}
+		rest := upper[len(kw):]
+		if rest == "" || !isIdentifierByte(rest[0]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIdentifierByte(c byte) bool {
+	return c == '_' || c >= '0' && c <= '9' ||
+		c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z'
 }

--- a/internal/chat/query_classify_test.go
+++ b/internal/chat/query_classify_test.go
@@ -79,6 +79,18 @@ func TestClassifyQuery(t *testing.T) {
 			"EXPLAIN (ANALYZE, BUFFERS) UPDATE t SET n = 1", QueryTypeDML, true},
 		{"comment hiding select into",
 			"/* harmless */ SELECT * INTO backup FROM users", QueryTypeDDL, true},
+		{"merge", "MERGE INTO t USING s ON t.id = s.id " +
+			"WHEN MATCHED THEN UPDATE SET n = s.n", QueryTypeDML, true},
+
+		// An escape string constant must not be allowed to swallow the rest of
+		// the statement. Read as a doubled quote rather than an escape, E'\''
+		// runs to the end of the text and hides the INTO behind it.
+		{"escape string hiding select into",
+			`SELECT E'\'' INTO backup FROM users`, QueryTypeDDL, true},
+		{"escape string hiding select into after a comma",
+			`SELECT E'a\'' , x INTO t FROM u`, QueryTypeDDL, true},
+		{"lowercase escape string hiding select into",
+			`SELECT e'\'' INTO backup FROM users`, QueryTypeDDL, true},
 
 		// Reads that must stay quiet, so that the prompt keeps its meaning.
 		{"explain insert without analyze",
@@ -87,6 +99,11 @@ func TestClassifyQuery(t *testing.T) {
 			"EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM t", QueryTypeSelect, false},
 		{"write keyword inside a literal",
 			"SELECT * FROM audit WHERE action = 'DELETE'", QueryTypeSelect, false},
+		{"write keyword inside an escape string literal",
+			`SELECT * FROM audit WHERE action = E'DEL\'ETE'`,
+			QueryTypeSelect, false},
+		{"backslash in a plain literal is an ordinary character",
+			`SELECT * FROM t WHERE path = 'C:\'`, QueryTypeSelect, false},
 		{"write keyword inside a quoted identifier",
 			`SELECT "delete" FROM t`, QueryTypeSelect, false},
 		{"write keyword as part of an identifier",

--- a/internal/chat/query_classify_test.go
+++ b/internal/chat/query_classify_test.go
@@ -54,9 +54,56 @@ func TestClassifyQuery(t *testing.T) {
 		{"commit", "COMMIT", QueryTypeOther, true},
 		{"set", "SET timezone TO 'UTC'", QueryTypeOther, true},
 
+		// Writes hiding behind a reading first keyword. Each of these runs a
+		// write on a writable connection, so each must raise the prompt.
+		{"select into", "SELECT * INTO backup FROM users", QueryTypeDDL, true},
+		{"select into lowercase", "select id into t2 from t1", QueryTypeDDL, true},
+		{"select into strict spacing", "SELECT 1 INTO\nnewtbl", QueryTypeDDL, true},
+		{"cte writing insert",
+			"WITH c AS (SELECT 1 AS n) INSERT INTO t SELECT n FROM c",
+			QueryTypeDML, true},
+		{"cte returning insert",
+			"WITH ins AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * FROM ins",
+			QueryTypeDML, true},
+		{"cte returning update",
+			"WITH u AS (UPDATE t SET n = 1 RETURNING *) SELECT * FROM u",
+			QueryTypeDML, true},
+		{"cte returning delete",
+			"WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d",
+			QueryTypeDML, true},
+		{"cte select into", "WITH c AS (SELECT 1) SELECT * INTO t FROM c",
+			QueryTypeDDL, true},
+		{"explain analyze insert",
+			"EXPLAIN ANALYZE INSERT INTO t VALUES (1)", QueryTypeDML, true},
+		{"explain analyze options update",
+			"EXPLAIN (ANALYZE, BUFFERS) UPDATE t SET n = 1", QueryTypeDML, true},
+		{"comment hiding select into",
+			"/* harmless */ SELECT * INTO backup FROM users", QueryTypeDDL, true},
+
+		// Reads that must stay quiet, so that the prompt keeps its meaning.
+		{"explain insert without analyze",
+			"EXPLAIN INSERT INTO t VALUES (1)", QueryTypeSelect, false},
+		{"explain analyze select",
+			"EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM t", QueryTypeSelect, false},
+		{"write keyword inside a literal",
+			"SELECT * FROM audit WHERE action = 'DELETE'", QueryTypeSelect, false},
+		{"write keyword inside a quoted identifier",
+			`SELECT "delete" FROM t`, QueryTypeSelect, false},
+		{"write keyword as part of an identifier",
+			"SELECT delete_flag, into_tray FROM t", QueryTypeSelect, false},
+		{"select for update", "SELECT * FROM t FOR UPDATE", QueryTypeSelect, false},
+		{"select for no key update",
+			"SELECT * FROM t FOR NO KEY UPDATE", QueryTypeSelect, false},
+		{"select for share", "SELECT * FROM t FOR SHARE", QueryTypeSelect, false},
+		{"comment before an ordinary select",
+			"-- counting rows\nSELECT count(*) FROM t", QueryTypeSelect, false},
+		{"subquery select", "SELECT * FROM t WHERE id IN (SELECT id FROM u)",
+			QueryTypeSelect, false},
+
 		// Edge cases
 		{"empty string", "", QueryTypeOther, true},
 		{"whitespace only", "   ", QueryTypeOther, true},
+		{"comment only", "-- nothing here", QueryTypeOther, true},
 	}
 
 	for _, tt := range tests {

--- a/internal/chat/query_classify_test.go
+++ b/internal/chat/query_classify_test.go
@@ -100,6 +100,12 @@ func TestClassifyQuery(t *testing.T) {
 			"SELECT 1 AS x$tag$; DELETE FROM t -- $tag$", QueryTypeDML, true},
 		{"dollar quote decoy without a tag hiding a delete",
 			"SELECT 1 AS x$$; DELETE FROM t -- $$", QueryTypeDML, true},
+		// The same decoy hiding a single statement's own INTO: verified
+		// against a real PostgreSQL server to actually create the target
+		// table when executed, since a genuine SELECT INTO is not caught by
+		// the multi-statement protection a smuggled second statement is.
+		{"dollar quote decoy hiding a select into",
+			"SELECT 1 AS x$tag$ INTO backup FROM users -- $tag$", QueryTypeDDL, true},
 
 		// Reads that must stay quiet, so that the prompt keeps its meaning.
 		{"explain insert without analyze",

--- a/internal/chat/query_classify_test.go
+++ b/internal/chat/query_classify_test.go
@@ -92,6 +92,15 @@ func TestClassifyQuery(t *testing.T) {
 		{"lowercase escape string hiding select into",
 			`SELECT e'\'' INTO backup FROM users`, QueryTypeDDL, true},
 
+		// A dollar-quote tag glued onto the end of an identifier must not be
+		// read as a delimiter: PostgreSQL treats x$tag$ as a single
+		// identifier, and misreading it opens a real, attacker-chosen
+		// dollar-quoted block that can swallow a smuggled statement.
+		{"dollar quote decoy hiding a delete",
+			"SELECT 1 AS x$tag$; DELETE FROM t -- $tag$", QueryTypeDML, true},
+		{"dollar quote decoy without a tag hiding a delete",
+			"SELECT 1 AS x$$; DELETE FROM t -- $$", QueryTypeDML, true},
+
 		// Reads that must stay quiet, so that the prompt keeps its meaning.
 		{"explain insert without analyze",
 			"EXPLAIN INSERT INTO t VALUES (1)", QueryTypeSelect, false},

--- a/internal/sqltext/sqltext.go
+++ b/internal/sqltext/sqltext.go
@@ -37,9 +37,11 @@ import "strings"
 // construct is ambiguous or unterminated it stops treating the text as a
 // literal and lets the remainder fall through to the residue as code, so the
 // failure mode is a rejected valid query rather than an admitted hostile one.
-// Backslash escapes inside string literals are not honoured, matching
-// standard_conforming_strings being on, which is the default and the only
-// setting under which the shorter reading is also the safer one.
+// Backslash escapes are honoured inside an E'...' escape string constant and
+// nowhere else. In a plain '...' literal a backslash is an ordinary character
+// under standard_conforming_strings, which is the default, so treating it as
+// an escape there would run the literal past its real end and hide the code
+// that follows.
 func Strip(query string) (residue string, bare string) {
 	var res, bar strings.Builder
 	res.Grow(len(query))
@@ -56,11 +58,18 @@ func Strip(query string) (residue string, bare string) {
 			i = skipBlockComment(query, i)
 			writeNoiseSeparator(&res, &bar)
 
+		case escapeStringStart(query, i):
+			// Write the E through to both forms, then consume the literal
+			// itself with backslash escapes honoured.
+			res.WriteByte(query[i])
+			bar.WriteByte(query[i])
+			i = consumeQuoted(query, i+1, '\'', true, &res, &bar)
+
 		case query[i] == '\'':
-			i = consumeQuoted(query, i, '\'', &res, &bar)
+			i = consumeQuoted(query, i, '\'', false, &res, &bar)
 
 		case query[i] == '"':
-			i = consumeQuoted(query, i, '"', &res, &bar)
+			i = consumeQuoted(query, i, '"', false, &res, &bar)
 
 		case query[i] == '$':
 			if end, ok := consumeDollarQuote(query, i, &res, &bar); ok {
@@ -111,8 +120,8 @@ func skipLineCommentBody(query string, i int) int {
 // consumeQuoted returns the index just past a quoted literal or identifier
 // starting at i, having written the original text to bar and an empty
 // same-quote placeholder to res.
-func consumeQuoted(query string, i int, quote byte, res, bar *strings.Builder) int {
-	end := endOfQuoted(query, i, quote)
+func consumeQuoted(query string, i int, quote byte, escapes bool, res, bar *strings.Builder) int {
+	end := endOfQuoted(query, i, quote, escapes)
 	bar.WriteString(query[i:end])
 	res.WriteByte(quote)
 	res.WriteByte(quote)
@@ -174,9 +183,19 @@ func skipBlockComment(query string, i int) int {
 // endOfQuoted returns the index just past a literal or quoted identifier that
 // starts at i, treating a doubled quote character as an escaped one. An
 // unterminated quote consumes the remainder of the statement.
-func endOfQuoted(query string, i int, quote byte) int {
+//
+// When escapes is set the literal is an escape string constant, E'...', in
+// which a backslash escapes the character after it. Honouring that matters:
+// in E'\” the backslash escapes the first quote and the second closes the
+// literal, whereas reading the pair as a doubled quote runs the literal on to
+// the end of the statement and hides whatever follows it.
+func endOfQuoted(query string, i int, quote byte, escapes bool) int {
 	i++
 	for i < len(query) {
+		if escapes && query[i] == '\\' && i+1 < len(query) {
+			i += 2
+			continue
+		}
 		if query[i] != quote {
 			i++
 			continue
@@ -188,6 +207,27 @@ func endOfQuoted(query string, i int, quote byte) int {
 		return i + 1
 	}
 	return len(query)
+}
+
+// escapeStringStart reports whether an E'...' escape string constant starts at
+// i, that is whether query[i] is an E introducing a literal rather than an
+// ordinary identifier character. Backslash escapes are honoured only for these
+// literals: with standard_conforming_strings on, which is the default, a
+// backslash in a plain '...' literal is an ordinary character, and treating it
+// as an escape there would run that literal past its real end.
+func escapeStringStart(query string, i int) bool {
+	if query[i] != 'E' && query[i] != 'e' {
+		return false
+	}
+	if i+1 >= len(query) || query[i+1] != '\'' {
+		return false
+	}
+	// An E that continues an identifier, as in "table_e'x'", is not a prefix.
+	return i == 0 || !isIdentifierByte(query[i-1])
+}
+
+func isIdentifierByte(c byte) bool {
+	return c == '_' || isASCIILetter(c) || isASCIIDigit(c)
 }
 
 // dollarQuoteTag returns the opening tag of a dollar-quoted string starting at

--- a/internal/sqltext/sqltext.go
+++ b/internal/sqltext/sqltext.go
@@ -236,12 +236,14 @@ func isIdentifierByte(c byte) bool {
 // dollarQuoteCanStartAt reports whether a dollar-quote tag may begin at i.
 // PostgreSQL treats $ as a legal, non-initial identifier character, so
 // "x$tag$" lexes as the single identifier x$tag$, not as x followed by a
-// dollar-quote delimiter. Without this check that byte is rejected as a tag
-// on its own (dollarQuoteTag's digit rule aside, $ after $ is not a valid
-// tag start either) and the scanner falls back to consuming it as ordinary
-// text one byte at a time, so the very next $ opens a dollar-quoted block
-// whose attacker-chosen closing tag can swallow arbitrary SQL that follows,
-// including a smuggled statement.
+// dollar-quote delimiter. Without this check, dollarQuoteTag reads forward
+// from that first $ and accepts the second one as the tag's own closing
+// mark, mistaking two bytes of an identifier for a two-character tag
+// "$tag$". Once that bogus tag is accepted, the scanner searches for its
+// next literal occurrence to close the body, and an attacker who plants one
+// later in the statement, for example inside a trailing comment, can make
+// everything in between disappear from the residue, including a smuggled
+// statement.
 func dollarQuoteCanStartAt(query string, i int) bool {
 	return i == 0 || (!isIdentifierByte(query[i-1]) && query[i-1] != '$')
 }

--- a/internal/sqltext/sqltext.go
+++ b/internal/sqltext/sqltext.go
@@ -72,12 +72,15 @@ func Strip(query string) (residue string, bare string) {
 			i = consumeQuoted(query, i, '"', false, &res, &bar)
 
 		case query[i] == '$':
-			if end, ok := consumeDollarQuote(query, i, &res, &bar); ok {
-				i = end
-				continue
+			if dollarQuoteCanStartAt(query, i) {
+				if end, ok := consumeDollarQuote(query, i, &res, &bar); ok {
+					i = end
+					continue
+				}
 			}
-			// Not a dollar quote, or never closed: treat as ordinary text so
-			// that anything following is still scanned as code.
+			// Not a dollar quote, never closed, or continuing an
+			// identifier: treat as ordinary text so that anything
+			// following is still scanned as code.
 			res.WriteByte(query[i])
 			bar.WriteByte(query[i])
 			i++
@@ -228,6 +231,19 @@ func escapeStringStart(query string, i int) bool {
 
 func isIdentifierByte(c byte) bool {
 	return c == '_' || isASCIILetter(c) || isASCIIDigit(c)
+}
+
+// dollarQuoteCanStartAt reports whether a dollar-quote tag may begin at i.
+// PostgreSQL treats $ as a legal, non-initial identifier character, so
+// "x$tag$" lexes as the single identifier x$tag$, not as x followed by a
+// dollar-quote delimiter. Without this check that byte is rejected as a tag
+// on its own (dollarQuoteTag's digit rule aside, $ after $ is not a valid
+// tag start either) and the scanner falls back to consuming it as ordinary
+// text one byte at a time, so the very next $ opens a dollar-quoted block
+// whose attacker-chosen closing tag can swallow arbitrary SQL that follows,
+// including a smuggled statement.
+func dollarQuoteCanStartAt(query string, i int) bool {
+	return i == 0 || (!isIdentifierByte(query[i-1]) && query[i-1] != '$')
 }
 
 // dollarQuoteTag returns the opening tag of a dollar-quoted string starting at

--- a/internal/sqltext/sqltext.go
+++ b/internal/sqltext/sqltext.go
@@ -1,0 +1,233 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Package sqltext provides the textual scanning shared by the checks that
+// need to reason about a SQL statement without parsing it.
+//
+// Two callers rely on it, for different purposes. The read-only guardrails in
+// internal/tools use it to decide whether a statement may run at all, and the
+// write classifier in internal/chat uses it to decide whether the user should
+// be asked to confirm a statement before it runs. Both need the same thing:
+// the statement's code with its comments and literals taken out of the way, so
+// that a keyword inside a string cannot be mistaken for the real thing, and a
+// comment cannot be used to hide one.
+//
+// The scanner is deliberately conservative rather than complete. It does not
+// parse SQL, and it is not a substitute for the transaction access mode that
+// actually enforces read-only behaviour at the server.
+package sqltext
+
+import "strings"
+
+// Strip scans a statement once and returns two normalised forms.
+//
+// residue has comments removed and every string literal, dollar-quoted block
+// and quoted identifier replaced by an empty placeholder, leaving only what
+// PostgreSQL would treat as code. bare has comments removed but literals left
+// intact, for the checks that must see inside a literal.
+//
+// The scanner is deliberately conservative rather than complete. Where a
+// construct is ambiguous or unterminated it stops treating the text as a
+// literal and lets the remainder fall through to the residue as code, so the
+// failure mode is a rejected valid query rather than an admitted hostile one.
+// Backslash escapes inside string literals are not honoured, matching
+// standard_conforming_strings being on, which is the default and the only
+// setting under which the shorter reading is also the safer one.
+func Strip(query string) (residue string, bare string) {
+	var res, bar strings.Builder
+	res.Grow(len(query))
+	bar.Grow(len(query))
+
+	i := 0
+	for i < len(query) {
+		switch {
+		case isLineCommentStart(query, i):
+			i = skipLineCommentBody(query, i)
+			writeNoiseSeparator(&res, &bar)
+
+		case isBlockCommentStart(query, i):
+			i = skipBlockComment(query, i)
+			writeNoiseSeparator(&res, &bar)
+
+		case query[i] == '\'':
+			i = consumeQuoted(query, i, '\'', &res, &bar)
+
+		case query[i] == '"':
+			i = consumeQuoted(query, i, '"', &res, &bar)
+
+		case query[i] == '$':
+			if end, ok := consumeDollarQuote(query, i, &res, &bar); ok {
+				i = end
+				continue
+			}
+			// Not a dollar quote, or never closed: treat as ordinary text so
+			// that anything following is still scanned as code.
+			res.WriteByte(query[i])
+			bar.WriteByte(query[i])
+			i++
+
+		default:
+			res.WriteByte(query[i])
+			bar.WriteByte(query[i])
+			i++
+		}
+	}
+
+	return res.String(), bar.String()
+}
+
+// HasMultipleStatements reports whether the residue holds more than one
+// statement. Trailing separators are ignored so that a single statement
+// written with a terminating semicolon is accepted.
+func HasMultipleStatements(residue string) bool {
+	return strings.Contains(strings.TrimRight(residue, "; \t\r\n"), ";")
+}
+
+// writeNoiseSeparator writes a single space to both builders, in place of a
+// dropped comment, so that the comment cannot join the tokens on either
+// side of it.
+func writeNoiseSeparator(res, bar *strings.Builder) {
+	res.WriteByte(' ')
+	bar.WriteByte(' ')
+}
+
+// skipLineCommentBody returns the index just past a "--" line comment
+// starting at i: the position of the next newline, or the end of the
+// string if the comment runs to the end of it.
+func skipLineCommentBody(query string, i int) int {
+	if end := strings.IndexByte(query[i:], '\n'); end >= 0 {
+		return i + end
+	}
+	return len(query)
+}
+
+// consumeQuoted returns the index just past a quoted literal or identifier
+// starting at i, having written the original text to bar and an empty
+// same-quote placeholder to res.
+func consumeQuoted(query string, i int, quote byte, res, bar *strings.Builder) int {
+	end := endOfQuoted(query, i, quote)
+	bar.WriteString(query[i:end])
+	res.WriteByte(quote)
+	res.WriteByte(quote)
+	return end
+}
+
+// consumeDollarQuote reports whether a dollar-quoted block starts at i, and
+// if so returns the index just past it, having written the original text to
+// bar and the tag doubled to res. Reports false if there is no valid, closed
+// dollar-quote at i, in which case the caller falls back to treating
+// query[i] as ordinary text.
+func consumeDollarQuote(query string, i int, res, bar *strings.Builder) (int, bool) {
+	tag, ok := dollarQuoteTag(query, i)
+	if !ok {
+		return 0, false
+	}
+	end := endOfDollarQuote(query, i, tag)
+	if end <= 0 {
+		return 0, false
+	}
+	bar.WriteString(query[i:end])
+	res.WriteString(tag)
+	res.WriteString(tag)
+	return end, true
+}
+
+func isLineCommentStart(query string, i int) bool {
+	return query[i] == '-' && i+1 < len(query) && query[i+1] == '-'
+}
+
+func isBlockCommentStart(query string, i int) bool {
+	return query[i] == '/' && i+1 < len(query) && query[i+1] == '*'
+}
+
+// skipBlockComment returns the index just past a block comment, honouring the
+// nesting that PostgreSQL allows. An unterminated comment consumes the rest of
+// the statement, which is what the server would do with it too.
+func skipBlockComment(query string, i int) int {
+	depth := 0
+	for i < len(query) {
+		if isBlockCommentStart(query, i) {
+			depth++
+			i += 2
+			continue
+		}
+		if query[i] == '*' && i+1 < len(query) && query[i+1] == '/' {
+			depth--
+			i += 2
+			if depth == 0 {
+				return i
+			}
+			continue
+		}
+		i++
+	}
+	return len(query)
+}
+
+// endOfQuoted returns the index just past a literal or quoted identifier that
+// starts at i, treating a doubled quote character as an escaped one. An
+// unterminated quote consumes the remainder of the statement.
+func endOfQuoted(query string, i int, quote byte) int {
+	i++
+	for i < len(query) {
+		if query[i] != quote {
+			i++
+			continue
+		}
+		if i+1 < len(query) && query[i+1] == quote {
+			i += 2
+			continue
+		}
+		return i + 1
+	}
+	return len(query)
+}
+
+// dollarQuoteTag returns the opening tag of a dollar-quoted string starting at
+// i, for example "$$" or "$body$". It reports false for anything else,
+// including positional parameter references such as $1, whose digit start is
+// not a valid tag.
+func dollarQuoteTag(query string, i int) (string, bool) {
+	j := i + 1
+	for j < len(query) {
+		c := query[j]
+		switch {
+		case c == '$':
+			return query[i : j+1], true
+		case c == '_' || isASCIILetter(c):
+			j++
+		case isASCIIDigit(c) && j > i+1:
+			// Digits are allowed in a tag, just not as its first character.
+			j++
+		default:
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// endOfDollarQuote returns the index just past the closing tag of a
+// dollar-quoted string, or 0 if the string is never closed.
+func endOfDollarQuote(query string, i int, tag string) int {
+	body := query[i+len(tag):]
+	end := strings.Index(body, tag)
+	if end < 0 {
+		return 0
+	}
+	return i + len(tag) + end + len(tag)
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isASCIIDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}

--- a/internal/sqltext/sqltext_test.go
+++ b/internal/sqltext/sqltext_test.go
@@ -1,0 +1,126 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package sqltext
+
+import "testing"
+
+func TestStrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		wantResidue string
+		wantBare    string
+	}{
+		{
+			name:        "plain statement is unchanged",
+			query:       "SELECT 1",
+			wantResidue: "SELECT 1",
+			wantBare:    "SELECT 1",
+		},
+		{
+			name:        "string literal is blanked in the residue only",
+			query:       "SELECT 'DELETE'",
+			wantResidue: "SELECT ''",
+			wantBare:    "SELECT 'DELETE'",
+		},
+		{
+			name:        "quoted identifier is blanked in the residue only",
+			query:       `SELECT "delete" FROM t`,
+			wantResidue: `SELECT "" FROM t`,
+			wantBare:    `SELECT "delete" FROM t`,
+		},
+		{
+			name:        "doubled quote does not end a literal early",
+			query:       "SELECT 'it''s DELETE'",
+			wantResidue: "SELECT ''",
+			wantBare:    "SELECT 'it''s DELETE'",
+		},
+		{
+			name:        "line comment becomes a separator",
+			query:       "SELECT 1 -- DROP TABLE t\n",
+			wantResidue: "SELECT 1  \n",
+			wantBare:    "SELECT 1  \n",
+		},
+		{
+			name:        "block comment becomes a separator",
+			query:       "SEL/* hidden */ECT 1",
+			wantResidue: "SEL ECT 1",
+			wantBare:    "SEL ECT 1",
+		},
+		{
+			name:        "nested block comment is consumed whole",
+			query:       "SELECT /* a /* b */ c */ 1",
+			wantResidue: "SELECT   1",
+			wantBare:    "SELECT   1",
+		},
+		{
+			name:        "dollar quoted body is blanked in the residue only",
+			query:       "DO $tag$ DROP TABLE t $tag$",
+			wantResidue: "DO $tag$$tag$",
+			wantBare:    "DO $tag$ DROP TABLE t $tag$",
+		},
+		{
+			name:        "positional parameter is not a dollar quote",
+			query:       "SELECT * FROM t WHERE id = $1",
+			wantResidue: "SELECT * FROM t WHERE id = $1",
+			wantBare:    "SELECT * FROM t WHERE id = $1",
+		},
+		{
+			name:        "unterminated literal consumes the remainder",
+			query:       "SELECT 'oops",
+			wantResidue: "SELECT ''",
+			wantBare:    "SELECT 'oops",
+		},
+		{
+			name:        "unclosed dollar quote falls through as code",
+			query:       "SELECT $tag$ DROP TABLE t",
+			wantResidue: "SELECT $tag$ DROP TABLE t",
+			wantBare:    "SELECT $tag$ DROP TABLE t",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			residue, bare := Strip(tt.query)
+			if residue != tt.wantResidue {
+				t.Errorf("Strip(%q) residue = %q, want %q",
+					tt.query, residue, tt.wantResidue)
+			}
+			if bare != tt.wantBare {
+				t.Errorf("Strip(%q) bare = %q, want %q",
+					tt.query, bare, tt.wantBare)
+			}
+		})
+	}
+}
+
+func TestHasMultipleStatements(t *testing.T) {
+	tests := []struct {
+		residue string
+		want    bool
+	}{
+		{"SELECT 1", false},
+		{"SELECT 1;", false},
+		{"SELECT 1;  \n", false},
+		{"SELECT 1; SELECT 2", true},
+		{"SELECT 1; COMMIT; SET x = 1", true},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.residue, func(t *testing.T) {
+			if got := HasMultipleStatements(tt.residue); got != tt.want {
+				t.Errorf("HasMultipleStatements(%q) = %v, want %v",
+					tt.residue, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sqltext/sqltext_test.go
+++ b/internal/sqltext/sqltext_test.go
@@ -125,6 +125,29 @@ func TestStrip(t *testing.T) {
 			wantResidue: "SELECT $tag$ DROP TABLE t",
 			wantBare:    "SELECT $tag$ DROP TABLE t",
 		},
+		{
+			// A $ that continues an identifier is not a delimiter: PostgreSQL
+			// treats x$tag$ as one identifier. Reading the first $ as a
+			// delimiter attempt fails and falls back to one byte of code,
+			// letting the very next $ open a real dollar-quoted block whose
+			// attacker-chosen closing tag swallows the DELETE that follows.
+			name:        "dollar sign continuing an identifier does not start a tag",
+			query:       "SELECT 1 AS x$tag$; DELETE FROM t -- $tag$",
+			wantResidue: "SELECT 1 AS x$tag$; DELETE FROM t  ",
+			wantBare:    "SELECT 1 AS x$tag$; DELETE FROM t  ",
+		},
+		{
+			name:        "dollar quote immediately after an identifier without a tag",
+			query:       "SELECT 1 AS x$$; DELETE FROM t -- $$",
+			wantResidue: "SELECT 1 AS x$$; DELETE FROM t  ",
+			wantBare:    "SELECT 1 AS x$$; DELETE FROM t  ",
+		},
+		{
+			name:        "dollar quote after a space still opens normally",
+			query:       "DO $ $tag$ DROP TABLE t $tag$",
+			wantResidue: "DO $ $tag$$tag$",
+			wantBare:    "DO $ $tag$ DROP TABLE t $tag$",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/sqltext/sqltext_test.go
+++ b/internal/sqltext/sqltext_test.go
@@ -74,6 +74,46 @@ func TestStrip(t *testing.T) {
 			wantBare:    "SELECT * FROM t WHERE id = $1",
 		},
 		{
+			// Read as a doubled quote the literal would run to the end of the
+			// statement and hide the INTO, which is a write going unseen.
+			name:        "escape string backslash-quote does not close the literal",
+			query:       `SELECT E'\'' INTO backup FROM users`,
+			wantResidue: `SELECT E'' INTO backup FROM users`,
+			wantBare:    `SELECT E'\'' INTO backup FROM users`,
+		},
+		{
+			name:        "escape string with a trailing backslash escape",
+			query:       `SELECT E'a\'' , x INTO t FROM u`,
+			wantResidue: `SELECT E'' , x INTO t FROM u`,
+			wantBare:    `SELECT E'a\'' , x INTO t FROM u`,
+		},
+		{
+			name:        "lowercase e prefix is also an escape string",
+			query:       `SELECT e'\'' INTO t`,
+			wantResidue: `SELECT e'' INTO t`,
+			wantBare:    `SELECT e'\'' INTO t`,
+		},
+		{
+			name:        "escaped backslash does not escape the closing quote",
+			query:       `SELECT E'a\\' INTO t`,
+			wantResidue: `SELECT E'' INTO t`,
+			wantBare:    `SELECT E'a\\' INTO t`,
+		},
+		{
+			// standard_conforming_strings is on by default, so this backslash
+			// is an ordinary character and the literal ends at the next quote.
+			name:        "plain literal does not honour a backslash escape",
+			query:       `SELECT 'a\' , x INTO t FROM u`,
+			wantResidue: `SELECT '' , x INTO t FROM u`,
+			wantBare:    `SELECT 'a\' , x INTO t FROM u`,
+		},
+		{
+			name:        "an E ending an identifier is not an escape prefix",
+			query:       `SELECT * FROM table_e'a\' , x`,
+			wantResidue: `SELECT * FROM table_e'' , x`,
+			wantBare:    `SELECT * FROM table_e'a\' , x`,
+		},
+		{
 			name:        "unterminated literal consumes the remainder",
 			query:       "SELECT 'oops",
 			wantResidue: "SELECT ''",

--- a/internal/sqltext/sqltext_test.go
+++ b/internal/sqltext/sqltext_test.go
@@ -127,10 +127,10 @@ func TestStrip(t *testing.T) {
 		},
 		{
 			// A $ that continues an identifier is not a delimiter: PostgreSQL
-			// treats x$tag$ as one identifier. Reading the first $ as a
-			// delimiter attempt fails and falls back to one byte of code,
-			// letting the very next $ open a real dollar-quoted block whose
-			// attacker-chosen closing tag swallows the DELETE that follows.
+			// treats x$tag$ as one identifier. Reading it as one anyway
+			// mistook the second $ for the tag's own closing mark, forming a
+			// bogus tag "$tag$" whose next occurrence, planted in the
+			// trailing comment, closed a body that swallowed the DELETE.
 			name:        "dollar sign continuing an identifier does not start a tag",
 			query:       "SELECT 1 AS x$tag$; DELETE FROM t -- $tag$",
 			wantResidue: "SELECT 1 AS x$tag$; DELETE FROM t  ",
@@ -141,6 +141,17 @@ func TestStrip(t *testing.T) {
 			query:       "SELECT 1 AS x$$; DELETE FROM t -- $$",
 			wantResidue: "SELECT 1 AS x$$; DELETE FROM t  ",
 			wantBare:    "SELECT 1 AS x$$; DELETE FROM t  ",
+		},
+		{
+			// The same decoy hiding a single statement's own INTO, rather
+			// than a smuggled second statement, is the more severe case: a
+			// SELECT INTO genuinely writes, and unlike a smuggled statement
+			// it is not stopped by the one-statement-per-message extended
+			// query protocol, since it really is only one statement.
+			name:        "dollar sign continuing an identifier does not hide a SELECT INTO",
+			query:       "SELECT 1 AS x$tag$ INTO backup FROM users -- $tag$",
+			wantResidue: "SELECT 1 AS x$tag$ INTO backup FROM users  ",
+			wantBare:    "SELECT 1 AS x$tag$ INTO backup FROM users  ",
 		},
 		{
 			name:        "dollar quote after a space still opens normally",

--- a/internal/tools/readonly_guard.go
+++ b/internal/tools/readonly_guard.go
@@ -13,7 +13,8 @@ package tools
 import (
 	"fmt"
 	"regexp"
-	"strings"
+
+	"pgedge-postgres-mcp/internal/sqltext"
 )
 
 // This file implements the textual half of the read-only guardrails. It is
@@ -205,204 +206,13 @@ func validateReadOnlyQuery(query string) error {
 // statement. Trailing separators are ignored so that a single statement
 // written with a terminating semicolon is accepted.
 func hasMultipleStatements(residue string) bool {
-	return strings.Contains(strings.TrimRight(residue, "; \t\r\n"), ";")
+	return sqltext.HasMultipleStatements(residue)
 }
 
-// stripSQLNoise scans a statement once and returns two normalised forms.
-//
-// residue has comments removed and every string literal, dollar-quoted block
-// and quoted identifier replaced by an empty placeholder, leaving only what
-// PostgreSQL would treat as code. bare has comments removed but literals left
-// intact, for the checks that must see inside a literal.
-//
-// The scanner is deliberately conservative rather than complete. Where a
-// construct is ambiguous or unterminated it stops treating the text as a
-// literal and lets the remainder fall through to the residue as code, so the
-// failure mode is a rejected valid query rather than an admitted hostile one.
-// Backslash escapes inside string literals are not honoured, matching
-// standard_conforming_strings being on, which is the default and the only
-// setting under which the shorter reading is also the safer one.
+// stripSQLNoise scans a statement into the two normalised forms the checks in
+// this package match against. The scanner itself lives in internal/sqltext,
+// which internal/chat also uses so that the write-confirmation prompt reasons
+// about a statement the same way this guard does.
 func stripSQLNoise(query string) (residue string, bare string) {
-	var res, bar strings.Builder
-	res.Grow(len(query))
-	bar.Grow(len(query))
-
-	i := 0
-	for i < len(query) {
-		switch {
-		case isLineCommentStart(query, i):
-			i = skipLineCommentBody(query, i)
-			writeNoiseSeparator(&res, &bar)
-
-		case isBlockCommentStart(query, i):
-			i = skipBlockComment(query, i)
-			writeNoiseSeparator(&res, &bar)
-
-		case query[i] == '\'':
-			i = consumeQuoted(query, i, '\'', &res, &bar)
-
-		case query[i] == '"':
-			i = consumeQuoted(query, i, '"', &res, &bar)
-
-		case query[i] == '$':
-			if end, ok := consumeDollarQuote(query, i, &res, &bar); ok {
-				i = end
-				continue
-			}
-			// Not a dollar quote, or never closed: treat as ordinary text so
-			// that anything following is still scanned as code.
-			res.WriteByte(query[i])
-			bar.WriteByte(query[i])
-			i++
-
-		default:
-			res.WriteByte(query[i])
-			bar.WriteByte(query[i])
-			i++
-		}
-	}
-
-	return res.String(), bar.String()
-}
-
-// writeNoiseSeparator writes a single space to both builders, in place of a
-// dropped comment, so that the comment cannot join the tokens on either
-// side of it.
-func writeNoiseSeparator(res, bar *strings.Builder) {
-	res.WriteByte(' ')
-	bar.WriteByte(' ')
-}
-
-// skipLineCommentBody returns the index just past a "--" line comment
-// starting at i: the position of the next newline, or the end of the
-// string if the comment runs to the end of it.
-func skipLineCommentBody(query string, i int) int {
-	if end := strings.IndexByte(query[i:], '\n'); end >= 0 {
-		return i + end
-	}
-	return len(query)
-}
-
-// consumeQuoted returns the index just past a quoted literal or identifier
-// starting at i, having written the original text to bar and an empty
-// same-quote placeholder to res.
-func consumeQuoted(query string, i int, quote byte, res, bar *strings.Builder) int {
-	end := endOfQuoted(query, i, quote)
-	bar.WriteString(query[i:end])
-	res.WriteByte(quote)
-	res.WriteByte(quote)
-	return end
-}
-
-// consumeDollarQuote reports whether a dollar-quoted block starts at i, and
-// if so returns the index just past it, having written the original text to
-// bar and the tag doubled to res. Reports false if there is no valid, closed
-// dollar-quote at i, in which case the caller falls back to treating
-// query[i] as ordinary text.
-func consumeDollarQuote(query string, i int, res, bar *strings.Builder) (int, bool) {
-	tag, ok := dollarQuoteTag(query, i)
-	if !ok {
-		return 0, false
-	}
-	end := endOfDollarQuote(query, i, tag)
-	if end <= 0 {
-		return 0, false
-	}
-	bar.WriteString(query[i:end])
-	res.WriteString(tag)
-	res.WriteString(tag)
-	return end, true
-}
-
-func isLineCommentStart(query string, i int) bool {
-	return query[i] == '-' && i+1 < len(query) && query[i+1] == '-'
-}
-
-func isBlockCommentStart(query string, i int) bool {
-	return query[i] == '/' && i+1 < len(query) && query[i+1] == '*'
-}
-
-// skipBlockComment returns the index just past a block comment, honouring the
-// nesting that PostgreSQL allows. An unterminated comment consumes the rest of
-// the statement, which is what the server would do with it too.
-func skipBlockComment(query string, i int) int {
-	depth := 0
-	for i < len(query) {
-		if isBlockCommentStart(query, i) {
-			depth++
-			i += 2
-			continue
-		}
-		if query[i] == '*' && i+1 < len(query) && query[i+1] == '/' {
-			depth--
-			i += 2
-			if depth == 0 {
-				return i
-			}
-			continue
-		}
-		i++
-	}
-	return len(query)
-}
-
-// endOfQuoted returns the index just past a literal or quoted identifier that
-// starts at i, treating a doubled quote character as an escaped one. An
-// unterminated quote consumes the remainder of the statement.
-func endOfQuoted(query string, i int, quote byte) int {
-	i++
-	for i < len(query) {
-		if query[i] != quote {
-			i++
-			continue
-		}
-		if i+1 < len(query) && query[i+1] == quote {
-			i += 2
-			continue
-		}
-		return i + 1
-	}
-	return len(query)
-}
-
-// dollarQuoteTag returns the opening tag of a dollar-quoted string starting at
-// i, for example "$$" or "$body$". It reports false for anything else,
-// including positional parameter references such as $1, whose digit start is
-// not a valid tag.
-func dollarQuoteTag(query string, i int) (string, bool) {
-	j := i + 1
-	for j < len(query) {
-		c := query[j]
-		switch {
-		case c == '$':
-			return query[i : j+1], true
-		case c == '_' || isASCIILetter(c):
-			j++
-		case isASCIIDigit(c) && j > i+1:
-			// Digits are allowed in a tag, just not as its first character.
-			j++
-		default:
-			return "", false
-		}
-	}
-	return "", false
-}
-
-// endOfDollarQuote returns the index just past the closing tag of a
-// dollar-quoted string, or 0 if the string is never closed.
-func endOfDollarQuote(query string, i int, tag string) int {
-	body := query[i+len(tag):]
-	end := strings.Index(body, tag)
-	if end < 0 {
-		return 0
-	}
-	return i + len(tag) + end + len(tag)
-}
-
-func isASCIILetter(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-}
-
-func isASCIIDigit(c byte) bool {
-	return c >= '0' && c <= '9'
+	return sqltext.Strip(query)
 }

--- a/web/src/utils/queryClassify.js
+++ b/web/src/utils/queryClassify.js
@@ -8,6 +8,8 @@
  *-------------------------------------------------------------------------
  */
 
+import { stripSqlNoise } from './sqlText';
+
 const WRITE_PREFIXES = [
     'CREATE', 'DROP', 'ALTER', 'TRUNCATE',
     'INSERT', 'UPDATE', 'DELETE',
@@ -18,22 +20,80 @@ const READ_PREFIXES = [
     'EXPLAIN', 'SHOW',
 ];
 
+// Prefixes that admit no write at all: TABLE and VALUES have no target to
+// write to, and SHOW only reports a setting.
+const ALWAYS_READ_PREFIXES = ['TABLE', 'VALUES', 'SHOW'];
+
+// A keyword that makes a statement with a reading first keyword write after
+// all. INTO catches SELECT ... INTO, which creates and populates a table; the
+// rest catch a data-modifying CTE, where the write hides inside a statement
+// whose first word is WITH.
+const DML_INDICATOR = /\b(INSERT|UPDATE|DELETE|MERGE)\b/;
+const DDL_INDICATOR = /\b(INTO|CREATE|DROP|ALTER|TRUNCATE|GRANT|REVOKE)\b/;
+
+// The locking clauses of an ordinary SELECT. They take row locks but modify
+// nothing, and their UPDATE keyword would otherwise trip DML_INDICATOR, so
+// they are removed before it runs.
+const ROW_LOCK_CLAUSE = /\bFOR\s+(NO\s+KEY\s+UPDATE|KEY\s+SHARE|UPDATE|SHARE)\b/g;
+
+// ANALYZE is what makes EXPLAIN run the statement it is given rather than
+// only plan it.
+const ANALYZE_OPTION = /\bANALYZE\b/;
+
+/**
+ * Reports whether the statement begins with one of the given keywords,
+ * requiring a word boundary after the match so that a table called "updates"
+ * is not read as an UPDATE.
+ */
+function hasPrefix(upper, keywords) {
+    return keywords.some(kw =>
+        upper.startsWith(kw) && !/[A-Z0-9_]/.test(upper.charAt(kw.length)));
+}
+
 /**
  * Classifies whether a SQL query is a write (DDL/DML) operation.
  * Read queries (SELECT, WITH, etc.) return false.
  * Write queries (CREATE, DROP, INSERT, etc.) return true.
  * Unknown query types are treated as potentially destructive.
  *
+ * The result drives the confirmation prompt shown before a statement runs on a
+ * writable connection, so the cost of the two errors is not symmetric: calling
+ * a read a write costs a needless prompt, whilst calling a write a read lets
+ * the statement run unannounced. The checks therefore lean towards prompting.
+ *
+ * A reading first keyword is not enough to call the statement a read.
+ * SELECT ... INTO creates and populates a table, a CTE can carry an INSERT,
+ * UPDATE or DELETE, and EXPLAIN ANALYZE runs the statement it is given rather
+ * than only planning it. Matching happens against the statement's code with
+ * comments removed and literals blanked, so a keyword inside a string cannot
+ * be mistaken for the real thing and a comment cannot hide one.
+ *
+ * This is a client-side prompt and not a security boundary. A statement whose
+ * writes happen inside a function it calls still reads as a SELECT here, and
+ * nothing textual could tell otherwise. What actually prevents a write on a
+ * read-only connection is the transaction access mode set by the server.
+ *
  * @param {string} sql - The SQL query to classify
  * @returns {boolean} - True if the query is a write operation
  */
 export function isWriteQuery(sql) {
     if (!sql || typeof sql !== 'string') return false;
-    const upper = sql.trim().toUpperCase();
-    if (READ_PREFIXES.some(p => upper.startsWith(p))) return false;
-    if (WRITE_PREFIXES.some(p => upper.startsWith(p))) return true;
-    // Unknown query types are treated as potentially destructive
-    return true;
+    const upper = stripSqlNoise(sql).trim().toUpperCase();
+
+    if (hasPrefix(upper, WRITE_PREFIXES)) return true;
+    if (!hasPrefix(upper, READ_PREFIXES)) {
+        // Unknown query types are treated as potentially destructive
+        return true;
+    }
+
+    if (hasPrefix(upper, ALWAYS_READ_PREFIXES)) return false;
+    if (hasPrefix(upper, ['EXPLAIN']) && !ANALYZE_OPTION.test(upper)) {
+        // EXPLAIN only plans its statement unless ANALYZE is given.
+        return false;
+    }
+
+    const scanned = upper.replace(ROW_LOCK_CLAUSE, ' ');
+    return DML_INDICATOR.test(scanned) || DDL_INDICATOR.test(scanned);
 }
 
 /**

--- a/web/src/utils/queryClassify.test.js
+++ b/web/src/utils/queryClassify.test.js
@@ -127,6 +127,22 @@ describe('isWriteQuery', () => {
                 .toBe(true);
         });
 
+        it('classifies MERGE as write', () => {
+            expect(isWriteQuery(
+                'MERGE INTO t USING s ON t.id = s.id '
+                + 'WHEN MATCHED THEN UPDATE SET n = s.n',
+            )).toBe(true);
+        });
+
+        it('is not fooled by an escape string hiding the INTO', () => {
+            expect(isWriteQuery("SELECT E'\\'' INTO backup FROM users"))
+                .toBe(true);
+        });
+
+        it('is not fooled by an escape string before a comma', () => {
+            expect(isWriteQuery("SELECT E'a\\'' , x INTO t FROM u")).toBe(true);
+        });
+
         it('sees through a leading comment', () => {
             expect(isWriteQuery('/* harmless */ SELECT * INTO backup FROM users'))
                 .toBe(true);
@@ -147,6 +163,17 @@ describe('isWriteQuery', () => {
             expect(isWriteQuery(
                 'SELECT * FROM audit WHERE action = \'DELETE\'',
             )).toBe(false);
+        });
+
+        it('ignores a write keyword inside an escape string literal', () => {
+            expect(isWriteQuery(
+                "SELECT * FROM audit WHERE action = E'DEL\\'ETE'",
+            )).toBe(false);
+        });
+
+        it('treats a backslash in a plain literal as an ordinary character', () => {
+            expect(isWriteQuery("SELECT * FROM t WHERE path = 'C:\\'"))
+                .toBe(false);
         });
 
         it('ignores a write keyword inside a quoted identifier', () => {

--- a/web/src/utils/queryClassify.test.js
+++ b/web/src/utils/queryClassify.test.js
@@ -75,6 +75,112 @@ describe('isWriteQuery', () => {
         });
     });
 
+    describe('writes hiding behind a reading first keyword return true', () => {
+        it('classifies SELECT ... INTO as write', () => {
+            expect(isWriteQuery('SELECT * INTO backup FROM users')).toBe(true);
+        });
+
+        it('classifies lowercase select ... into as write', () => {
+            expect(isWriteQuery('select id into t2 from t1')).toBe(true);
+        });
+
+        it('classifies SELECT ... INTO split across lines as write', () => {
+            expect(isWriteQuery('SELECT 1 INTO\nnewtbl')).toBe(true);
+        });
+
+        it('classifies a CTE carrying an INSERT as write', () => {
+            expect(isWriteQuery(
+                'WITH c AS (SELECT 1 AS n) INSERT INTO t SELECT n FROM c',
+            )).toBe(true);
+        });
+
+        it('classifies a data-modifying CTE with RETURNING as write', () => {
+            expect(isWriteQuery(
+                'WITH ins AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * FROM ins',
+            )).toBe(true);
+        });
+
+        it('classifies a CTE carrying an UPDATE as write', () => {
+            expect(isWriteQuery(
+                'WITH u AS (UPDATE t SET n = 1 RETURNING *) SELECT * FROM u',
+            )).toBe(true);
+        });
+
+        it('classifies a CTE carrying a DELETE as write', () => {
+            expect(isWriteQuery(
+                'WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d',
+            )).toBe(true);
+        });
+
+        it('classifies a CTE followed by SELECT ... INTO as write', () => {
+            expect(isWriteQuery('WITH c AS (SELECT 1) SELECT * INTO t FROM c'))
+                .toBe(true);
+        });
+
+        it('classifies EXPLAIN ANALYZE of an INSERT as write', () => {
+            expect(isWriteQuery('EXPLAIN ANALYZE INSERT INTO t VALUES (1)'))
+                .toBe(true);
+        });
+
+        it('classifies EXPLAIN (ANALYZE) of an UPDATE as write', () => {
+            expect(isWriteQuery('EXPLAIN (ANALYZE, BUFFERS) UPDATE t SET n = 1'))
+                .toBe(true);
+        });
+
+        it('sees through a leading comment', () => {
+            expect(isWriteQuery('/* harmless */ SELECT * INTO backup FROM users'))
+                .toBe(true);
+        });
+    });
+
+    describe('reads that must not prompt return false', () => {
+        it('classifies EXPLAIN without ANALYZE as read', () => {
+            expect(isWriteQuery('EXPLAIN INSERT INTO t VALUES (1)')).toBe(false);
+        });
+
+        it('classifies EXPLAIN ANALYZE of a SELECT as read', () => {
+            expect(isWriteQuery('EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM t'))
+                .toBe(false);
+        });
+
+        it('ignores a write keyword inside a string literal', () => {
+            expect(isWriteQuery(
+                'SELECT * FROM audit WHERE action = \'DELETE\'',
+            )).toBe(false);
+        });
+
+        it('ignores a write keyword inside a quoted identifier', () => {
+            expect(isWriteQuery('SELECT "delete" FROM t')).toBe(false);
+        });
+
+        it('ignores a write keyword that is part of an identifier', () => {
+            expect(isWriteQuery('SELECT delete_flag, into_tray FROM t'))
+                .toBe(false);
+        });
+
+        it('classifies SELECT ... FOR UPDATE as read', () => {
+            expect(isWriteQuery('SELECT * FROM t FOR UPDATE')).toBe(false);
+        });
+
+        it('classifies SELECT ... FOR NO KEY UPDATE as read', () => {
+            expect(isWriteQuery('SELECT * FROM t FOR NO KEY UPDATE')).toBe(false);
+        });
+
+        it('classifies SELECT ... FOR SHARE as read', () => {
+            expect(isWriteQuery('SELECT * FROM t FOR SHARE')).toBe(false);
+        });
+
+        it('classifies a subquery SELECT as read', () => {
+            expect(isWriteQuery('SELECT * FROM t WHERE id IN (SELECT id FROM u)'))
+                .toBe(false);
+        });
+
+        it('sees past a leading line comment on an ordinary read', () => {
+            expect(isWriteQuery('-- counting rows\nSELECT count(*) FROM t'))
+                .toBe(false);
+        });
+    });
+
     describe('case insensitivity', () => {
         it('handles lowercase SELECT', () => {
             expect(isWriteQuery('select * from users')).toBe(false);

--- a/web/src/utils/queryClassify.test.js
+++ b/web/src/utils/queryClassify.test.js
@@ -158,6 +158,12 @@ describe('isWriteQuery', () => {
             expect(isWriteQuery('SELECT 1 AS x$$; DELETE FROM t -- $$'))
                 .toBe(true);
         });
+
+        it('is not fooled by a dollar-quote decoy hiding a SELECT INTO', () => {
+            expect(isWriteQuery(
+                'SELECT 1 AS x$tag$ INTO backup FROM users -- $tag$',
+            )).toBe(true);
+        });
     });
 
     describe('reads that must not prompt return false', () => {

--- a/web/src/utils/queryClassify.test.js
+++ b/web/src/utils/queryClassify.test.js
@@ -147,6 +147,17 @@ describe('isWriteQuery', () => {
             expect(isWriteQuery('/* harmless */ SELECT * INTO backup FROM users'))
                 .toBe(true);
         });
+
+        it('is not fooled by a dollar-quote decoy hiding a DELETE', () => {
+            expect(isWriteQuery(
+                'SELECT 1 AS x$tag$; DELETE FROM t -- $tag$',
+            )).toBe(true);
+        });
+
+        it('is not fooled by a tagless dollar-quote decoy hiding a DELETE', () => {
+            expect(isWriteQuery('SELECT 1 AS x$$; DELETE FROM t -- $$'))
+                .toBe(true);
+        });
     });
 
     describe('reads that must not prompt return false', () => {

--- a/web/src/utils/sqlText.js
+++ b/web/src/utils/sqlText.js
@@ -17,6 +17,12 @@
  * parse SQL. Where a construct is ambiguous or unterminated it stops treating
  * the text as a literal and lets the remainder fall through as code, so the
  * failure mode is a needless confirmation prompt rather than a missed write.
+ *
+ * Backslash escapes are honoured inside an E'...' escape string constant and
+ * nowhere else. In a plain '...' literal a backslash is an ordinary character
+ * under standard_conforming_strings, which is the default, so treating it as
+ * an escape there would run the literal past its real end and hide the code
+ * that follows.
  */
 
 const isAsciiLetter = c => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
@@ -58,10 +64,20 @@ function skipBlockComment(sql, i) {
  * Returns the index just past a literal or quoted identifier starting at i,
  * treating a doubled quote character as an escaped one. An unterminated quote
  * consumes the remainder of the statement.
+ *
+ * When escapes is set the literal is an escape string constant, E'...', in
+ * which a backslash escapes the character after it. Honouring that matters: in
+ * E'\'' the backslash escapes the first quote and the second closes the
+ * literal, whereas reading the pair as a doubled quote runs the literal on to
+ * the end of the statement and hides whatever follows it.
  */
-function endOfQuoted(sql, i, quote) {
+function endOfQuoted(sql, i, quote, escapes) {
     i++;
     while (i < sql.length) {
+        if (escapes && sql[i] === '\\' && i + 1 < sql.length) {
+            i += 2;
+            continue;
+        }
         if (sql[i] !== quote) {
             i++;
             continue;
@@ -73,6 +89,21 @@ function endOfQuoted(sql, i, quote) {
         return i + 1;
     }
     return sql.length;
+}
+
+/**
+ * Reports whether an E'...' escape string constant starts at i, that is
+ * whether sql[i] is an E introducing a literal rather than an ordinary
+ * identifier character. Backslash escapes are honoured only for these
+ * literals: with standard_conforming_strings on, which is the default, a
+ * backslash in a plain '...' literal is an ordinary character, and treating it
+ * as an escape there would run that literal past its real end.
+ */
+function isEscapeStringStart(sql, i) {
+    if (sql[i] !== 'E' && sql[i] !== 'e') return false;
+    if (sql[i + 1] !== '\'') return false;
+    // An E that continues an identifier, as in "table_e'x'", is not a prefix.
+    return i === 0 || !/[A-Za-z0-9_]/.test(sql[i - 1]);
 }
 
 /**
@@ -116,8 +147,14 @@ export function stripSqlNoise(sql) {
         } else if (c === '/' && sql[i + 1] === '*') {
             i = skipBlockComment(sql, i);
             out += ' ';
+        } else if (isEscapeStringStart(sql, i)) {
+            // Keep the E, then consume the literal with backslash escapes
+            // honoured.
+            out += c;
+            i = endOfQuoted(sql, i + 1, '\'', true);
+            out += "''";
         } else if (c === '\'' || c === '"') {
-            i = endOfQuoted(sql, i, c);
+            i = endOfQuoted(sql, i, c, false);
             out += c + c;
         } else if (c === '$') {
             const tag = dollarQuoteTag(sql, i);

--- a/web/src/utils/sqlText.js
+++ b/web/src/utils/sqlText.js
@@ -111,10 +111,13 @@ function isEscapeStringStart(sql, i) {
  * Reports whether a dollar-quote tag may begin at i. PostgreSQL treats $ as a
  * legal, non-initial identifier character, so "x$tag$" lexes as the single
  * identifier x$tag$, not as x followed by a dollar-quote delimiter. Without
- * this check that byte is rejected as a tag on its own and the scanner falls
- * back to consuming it as ordinary text one byte at a time, so the very next
- * $ opens a dollar-quoted block whose attacker-chosen closing tag can swallow
- * arbitrary SQL that follows, including a smuggled statement.
+ * this check, dollarQuoteTag reads forward from that first $ and accepts the
+ * second one as the tag's own closing mark, mistaking two bytes of an
+ * identifier for a two-character tag "$tag$". Once that bogus tag is
+ * accepted, the scanner searches for its next literal occurrence to close
+ * the body, and an attacker who plants one later in the statement, for
+ * example inside a trailing comment, can make everything in between
+ * disappear from the residue, including a smuggled statement.
  */
 function canStartDollarQuote(sql, i) {
     return i === 0 || (!isIdentifierByte(sql[i - 1]) && sql[i - 1] !== '$');

--- a/web/src/utils/sqlText.js
+++ b/web/src/utils/sqlText.js
@@ -27,6 +27,7 @@
 
 const isAsciiLetter = c => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 const isAsciiDigit = c => c >= '0' && c <= '9';
+const isIdentifierByte = c => c === '_' || isAsciiLetter(c) || isAsciiDigit(c);
 
 /**
  * Returns the index just past a "--" line comment starting at i.
@@ -107,6 +108,19 @@ function isEscapeStringStart(sql, i) {
 }
 
 /**
+ * Reports whether a dollar-quote tag may begin at i. PostgreSQL treats $ as a
+ * legal, non-initial identifier character, so "x$tag$" lexes as the single
+ * identifier x$tag$, not as x followed by a dollar-quote delimiter. Without
+ * this check that byte is rejected as a tag on its own and the scanner falls
+ * back to consuming it as ordinary text one byte at a time, so the very next
+ * $ opens a dollar-quoted block whose attacker-chosen closing tag can swallow
+ * arbitrary SQL that follows, including a smuggled statement.
+ */
+function canStartDollarQuote(sql, i) {
+    return i === 0 || (!isIdentifierByte(sql[i - 1]) && sql[i - 1] !== '$');
+}
+
+/**
  * Returns the opening tag of a dollar-quoted string starting at i, for example
  * "$$" or "$body$", or null for anything else. Positional parameters such as
  * $1 are not tags, since a digit cannot start one.
@@ -157,14 +171,15 @@ export function stripSqlNoise(sql) {
             i = endOfQuoted(sql, i, c, false);
             out += c + c;
         } else if (c === '$') {
-            const tag = dollarQuoteTag(sql, i);
+            const tag = canStartDollarQuote(sql, i) ? dollarQuoteTag(sql, i) : null;
             const body = tag === null ? -1 : sql.indexOf(tag, i + tag.length);
             if (tag !== null && body >= 0) {
                 i = body + tag.length;
                 out += tag + tag;
             } else {
-                // Not a dollar quote, or never closed: treat as ordinary text
-                // so that anything following is still scanned as code.
+                // Not a dollar quote, never closed, or continuing an
+                // identifier: treat as ordinary text so that anything
+                // following is still scanned as code.
                 out += c;
                 i++;
             }

--- a/web/src/utils/sqlText.js
+++ b/web/src/utils/sqlText.js
@@ -1,0 +1,141 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Textual scanning for SQL statements, mirroring internal/sqltext in the
+ * server so that this client reasons about a statement the same way the CLI
+ * client and the read-only guardrails do.
+ *
+ * The scanner is deliberately conservative rather than complete. It does not
+ * parse SQL. Where a construct is ambiguous or unterminated it stops treating
+ * the text as a literal and lets the remainder fall through as code, so the
+ * failure mode is a needless confirmation prompt rather than a missed write.
+ */
+
+const isAsciiLetter = c => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+const isAsciiDigit = c => c >= '0' && c <= '9';
+
+/**
+ * Returns the index just past a "--" line comment starting at i.
+ */
+function skipLineComment(sql, i) {
+    const end = sql.indexOf('\n', i);
+    return end < 0 ? sql.length : end;
+}
+
+/**
+ * Returns the index just past a block comment, honouring the nesting that
+ * PostgreSQL allows. An unterminated comment consumes the rest of the
+ * statement, which is what the server would do with it too.
+ */
+function skipBlockComment(sql, i) {
+    let depth = 0;
+    while (i < sql.length) {
+        if (sql[i] === '/' && sql[i + 1] === '*') {
+            depth++;
+            i += 2;
+            continue;
+        }
+        if (sql[i] === '*' && sql[i + 1] === '/') {
+            depth--;
+            i += 2;
+            if (depth === 0) return i;
+            continue;
+        }
+        i++;
+    }
+    return sql.length;
+}
+
+/**
+ * Returns the index just past a literal or quoted identifier starting at i,
+ * treating a doubled quote character as an escaped one. An unterminated quote
+ * consumes the remainder of the statement.
+ */
+function endOfQuoted(sql, i, quote) {
+    i++;
+    while (i < sql.length) {
+        if (sql[i] !== quote) {
+            i++;
+            continue;
+        }
+        if (sql[i + 1] === quote) {
+            i += 2;
+            continue;
+        }
+        return i + 1;
+    }
+    return sql.length;
+}
+
+/**
+ * Returns the opening tag of a dollar-quoted string starting at i, for example
+ * "$$" or "$body$", or null for anything else. Positional parameters such as
+ * $1 are not tags, since a digit cannot start one.
+ */
+function dollarQuoteTag(sql, i) {
+    let j = i + 1;
+    while (j < sql.length) {
+        const c = sql[j];
+        if (c === '$') return sql.slice(i, j + 1);
+        if (c === '_' || isAsciiLetter(c) || (isAsciiDigit(c) && j > i + 1)) {
+            j++;
+            continue;
+        }
+        return null;
+    }
+    return null;
+}
+
+/**
+ * Removes comments and blanks every string literal, dollar-quoted block and
+ * quoted identifier, leaving only what PostgreSQL would treat as code. A
+ * dropped comment becomes a single space, so that it cannot join the tokens on
+ * either side of it.
+ *
+ * @param {string} sql - The SQL statement to scan
+ * @returns {string} - The statement's code, with literals blanked
+ */
+export function stripSqlNoise(sql) {
+    let out = '';
+    let i = 0;
+
+    while (i < sql.length) {
+        const c = sql[i];
+
+        if (c === '-' && sql[i + 1] === '-') {
+            i = skipLineComment(sql, i);
+            out += ' ';
+        } else if (c === '/' && sql[i + 1] === '*') {
+            i = skipBlockComment(sql, i);
+            out += ' ';
+        } else if (c === '\'' || c === '"') {
+            i = endOfQuoted(sql, i, c);
+            out += c + c;
+        } else if (c === '$') {
+            const tag = dollarQuoteTag(sql, i);
+            const body = tag === null ? -1 : sql.indexOf(tag, i + tag.length);
+            if (tag !== null && body >= 0) {
+                i = body + tag.length;
+                out += tag + tag;
+            } else {
+                // Not a dollar quote, or never closed: treat as ordinary text
+                // so that anything following is still scanned as code.
+                out += c;
+                i++;
+            }
+        } else {
+            out += c;
+            i++;
+        }
+    }
+
+    return out;
+}

--- a/web/src/utils/sqlText.test.js
+++ b/web/src/utils/sqlText.test.js
@@ -1,0 +1,82 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - SQL Text Scanner Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripSqlNoise } from './sqlText';
+
+// These cases mirror TestStrip in internal/sqltext/sqltext_test.go, so that
+// the two scanners can be compared directly as either one changes. The Go
+// scanner also returns a "bare" form with literals intact; this one does not,
+// because no web client check needs to see inside a literal.
+describe('stripSqlNoise', () => {
+    const cases = [
+        ['leaves a plain statement unchanged',
+            'SELECT 1', 'SELECT 1'],
+        ['blanks a string literal',
+            "SELECT 'DELETE'", "SELECT ''"],
+        ['blanks a quoted identifier',
+            'SELECT "delete" FROM t', 'SELECT "" FROM t'],
+        ['does not end a literal early on a doubled quote',
+            "SELECT 'it''s DELETE'", "SELECT ''"],
+        ['turns a line comment into a separator',
+            'SELECT 1 -- DROP TABLE t\n', 'SELECT 1  \n'],
+        ['turns a block comment into a separator',
+            'SEL/* hidden */ECT 1', 'SEL ECT 1'],
+        ['consumes a nested block comment whole',
+            'SELECT /* a /* b */ c */ 1', 'SELECT   1'],
+        ['blanks a dollar quoted body',
+            'DO $tag$ DROP TABLE t $tag$', 'DO $tag$$tag$'],
+        ['leaves a positional parameter alone',
+            'SELECT * FROM t WHERE id = $1', 'SELECT * FROM t WHERE id = $1'],
+        ['lets an unterminated literal consume the remainder',
+            "SELECT 'oops", "SELECT ''"],
+        ['lets an unclosed dollar quote fall through as code',
+            'SELECT $tag$ DROP TABLE t', 'SELECT $tag$ DROP TABLE t'],
+    ];
+
+    it.each(cases)('%s', (_name, input, expected) => {
+        expect(stripSqlNoise(input)).toBe(expected);
+    });
+
+    // Read as a doubled quote rather than an escape, E'\'' would run to the
+    // end of the statement and hide the INTO behind it, which is a write
+    // going unseen by the confirmation prompt.
+    describe('escape string constants', () => {
+        it('does not let a backslash-quote close the literal', () => {
+            expect(stripSqlNoise("SELECT E'\\'' INTO backup FROM users"))
+                .toBe("SELECT E'' INTO backup FROM users");
+        });
+
+        it('handles a backslash escape before the closing quote', () => {
+            expect(stripSqlNoise("SELECT E'a\\'' , x INTO t FROM u"))
+                .toBe("SELECT E'' , x INTO t FROM u");
+        });
+
+        it('accepts a lowercase e prefix', () => {
+            expect(stripSqlNoise("SELECT e'\\'' INTO t"))
+                .toBe("SELECT e'' INTO t");
+        });
+
+        it('does not let an escaped backslash escape the closing quote', () => {
+            expect(stripSqlNoise("SELECT E'a\\\\' INTO t"))
+                .toBe("SELECT E'' INTO t");
+        });
+
+        it('does not honour a backslash in a plain literal', () => {
+            expect(stripSqlNoise("SELECT 'a\\' , x INTO t FROM u"))
+                .toBe("SELECT '' , x INTO t FROM u");
+        });
+
+        it('does not treat an E ending an identifier as a prefix', () => {
+            expect(stripSqlNoise("SELECT * FROM table_e'a\\' , x"))
+                .toBe("SELECT * FROM table_e'' , x");
+        });
+    });
+});

--- a/web/src/utils/sqlText.test.js
+++ b/web/src/utils/sqlText.test.js
@@ -39,6 +39,14 @@ describe('stripSqlNoise', () => {
             "SELECT 'oops", "SELECT ''"],
         ['lets an unclosed dollar quote fall through as code',
             'SELECT $tag$ DROP TABLE t', 'SELECT $tag$ DROP TABLE t'],
+        ['does not let a $ continuing an identifier start a tag',
+            'SELECT 1 AS x$tag$; DELETE FROM t -- $tag$',
+            'SELECT 1 AS x$tag$; DELETE FROM t  '],
+        ['does not let a dollar quote without a tag continue an identifier',
+            'SELECT 1 AS x$$; DELETE FROM t -- $$',
+            'SELECT 1 AS x$$; DELETE FROM t  '],
+        ['still opens a dollar quote that follows a space',
+            'DO $ $tag$ DROP TABLE t $tag$', 'DO $ $tag$$tag$'],
     ];
 
     it.each(cases)('%s', (_name, input, expected) => {

--- a/web/src/utils/sqlText.test.js
+++ b/web/src/utils/sqlText.test.js
@@ -47,6 +47,9 @@ describe('stripSqlNoise', () => {
             'SELECT 1 AS x$$; DELETE FROM t  '],
         ['still opens a dollar quote that follows a space',
             'DO $ $tag$ DROP TABLE t $tag$', 'DO $ $tag$$tag$'],
+        ['does not let a $ continuing an identifier hide a SELECT INTO',
+            'SELECT 1 AS x$tag$ INTO backup FROM users -- $tag$',
+            'SELECT 1 AS x$tag$ INTO backup FROM users  '],
     ];
 
     it.each(cases)('%s', (_name, input, expected) => {


### PR DESCRIPTION
## What this fixes

The confirmation prompt that both clients show before a statement
modifies data decided what counts as a write by looking only at the
statement's first keyword. Anything starting with a reading keyword was
waved through, so on a connection configured with `allow_writes: true`
these all ran with no prompt at all:

- `SELECT * INTO backup FROM users`, which creates and populates a table.
- `WITH ins AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * FROM ins`,
  and the `UPDATE` and `DELETE` equivalents, where the write hides inside
  a statement whose first word is `WITH`.
- `EXPLAIN ANALYZE INSERT INTO t VALUES (1)`, because `ANALYZE` makes
  `EXPLAIN` run the statement rather than only plan it.

This completes the fix in #198, which made custom tools confirm their
writes. That change corrected *which tools* are gated; this one corrects
*which statements* are, so together they close the gap between what the
prompt claims to cover and what it actually caught.

## How it works now

Classification runs against the statement's comment-stripped,
literal-blanked code, so a keyword inside a string cannot be mistaken for
the real thing and a comment cannot be used to hide one. A reading first
keyword is no longer sufficient on its own: the code is also scanned for
a write indicator, with `EXPLAIN` needing `ANALYZE` before it counts.

The checks deliberately lean towards prompting, because calling a read a
write costs a needless prompt whilst the reverse lets a statement run
unannounced. Reads that must stay quiet still do, so the prompt keeps its
meaning: `SELECT ... FOR UPDATE` and its `FOR NO KEY UPDATE` / `FOR SHARE`
variants take locks but modify nothing, `EXPLAIN` without `ANALYZE` only
plans, and a write keyword appearing in a literal, a quoted identifier or
as part of a longer identifier (`delete_flag`) is ignored.

## On the refactor in the diff

The scanner that strips comments and blanks literals already existed, in
`internal/tools/readonly_guard.go`, and the classifier needs exactly the
same thing. Rather than duplicate a subtle SQL lexer into a second
security-adjacent code path, it has moved to `internal/sqltext` and is
now shared. `readonly_guard.go` keeps thin wrappers over the two moved
functions, so every existing guard and `count_rows` test exercises the
shared code unchanged, which is what demonstrates the move altered no
behaviour. `web/src/utils/sqlText.js` mirrors it for the web client,
where sharing across languages is not possible.

`internal/sqltext` is also added to the `test-server` package list in the
`Makefile`, whose enumeration is explicit rather than a wildcard.

## Scope

This is a client-side confirmation prompt, not a security boundary, and
the change does not pretend otherwise. A statement whose writes happen
inside a function it calls still reads as a `SELECT`, and nothing textual
could tell otherwise. What prevents a write on a read-only connection
remains the transaction access mode set by the server. On a read-only
connection none of the statements above could ever have written; the gap
was only ever about the prompt on a writable one.

## How I checked this

- Added table-driven cases to `internal/chat/query_classify_test.go` and
  `web/src/utils/queryClassify.test.js` covering every construct above,
  plus the reads that must not start prompting.
- Added `internal/sqltext/sqltext_test.go` for the newly public API,
  covering literals, doubled quotes, nested block comments, dollar
  quoting, positional parameters and unterminated constructs.
- `make lint`: 0 issues. `make test`: all 22 Go packages pass.
- `npx vitest run` in `web/`: 148 tests across 13 files pass.
- The `test/` integration failures in my environment are a local
  PostgreSQL authentication problem and reproduce identically on an
  unmodified tree, so they are not related to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved SQL statement classification in CLI and web confirmation prompts.
  * More reliably detects writes hidden in comments, literals, CTEs, `SELECT INTO`, `MERGE`, and `EXPLAIN ANALYZE`.
  * Continues treating standard `SELECT`, plain `EXPLAIN`, and row-locking queries as reads.
  * Unrecognized or ambiguous statements are conservatively treated as writable.

* **Documentation**
  * Added an Unreleased changelog entry covering SQL classification and read-only connection protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->