### PR TITLE
chore: run the web client suite from make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-server build-client clean clean-server clean-client test test-server test-client test-web run install help lint lint-server lint-client vulncheck fmt format gofmt openapi
+.PHONY: all build build-server build-client clean clean-server clean-client test test-server test-client test-web run install help lint lint-server lint-client vulncheck fmt format gofmt openapi
 
 # Binary names and directories
 SERVER_BINARY=pgedge-postgres-mcp
@@ -104,20 +104,26 @@ test-client:
 # rather than a package added to the Go lists above. Dependencies are installed
 # only when node_modules is absent, so a repeat run does not pay for it.
 # A missing npm is reported and skipped rather than failed, matching how the
-# lint targets treat a missing golangci-lint; the tests themselves failing is
-# still a hard failure.
+# lint targets treat a missing golangci-lint; a failing npm ci, and a failing
+# test, are both hard failures.
+#
+# The recipe changes directory exactly once and tests node_modules from inside
+# $(WEB_DIR). Doing the install with its own "cd $(WEB_DIR)" would leave the
+# shell there for the command after it, since make runs the whole recipe in one
+# shell, and the second cd would then fail on a clean checkout.
 test-web:
 	@echo "Running web client tests..."
-	@if command -v npm >/dev/null 2>&1; then \
-		if [ ! -d $(WEB_DIR)/node_modules ]; then \
-			echo "Installing web client dependencies..."; \
-			cd $(WEB_DIR) && npm ci; \
-		fi; \
-		cd $(WEB_DIR) && npm test -- --run; \
-	else \
+	@if ! command -v npm >/dev/null 2>&1; then \
 		echo "npm not found, skipping web client tests. Install Node.js from:"; \
 		echo "  https://nodejs.org/"; \
-	fi
+		exit 0; \
+	fi; \
+	cd $(WEB_DIR) || exit 1; \
+	if [ ! -d node_modules ]; then \
+		echo "Installing web client dependencies..."; \
+		npm ci || exit 1; \
+	fi; \
+	npm test -- --run
 
 # Run with example environment
 run:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-server build-client clean clean-server clean-client test test-server test-client run install help lint lint-server lint-client vulncheck fmt format gofmt openapi
+.PHONY: build build-server build-client clean clean-server clean-client test test-server test-client test-web run install help lint lint-server lint-client vulncheck fmt format gofmt openapi
 
 # Binary names and directories
 SERVER_BINARY=pgedge-postgres-mcp
@@ -6,6 +6,7 @@ CLIENT_BINARY=pgedge-nla-cli
 BIN_DIR=bin
 SERVER_CMD_DIR=cmd/pgedge-pg-mcp-svr
 CLIENT_CMD_DIR=cmd/pgedge-pg-mcp-cli
+WEB_DIR=web
 
 # Build variables
 GO=go
@@ -84,7 +85,7 @@ clean-client:
 	@echo "Client clean complete"
 
 # Run all tests
-test: test-server test-client
+test: test-server test-client test-web
 
 # Run server tests
 # Lists every server-side package that has tests. The client-side packages are
@@ -97,6 +98,26 @@ test-server:
 test-client:
 	@echo "Running client tests..."
 	$(GO) test -v ./internal/chat/... ./$(CLIENT_CMD_DIR)/...
+
+# Run web client tests
+# The web client is a separate npm project, so its suite needs its own target
+# rather than a package added to the Go lists above. Dependencies are installed
+# only when node_modules is absent, so a repeat run does not pay for it.
+# A missing npm is reported and skipped rather than failed, matching how the
+# lint targets treat a missing golangci-lint; the tests themselves failing is
+# still a hard failure.
+test-web:
+	@echo "Running web client tests..."
+	@if command -v npm >/dev/null 2>&1; then \
+		if [ ! -d $(WEB_DIR)/node_modules ]; then \
+			echo "Installing web client dependencies..."; \
+			cd $(WEB_DIR) && npm ci; \
+		fi; \
+		cd $(WEB_DIR) && npm test -- --run; \
+	else \
+		echo "npm not found, skipping web client tests. Install Node.js from:"; \
+		echo "  https://nodejs.org/"; \
+	fi
 
 # Run with example environment
 run:
@@ -222,9 +243,10 @@ help:
 	@echo "  make build-windows  - Build for Windows (amd64)"
 	@echo ""
 	@echo "Testing:"
-	@echo "  make test           - Run all tests (server + client)"
+	@echo "  make test           - Run all tests (server + client + web)"
 	@echo "  make test-server    - Run server tests only"
 	@echo "  make test-client    - Run client tests only"
+	@echo "  make test-web       - Run web client tests only"
 	@echo ""
 	@echo "Formatting:"
 	@echo "  make fmt            - Format Go code with go fmt"


### PR DESCRIPTION
## What this fixes

`make test` ran `test-server` and `test-client`, both Go, and stopped
there. The web client's 127 vitest tests were never part of it, so a
change under `web/src` could break its suite whilst `make test` reported
success. The `Web Client` CI workflow has been catching this all along,
but only after a push, which is the wrong place to find out, and the
project's own guidance in `.claude/CLAUDE.md` asks that `make test` run
all test suites.

## What changed

A `test-web` target, wired into `test`. The web client is a separate npm
project, so it needs its own target rather than another package appended
to the Go lists in `test-server`.

Two details worth noting. Dependencies are installed with `npm ci`, and
only when `web/node_modules` is absent, so a repeat run does not pay the
install cost. A missing `npm` is reported and skipped rather than failed,
which matches how `lint`, `lint-server` and `lint-client` already treat a
missing `golangci-lint`, and keeps `make test` usable for someone working
only on the Go side without Node installed. A test that actually fails is
still a hard failure.

`help` and `.PHONY` are updated to match.

## How I checked this

- `make test-web` from a clean checkout: 13 files, 127 tests, all pass.
- The dependency-install branch is guarded on `web/node_modules` and uses
  the committed `web/package-lock.json`.
- No change to any Go target, so `test-server` and `test-client` behave
  exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded the aggregate test command to include web application tests.
  - Added a standalone command for running web tests.
  - Web dependencies are installed automatically when needed.
  - Web tests are skipped with an informational message when npm is unavailable; test failures still report errors.

- **Documentation**
  - Updated command-line help to describe the expanded test options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->