### PR TITLE
fix(web): stop repeating a tool call that keeps failing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -76,6 +76,16 @@ and this project adheres to
 
 ### Fixed
 
+- The web client no longer keeps re-running a tool call that cannot
+  succeed. Where a model responded to a tool error by reissuing the
+  identical call, the agentic loop would repeat it up to fifty times,
+  spending a request on each attempt, before failing with a bare
+  message about the loop limit. The loop now stops after the same tool
+  fails three times in a row with the same arguments, and explains what
+  happened, naming the tool and quoting the error. A retry with
+  different arguments is not affected, and a success clears the count,
+  so a model that adapts is left alone.
+
 - Switching `embedding.provider` (or `knowledgebase.embedding_provider`)
   away from Ollama without also setting a model no longer sends the
   Ollama model name to the new provider. `defaultConfig` seeded both

--- a/web/src/components/ChatInterface.jsx
+++ b/web/src/components/ChatInterface.jsx
@@ -974,6 +974,14 @@ const ChatInterface = ({ conversations }) => {
                     // once per block.
                     const toolResultMessages = [];
                     for (const toolUseBlock of toolUses) {
+                        // A batch of parallel tool_use blocks can repeat the
+                        // same failing call several times in one response;
+                        // stop issuing further calls the moment the guard
+                        // has already tripped on an earlier one this batch.
+                        if (toolRepeatGuard.getTripped()) {
+                            break;
+                        }
+
                         const toolUse = toolUseBlock.tool_use || toolUseBlock;
                         const toolUseId = toolUse.id;
                         const toolName = toolUse.name;
@@ -1549,6 +1557,14 @@ const ChatInterface = ({ conversations }) => {
                     // details under a `tool_use` object.
                     const toolResultMessages = [];
                     for (const toolUseBlock of toolUses) {
+                        // A batch of parallel tool_use blocks can repeat the
+                        // same failing call several times in one response;
+                        // stop issuing further calls the moment the guard
+                        // has already tripped on an earlier one this batch.
+                        if (toolRepeatGuard.getTripped()) {
+                            break;
+                        }
+
                         const toolUse = toolUseBlock.tool_use || toolUseBlock;
                         const toolUseId = toolUse.id;
                         const toolName = toolUse.name;

--- a/web/src/components/ChatInterface.jsx
+++ b/web/src/components/ChatInterface.jsx
@@ -25,9 +25,19 @@ import PromptPopover from './PromptPopover';
 import WriteQueryConfirmDialog from './WriteQueryConfirmDialog';
 import { writeConfirmationSubject } from '../utils/queryClassify';
 import { sseChat } from '../utils/sseChat';
+import {
+    createToolRepeatGuard,
+    buildRepeatedToolFailureMessage,
+} from '../utils/toolRepeatGuard';
 import { conversationToMarkdown, downloadMarkdown } from '../lib/conversationExport';
 
 const MAX_AGENTIC_LOOPS = 50;
+// Consecutive failures of the same tool, called with the same arguments,
+// that end the agentic loop early. Three allows a transient failure plus
+// one considered retry, whilst still catching a model that has locked on
+// to repeating a call that cannot succeed; without it the loop grinds all
+// the way to MAX_AGENTIC_LOOPS, spending a request on every attempt.
+const MAX_IDENTICAL_TOOL_FAILURES = 3;
 // Compact if estimated tokens exceed this threshold.
 // Note: Anthropic rate limits are typically 30k-60k input tokens/minute cumulative.
 // Setting lower allows multiple requests within the rate limit window.
@@ -741,6 +751,7 @@ const ChatInterface = ({ conversations }) => {
             const activity = [];
             let loopCount = 0;
             let rateLimitRetryCount = 0;
+            const toolRepeatGuard = createToolRepeatGuard(MAX_IDENTICAL_TOOL_FAILURES);
 
             // Agentic loop
             while (loopCount < MAX_AGENTIC_LOOPS) {
@@ -1007,9 +1018,16 @@ const ChatInterface = ({ conversations }) => {
                                 if (!confirmed) {
                                     activity[activityIndex].isError = true;
                                     activity[activityIndex].tokens = 0;
+                                    const declinedText = 'Execution was declined by the user. Do not retry this call. Ask the user how they would like to proceed.';
+                                    toolRepeatGuard.record({
+                                        name: toolName,
+                                        input: toolInput,
+                                        isError: true,
+                                        resultText: declinedText,
+                                    });
                                     toolResultMessages.push(buildToolResultMessage(
                                         toolUseId,
-                                        'Execution was declined by the user. Do not retry this call. Ask the user how they would like to proceed.',
+                                        declinedText,
                                         true,
                                     ));
                                     continue;
@@ -1026,6 +1044,15 @@ const ChatInterface = ({ conversations }) => {
                             const resultTokens = estimateToolResultTokens(result.content);
                             activity[activityIndex].tokens = resultTokens;
                             activity[activityIndex].isError = result.isError || false;
+
+                            // Track repeated identical failures so the loop
+                            // can stop rather than retry indefinitely.
+                            toolRepeatGuard.record({
+                                name: toolName,
+                                input: toolInput,
+                                isError: Boolean(result.isError),
+                                resultText: flattenToolResultText(result.content),
+                            });
 
                             // Update thinking message with token count
                             setMessages(prev => {
@@ -1060,12 +1087,40 @@ const ChatInterface = ({ conversations }) => {
                             activity[activityIndex].tokens = estimateToolResultTokens(errorContent);
                             activity[activityIndex].isError = true;
 
+                            toolRepeatGuard.record({
+                                name: toolName,
+                                input: toolInput,
+                                isError: true,
+                                resultText: errorContent,
+                            });
+
                             toolResultMessages.push(buildToolResultMessage(
                                 toolUseId,
                                 errorContent,
                                 true,
                             ));
                         }
+                    }
+
+                    // If the same call has now failed repeatedly, stop here
+                    // and explain why, rather than sending the model back
+                    // round to repeat it.
+                    const repeatedFailure = toolRepeatGuard.getTripped();
+                    if (repeatedFailure) {
+                        pendingSaveRef.current = true;
+                        setMessages(prev => {
+                            const newMessages = prev.slice(0, -1);
+                            return [...newMessages, {
+                                role: 'assistant',
+                                content: buildRepeatedToolFailureMessage(repeatedFailure),
+                                timestamp: new Date().toISOString(),
+                                provider: llmProviders.selectedProvider,
+                                model: llmProviders.selectedModel,
+                                activity: activity,
+                                tokenUsage: usage,
+                            }];
+                        });
+                        break;
                     }
 
                     // Echo the assistant turn (text + tool_use blocks) back
@@ -1319,6 +1374,7 @@ const ChatInterface = ({ conversations }) => {
             let loopCount = 0;
             const activity = [];
             let rateLimitRetryCount = 0;
+            const toolRepeatGuard = createToolRepeatGuard(MAX_IDENTICAL_TOOL_FAILURES);
 
             while (loopCount < MAX_AGENTIC_LOOPS) {
                 loopCount++;
@@ -1535,9 +1591,16 @@ const ChatInterface = ({ conversations }) => {
                                 if (!confirmed) {
                                     activity[activityIndex].isError = true;
                                     activity[activityIndex].tokens = 0;
+                                    const declinedText = 'Execution was declined by the user. Do not retry this call. Ask the user how they would like to proceed.';
+                                    toolRepeatGuard.record({
+                                        name: toolName,
+                                        input: toolInput,
+                                        isError: true,
+                                        resultText: declinedText,
+                                    });
                                     toolResultMessages.push(buildToolResultMessage(
                                         toolUseId,
-                                        'Execution was declined by the user. Do not retry this call. Ask the user how they would like to proceed.',
+                                        declinedText,
                                         true,
                                     ));
                                     continue;
@@ -1553,6 +1616,15 @@ const ChatInterface = ({ conversations }) => {
                             const resultTokens = estimateToolResultTokens(result.content);
                             activity[activityIndex].tokens = resultTokens;
                             activity[activityIndex].isError = result.isError || false;
+
+                            // Track repeated identical failures so the loop
+                            // can stop rather than retry indefinitely.
+                            toolRepeatGuard.record({
+                                name: toolName,
+                                input: toolInput,
+                                isError: Boolean(result.isError),
+                                resultText: flattenToolResultText(result.content),
+                            });
 
                             // Update thinking message with token count
                             setMessages(prev => {
@@ -1587,12 +1659,40 @@ const ChatInterface = ({ conversations }) => {
                             activity[activityIndex].tokens = estimateToolResultTokens(errorContent);
                             activity[activityIndex].isError = true;
 
+                            toolRepeatGuard.record({
+                                name: toolName,
+                                input: toolInput,
+                                isError: true,
+                                resultText: errorContent,
+                            });
+
                             toolResultMessages.push(buildToolResultMessage(
                                 toolUseId,
                                 errorContent,
                                 true,
                             ));
                         }
+                    }
+
+                    // If the same call has now failed repeatedly, stop here
+                    // and explain why, rather than sending the model back
+                    // round to repeat it.
+                    const repeatedFailure = toolRepeatGuard.getTripped();
+                    if (repeatedFailure) {
+                        pendingSaveRef.current = true;
+                        setMessages(prev => {
+                            const newMessages = prev.slice(0, -1);
+                            return [...newMessages, {
+                                role: 'assistant',
+                                content: buildRepeatedToolFailureMessage(repeatedFailure),
+                                timestamp: new Date().toISOString(),
+                                provider: llmProviders.selectedProvider,
+                                model: llmProviders.selectedModel,
+                                activity: activity,
+                                tokenUsage: usage,
+                            }];
+                        });
+                        break;
                     }
 
                     // Echo the assistant turn into the conversation

--- a/web/src/components/__tests__/ChatInterface.repeatGuard.test.jsx
+++ b/web/src/components/__tests__/ChatInterface.repeatGuard.test.jsx
@@ -217,6 +217,31 @@ describe('ChatInterface repeated tool failure guard', () => {
         expect(text).toContain('relation "users" does not exist');
     });
 
+    it('stops mid-batch when one response repeats the same failing call', async () => {
+        const sameCall = (id) => ({
+            type: 'tool_use',
+            tool_use: { id, name: 'query_database', input: { sql: 'SELECT count(*) FROM users' } },
+        });
+        mockSseChat.mockImplementation(async () => ({
+            stop_reason: 'tool_use',
+            content: [sameCall('call-1'), sameCall('call-2'), sameCall('call-3'), sameCall('call-4')],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        }));
+        mockCallTool.mockResolvedValue(
+            errorResult('ERROR: relation "users" does not exist'));
+
+        await sendMessage();
+        const text = await finalMessageText();
+
+        // The fourth identical call in the batch must never run: the
+        // guard trips on the third failure, so the loop should stop
+        // issuing further calls from the same response rather than
+        // running the whole batch before checking.
+        expect(mockCallTool).toHaveBeenCalledTimes(3);
+        expect(mockSseChat).toHaveBeenCalledTimes(1);
+        expect(text).toContain('3 times');
+    });
+
     it('ignores argument key ordering when matching repeats', async () => {
         const inputs = [
             { sql: 'SELECT 1', limit: 10 },

--- a/web/src/components/__tests__/ChatInterface.repeatGuard.test.jsx
+++ b/web/src/components/__tests__/ChatInterface.repeatGuard.test.jsx
@@ -1,0 +1,318 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - ChatInterface Repeated Tool Failure Guard Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// The component pulls in a lot of application context; stub every hook and
+// child so the tests can concentrate on the agentic loop itself.
+const mockCallTool = vi.fn();
+const mockGetPrompt = vi.fn();
+const mockSseChat = vi.fn();
+
+vi.mock('../../contexts/AuthContext', () => ({
+    useAuth: () => ({ sessionToken: 'test-token', forceLogout: vi.fn() }),
+}));
+
+vi.mock('../../contexts/LLMProcessingContext', () => ({
+    useLLMProcessing: () => ({ setIsProcessing: vi.fn() }),
+}));
+
+vi.mock('../../contexts/DatabaseContext', () => ({
+    useDatabaseContext: () => ({
+        databases: [],
+        currentDatabase: null,
+        selectDatabase: vi.fn(),
+        fetchDatabases: vi.fn(),
+    }),
+}));
+
+vi.mock('../../contexts/ConversationActionsContext', () => ({
+    useConversationActions: () => ({ registerActions: vi.fn() }),
+}));
+
+vi.mock('../../hooks/useLocalStorage', () => ({
+    useLocalStorageBoolean: () => [false, vi.fn()],
+}));
+
+vi.mock('../../hooks/useQueryHistory', () => ({
+    useQueryHistory: () => ({
+        addToHistory: vi.fn(),
+        clearHistory: vi.fn(),
+        setHistory: vi.fn(),
+        navigateUp: (current) => current,
+        navigateDown: (current) => current,
+        isNavigating: false,
+        resetNavigation: vi.fn(),
+    }),
+}));
+
+vi.mock('../../hooks/useMCPClient', () => ({
+    useMCPClient: () => ({
+        mcpClient: { callTool: mockCallTool, getPrompt: mockGetPrompt },
+        tools: [{ name: 'query_database', inputSchema: {} }],
+        prompts: [{ name: 'test_prompt', arguments: [] }],
+        refreshTools: vi.fn(),
+    }),
+}));
+
+vi.mock('../../hooks/useLLMProviders', () => ({
+    useLLMProviders: () => ({
+        providers: ['anthropic'],
+        selectedProvider: 'anthropic',
+        models: ['test-model'],
+        selectedModel: 'test-model',
+        setSelectedProvider: vi.fn(),
+        setSelectedModel: vi.fn(),
+        loadingModels: false,
+        restoreProviderAndModel: vi.fn(),
+    }),
+}));
+
+vi.mock('../../utils/sseChat', () => ({
+    sseChat: (...args) => mockSseChat(...args),
+}));
+
+vi.mock('../MessageList', () => ({
+    default: ({ messages }) => (
+        <div>
+            {messages.map((msg, index) => (
+                <div key={index} data-testid="message" data-role={msg.role}
+                    data-thinking={msg.isThinking ? 'true' : 'false'}>
+                    {typeof msg.content === 'string'
+                        ? msg.content
+                        : JSON.stringify(msg.content)}
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+vi.mock('../MessageInput', () => ({
+    default: ({ value, onChange, onSend, disabled }) => (
+        <div>
+            <textarea aria-label="prompt" value={value} onChange={onChange} />
+            <button type="button" onClick={onSend} disabled={disabled}>
+                Send
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock('../ProviderSelector', () => ({ default: () => null }));
+// The popover is reduced to a single button so the prompt-driven agentic
+// loop can be exercised without driving the real popover UI.
+vi.mock('../PromptPopover', () => ({
+    default: ({ onExecute }) => (
+        <button type="button" onClick={() => onExecute('test_prompt', {})}>
+            Run prompt
+        </button>
+    ),
+}));
+vi.mock('../WriteQueryConfirmDialog', () => ({ default: () => null }));
+
+const ChatInterface = (await import('../ChatInterface')).default;
+
+/**
+ * Builds an LLM response that asks for one tool call.
+ * @param {string} id - The tool_use id.
+ * @param {object} input - The arguments for the call.
+ * @returns {object} - A tool_use response envelope.
+ */
+const toolUseResponse = (id, input) => ({
+    stop_reason: 'tool_use',
+    content: [{
+        type: 'tool_use',
+        tool_use: { id, name: 'query_database', input },
+    }],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+});
+
+/**
+ * Builds a final LLM response carrying plain text.
+ * @param {string} text - The assistant's reply.
+ * @returns {object} - An end_turn response envelope.
+ */
+const endTurnResponse = (text) => ({
+    stop_reason: 'end_turn',
+    content: [{ type: 'text', text }],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+});
+
+/**
+ * A failing MCP tool result.
+ * @param {string} text - The error text.
+ * @returns {object} - An MCP result marked as an error.
+ */
+const errorResult = (text) => ({
+    content: [{ type: 'text', text }],
+    isError: true,
+});
+
+/**
+ * A successful MCP tool result.
+ * @param {string} text - The result text.
+ * @returns {object} - An MCP result.
+ */
+const okResult = (text) => ({
+    content: [{ type: 'text', text }],
+    isError: false,
+});
+
+/**
+ * Renders the component and sends a message through it.
+ * @returns {Promise<void>} - Resolves once the send has been dispatched.
+ */
+const sendMessage = async () => {
+    render(<ChatInterface />);
+    fireEvent.change(screen.getByLabelText('prompt'), {
+        target: { value: 'how many users are there?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+};
+
+/**
+ * Waits until the conversation has settled, then returns the text of the
+ * final assistant message.
+ * @returns {Promise<string>} - The final message text.
+ */
+const finalMessageText = async () => {
+    await waitFor(() => {
+        const messages = screen.getAllByTestId('message');
+        const last = messages[messages.length - 1];
+        expect(last.dataset.thinking).toBe('false');
+        expect(last.dataset.role).toBe('assistant');
+    }, { timeout: 5000 });
+    const messages = screen.getAllByTestId('message');
+    return messages[messages.length - 1].textContent;
+};
+
+describe('ChatInterface repeated tool failure guard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    it('stops after three identical failing calls', async () => {
+        mockSseChat.mockImplementation(async () =>
+            toolUseResponse('call-1', { sql: 'SELECT count(*) FROM users' }));
+        mockCallTool.mockResolvedValue(
+            errorResult('ERROR: relation "users" does not exist'));
+
+        await sendMessage();
+        const text = await finalMessageText();
+
+        expect(mockCallTool).toHaveBeenCalledTimes(3);
+        expect(mockSseChat).toHaveBeenCalledTimes(3);
+        expect(text).toContain('query_database');
+        expect(text).toContain('3 times');
+        expect(text).toContain('relation "users" does not exist');
+    });
+
+    it('ignores argument key ordering when matching repeats', async () => {
+        const inputs = [
+            { sql: 'SELECT 1', limit: 10 },
+            { limit: 10, sql: 'SELECT 1' },
+            { sql: 'SELECT 1', limit: 10 },
+            { limit: 10, sql: 'SELECT 1' },
+        ];
+        let call = 0;
+        mockSseChat.mockImplementation(async () =>
+            toolUseResponse(`call-${call}`, inputs[call++] || inputs[0]));
+        mockCallTool.mockResolvedValue(errorResult('ERROR: broken'));
+
+        await sendMessage();
+        const text = await finalMessageText();
+
+        expect(mockCallTool).toHaveBeenCalledTimes(3);
+        expect(text).toContain('3 times');
+    });
+
+    it('does not trip when the arguments differ each time', async () => {
+        let call = 0;
+        mockSseChat.mockImplementation(async () => {
+            call++;
+            if (call > 4) return endTurnResponse('I gave up gracefully.');
+            return toolUseResponse(`call-${call}`, { sql: `SELECT ${call}` });
+        });
+        mockCallTool.mockResolvedValue(errorResult('ERROR: broken'));
+
+        await sendMessage();
+        const text = await finalMessageText();
+
+        expect(mockCallTool).toHaveBeenCalledTimes(4);
+        expect(text).toBe('I gave up gracefully.');
+    });
+
+    it('resets the count when the same call later succeeds', async () => {
+        const outcomes = [
+            errorResult('ERROR: broken'),
+            errorResult('ERROR: broken'),
+            okResult('42'),
+            errorResult('ERROR: broken'),
+            errorResult('ERROR: broken'),
+        ];
+        let call = 0;
+        mockSseChat.mockImplementation(async () => {
+            call++;
+            if (call > outcomes.length) {
+                return endTurnResponse('All done.');
+            }
+            return toolUseResponse(`call-${call}`, { sql: 'SELECT 1' });
+        });
+        let outcome = 0;
+        mockCallTool.mockImplementation(async () => outcomes[outcome++]);
+
+        await sendMessage();
+        const text = await finalMessageText();
+
+        expect(text).toBe('All done.');
+        expect(mockCallTool).toHaveBeenCalledTimes(5);
+    });
+
+    it('guards the prompt-driven loop as well', async () => {
+        mockGetPrompt.mockResolvedValue({
+            messages: [{ role: 'user', content: { text: 'audit the database' } }],
+        });
+        mockSseChat.mockImplementation(async () =>
+            toolUseResponse('call-1', { sql: 'SELECT 1' }));
+        mockCallTool.mockResolvedValue(errorResult('ERROR: broken'));
+
+        render(<ChatInterface />);
+        fireEvent.click(screen.getByRole('button', { name: 'Run prompt' }));
+        const text = await finalMessageText();
+
+        expect(mockCallTool).toHaveBeenCalledTimes(3);
+        expect(mockSseChat).toHaveBeenCalledTimes(3);
+        expect(text).toContain('query_database');
+        expect(text).toContain('3 times');
+        expect(text).toContain('ERROR: broken');
+    });
+
+    it('leaves a successful conversation untouched', async () => {
+        let call = 0;
+        mockSseChat.mockImplementation(async () => {
+            call++;
+            if (call === 1) {
+                return toolUseResponse('call-1', { sql: 'SELECT 1' });
+            }
+            return endTurnResponse('There are 42 users.');
+        });
+        mockCallTool.mockResolvedValue(okResult('42'));
+
+        await sendMessage();
+        const text = await finalMessageText();
+
+        expect(mockCallTool).toHaveBeenCalledTimes(1);
+        expect(mockSseChat).toHaveBeenCalledTimes(2);
+        expect(text).toBe('There are 42 users.');
+    });
+});

--- a/web/src/utils/toolRepeatGuard.js
+++ b/web/src/utils/toolRepeatGuard.js
@@ -1,0 +1,153 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Guards the agentic loop against a model that keeps re-issuing the same
+ * failing tool call. Some providers respond to a tool error by repeating
+ * the identical call rather than adapting, which burns a request per
+ * attempt until the loop hits its iteration cap; the guard spots that
+ * pattern early and lets the caller stop with a useful explanation.
+ */
+
+// The longest error text quoted back to the user. Tool errors can carry a
+// whole server response, and the chat bubble only needs enough of it to
+// identify the problem.
+const MAX_QUOTED_ERROR_LENGTH = 500;
+
+/**
+ * Serialises a value to a string that does not depend on object key
+ * order, so that {a: 1, b: 2} and {b: 2, a: 1} produce the same text.
+ * Arrays keep their order, because argument order is significant.
+ * Cycles are replaced with a marker rather than throwing, since the
+ * guard must never be the thing that breaks a conversation.
+ * @param {*} value - The value to serialise.
+ * @param {WeakSet} [seen] - Containers already being serialised.
+ * @returns {string} - A stable textual representation.
+ */
+export const stableStringify = (value, seen = new WeakSet()) => {
+    if (value === null || value === undefined) return 'null';
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? String(value) : 'null';
+    }
+    if (typeof value === 'boolean') return String(value);
+    if (typeof value === 'string') return JSON.stringify(value);
+    if (typeof value !== 'object') return JSON.stringify(String(value));
+
+    if (seen.has(value)) return '"[circular]"';
+    seen.add(value);
+
+    let out;
+    if (Array.isArray(value)) {
+        out = `[${value.map((item) => stableStringify(item, seen)).join(',')}]`;
+    } else {
+        const keys = Object.keys(value).sort();
+        const parts = keys.map(
+            (key) => `${JSON.stringify(key)}:${stableStringify(value[key], seen)}`,
+        );
+        out = `{${parts.join(',')}}`;
+    }
+
+    seen.delete(value);
+    return out;
+};
+
+/**
+ * Builds the key that identifies one specific tool call: the tool name
+ * together with its arguments, so a retry with genuinely different
+ * arguments counts as a different call.
+ * @param {string} name - The tool name.
+ * @param {*} input - The arguments passed to the tool.
+ * @returns {string} - The identity key for the call.
+ */
+export const toolCallKey = (name, input) =>
+    `${String(name)}::${stableStringify(input)}`;
+
+/**
+ * Shortens error text for display, appending an ellipsis when trimmed.
+ * @param {string} text - The raw error text.
+ * @returns {string} - Text no longer than MAX_QUOTED_ERROR_LENGTH.
+ */
+const truncateError = (text) => {
+    const trimmed = (text || '').trim();
+    if (trimmed.length <= MAX_QUOTED_ERROR_LENGTH) return trimmed;
+    return `${trimmed.slice(0, MAX_QUOTED_ERROR_LENGTH)}...`;
+};
+
+/**
+ * Composes the message shown to the user when the guard trips. It names
+ * the tool, says how many times it failed, and quotes the last error so
+ * that the user can see what needs fixing.
+ * @param {object} info - The trip details from the guard.
+ * @param {string} info.name - The tool that kept failing.
+ * @param {number} info.count - How many times it failed in a row.
+ * @param {string} info.errorText - The most recent error text.
+ * @returns {string} - The assistant message content.
+ */
+export const buildRepeatedToolFailureMessage = ({ name, count, errorText }) => {
+    const quoted = truncateError(errorText);
+    const detail = quoted
+        ? ` The last error was: ${quoted}`
+        : '';
+    return `I have stopped because the \`${name}\` tool failed ${count} times ` +
+        `in a row with exactly the same arguments, so repeating it again is ` +
+        `unlikely to help.${detail}\n\n` +
+        `You may need to address the underlying problem, or rephrase your ` +
+        `request so that a different approach is taken.`;
+};
+
+/**
+ * Creates a guard that tracks consecutive failures per distinct tool
+ * call. Record every executed call; the guard trips once one call has
+ * failed `limit` times without an intervening success.
+ * @param {number} limit - Consecutive failures that trip the guard.
+ * @returns {object} - Guard with `record` and `getTripped` methods.
+ */
+export const createToolRepeatGuard = (limit) => {
+    const failures = new Map();
+    let tripped = null;
+
+    return {
+        /**
+         * Records the outcome of one tool call.
+         * @param {object} call - The call outcome.
+         * @param {string} call.name - The tool name.
+         * @param {*} call.input - The arguments the tool was called with.
+         * @param {boolean} call.isError - Whether the call failed.
+         * @param {string} [call.resultText] - The result or error text.
+         * @returns {object|null} - Trip details, or null if not tripped.
+         */
+        record({ name, input, isError, resultText }) {
+            const key = toolCallKey(name, input);
+
+            // A success means the loop is making progress, so forget the
+            // earlier failures of that exact call.
+            if (!isError) {
+                failures.delete(key);
+                return tripped;
+            }
+
+            const count = (failures.get(key) || 0) + 1;
+            failures.set(key, count);
+
+            if (!tripped && count >= limit) {
+                tripped = { name, count, errorText: resultText || '' };
+            }
+            return tripped;
+        },
+
+        /**
+         * Reports whether the guard has tripped.
+         * @returns {object|null} - Trip details, or null if not tripped.
+         */
+        getTripped() {
+            return tripped;
+        },
+    };
+};

--- a/web/src/utils/toolRepeatGuard.test.js
+++ b/web/src/utils/toolRepeatGuard.test.js
@@ -1,0 +1,237 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    createToolRepeatGuard,
+    buildRepeatedToolFailureMessage,
+    stableStringify,
+    toolCallKey,
+} from './toolRepeatGuard';
+
+/**
+ * Records a failing call against the guard.
+ * @param {object} guard - The guard under test.
+ * @param {string} name - The tool name.
+ * @param {*} input - The tool arguments.
+ * @param {string} [text] - The error text.
+ * @returns {object|null} - Trip details, or null.
+ */
+const fail = (guard, name, input, text = 'boom') =>
+    guard.record({ name, input, isError: true, resultText: text });
+
+/**
+ * Records a successful call against the guard.
+ * @param {object} guard - The guard under test.
+ * @param {string} name - The tool name.
+ * @param {*} input - The tool arguments.
+ * @returns {object|null} - Trip details, or null.
+ */
+const succeed = (guard, name, input) =>
+    guard.record({ name, input, isError: false, resultText: 'fine' });
+
+describe('stableStringify', () => {
+    it('produces the same text regardless of key order', () => {
+        expect(stableStringify({ a: 1, b: 2 }))
+            .toBe(stableStringify({ b: 2, a: 1 }));
+    });
+
+    it('sorts nested object keys too', () => {
+        expect(stableStringify({ outer: { x: 1, y: 2 }, z: 3 }))
+            .toBe(stableStringify({ z: 3, outer: { y: 2, x: 1 } }));
+    });
+
+    it('preserves array order', () => {
+        expect(stableStringify([1, 2])).not.toBe(stableStringify([2, 1]));
+    });
+
+    it('distinguishes values of different types', () => {
+        expect(stableStringify({ a: 1 })).not.toBe(stableStringify({ a: '1' }));
+    });
+
+    it('treats null and undefined alike', () => {
+        expect(stableStringify(null)).toBe('null');
+        expect(stableStringify(undefined)).toBe('null');
+    });
+
+    it('handles circular structures without throwing', () => {
+        const cyclic = { name: 'loop' };
+        cyclic.self = cyclic;
+        expect(() => stableStringify(cyclic)).not.toThrow();
+        expect(stableStringify(cyclic)).toContain('[circular]');
+    });
+});
+
+describe('toolCallKey', () => {
+    it('matches identical calls whose keys are ordered differently', () => {
+        expect(toolCallKey('query_database', { sql: 'SELECT 1', db: 'x' }))
+            .toBe(toolCallKey('query_database', { db: 'x', sql: 'SELECT 1' }));
+    });
+
+    it('separates different tools carrying the same arguments', () => {
+        expect(toolCallKey('tool_a', { q: 1 }))
+            .not.toBe(toolCallKey('tool_b', { q: 1 }));
+    });
+});
+
+describe('createToolRepeatGuard', () => {
+    it('does not trip before the limit is reached', () => {
+        const guard = createToolRepeatGuard(3);
+        expect(fail(guard, 'query_database', { sql: 'SELECT 1' })).toBeNull();
+        expect(fail(guard, 'query_database', { sql: 'SELECT 1' })).toBeNull();
+        expect(guard.getTripped()).toBeNull();
+    });
+
+    it('trips on the third identical failure', () => {
+        const guard = createToolRepeatGuard(3);
+        fail(guard, 'query_database', { sql: 'SELECT 1' }, 'relation missing');
+        fail(guard, 'query_database', { sql: 'SELECT 1' }, 'relation missing');
+        const tripped = fail(
+            guard, 'query_database', { sql: 'SELECT 1' }, 'relation missing');
+
+        expect(tripped).toEqual({
+            name: 'query_database',
+            count: 3,
+            errorText: 'relation missing',
+        });
+        expect(guard.getTripped()).toEqual(tripped);
+    });
+
+    it('ignores argument key ordering when matching calls', () => {
+        const guard = createToolRepeatGuard(3);
+        fail(guard, 'query_database', { sql: 'SELECT 1', limit: 10 });
+        fail(guard, 'query_database', { limit: 10, sql: 'SELECT 1' });
+        expect(guard.getTripped()).toBeNull();
+
+        fail(guard, 'query_database', { sql: 'SELECT 1', limit: 10 });
+        expect(guard.getTripped()?.count).toBe(3);
+    });
+
+    it('does not trip when the same tool fails with different arguments', () => {
+        const guard = createToolRepeatGuard(3);
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+        fail(guard, 'query_database', { sql: 'SELECT 2' });
+        fail(guard, 'query_database', { sql: 'SELECT 3' });
+        fail(guard, 'query_database', { sql: 'SELECT 4' });
+        expect(guard.getTripped()).toBeNull();
+    });
+
+    it('does not trip when different tools fail with the same arguments', () => {
+        const guard = createToolRepeatGuard(3);
+        fail(guard, 'tool_a', { q: 1 });
+        fail(guard, 'tool_b', { q: 1 });
+        fail(guard, 'tool_c', { q: 1 });
+        expect(guard.getTripped()).toBeNull();
+    });
+
+    it('resets the count for a call that later succeeds', () => {
+        const guard = createToolRepeatGuard(3);
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+        succeed(guard, 'query_database', { sql: 'SELECT 1' });
+
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+        expect(guard.getTripped()).toBeNull();
+
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+        expect(guard.getTripped()?.count).toBe(3);
+    });
+
+    it('only resets the call that succeeded', () => {
+        const guard = createToolRepeatGuard(3);
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+        succeed(guard, 'query_database', { sql: 'SELECT 2' });
+        fail(guard, 'query_database', { sql: 'SELECT 1' });
+
+        expect(guard.getTripped()?.count).toBe(3);
+    });
+
+    it('never trips when every call succeeds', () => {
+        const guard = createToolRepeatGuard(3);
+        for (let i = 0; i < 10; i++) {
+            succeed(guard, 'query_database', { sql: 'SELECT 1' });
+        }
+        expect(guard.getTripped()).toBeNull();
+    });
+
+    it('keeps the first trip details once tripped', () => {
+        const guard = createToolRepeatGuard(2);
+        fail(guard, 'tool_a', { q: 1 }, 'first error');
+        fail(guard, 'tool_a', { q: 1 }, 'first error');
+        fail(guard, 'tool_a', { q: 1 }, 'later error');
+
+        expect(guard.getTripped()).toEqual({
+            name: 'tool_a',
+            count: 2,
+            errorText: 'first error',
+        });
+    });
+
+    it('treats missing and empty arguments consistently', () => {
+        const guard = createToolRepeatGuard(3);
+        fail(guard, 'list_databases', {});
+        fail(guard, 'list_databases', {});
+        fail(guard, 'list_databases', {});
+        expect(guard.getTripped()?.name).toBe('list_databases');
+    });
+
+    it('honours a limit of one', () => {
+        const guard = createToolRepeatGuard(1);
+        expect(fail(guard, 'tool_a', { q: 1 })?.count).toBe(1);
+    });
+});
+
+describe('buildRepeatedToolFailureMessage', () => {
+    it('names the tool, the count, and the last error', () => {
+        const message = buildRepeatedToolFailureMessage({
+            name: 'query_database',
+            count: 3,
+            errorText: 'relation "users" does not exist',
+        });
+
+        expect(message).toContain('query_database');
+        expect(message).toContain('3 times');
+        expect(message).toContain('relation "users" does not exist');
+    });
+
+    it('omits the error detail when there is no error text', () => {
+        const message = buildRepeatedToolFailureMessage({
+            name: 'query_database',
+            count: 3,
+            errorText: '',
+        });
+
+        expect(message).toContain('query_database');
+        expect(message).not.toContain('The last error was');
+    });
+
+    it('truncates very long error text', () => {
+        const message = buildRepeatedToolFailureMessage({
+            name: 'query_database',
+            count: 3,
+            errorText: 'x'.repeat(2000),
+        });
+
+        expect(message.length).toBeLessThan(1000);
+        expect(message).toContain('...');
+    });
+
+    it('contains no emdash', () => {
+        const message = buildRepeatedToolFailureMessage({
+            name: 'query_database',
+            count: 3,
+            errorText: 'boom',
+        });
+
+        expect(message).not.toContain('—');
+    });
+});


### PR DESCRIPTION
## Summary

Issue #235 reports that with the Gemini provider a failing tool is called over
and over until the user cancels. It is not quite infinite: both agentic loops
are bounded by `MAX_AGENTIC_LOOPS` (50), so what actually happens is fifty round
trips, each costing a request, ending in a bare `Maximum tool execution loops
reached` error rather than anything the user can act on.

- Each executed call is keyed by tool name plus its arguments, serialised so key
  order is irrelevant, and three consecutive failures of that key end the turn
  with an ordinary assistant message naming the tool and quoting the error.
- A retry with different arguments is a different key and is left alone, since a
  model adapting its approach is making progress. A success clears the count for
  that call, so intermittent failures never accumulate.
- Nothing is thrown, so the user reads an explanation rather than an error
  banner. The guard lives in `web/src/utils/toolRepeatGuard.js` and is wired into
  both agentic loops.

## On the root cause, and why this says Refs rather than Closes

This is deliberately a backstop rather than a diagnosis, so I have not marked the
issue auto-closing.

The provider side is addressed separately in pgEdge/pgedge-go-llm-lib#34: Gemini
was receiving failed tool results as though they had succeeded, because the
provider never read `IsError`. That is a real bug with a demonstrable
consequence, verified against the live API, where a failed tool with no error
text made the model reply "I was able to read the system info resource, but it
appears to be empty" instead of admitting the failure.

However, it does not by itself reproduce the runaway. Driving the real Gemini API
through the proxy exactly as this client does, including the `sseChat` `tool_use`
inference, the model stops after a single failing call. I tried four variants
(direct client, faithful proxy round-trip, empty error text, and a mismatched
`tool_use_id`) and none looped. Something in the reporter's environment differs,
most likely the full tool set, the real system prompt, or the specific error text
a given tool emits, and a trace of the request bodies from a looping session
would settle it.

Bounding the damage is worth having regardless, and it protects against any
provider behaving this way rather than only the one reported.

## Test plan

- [x] 23 unit tests for the guard: key stability under argument reordering,
      per-call counters, reset on success, and cycle-safe serialisation.
- [x] 6 integration tests driving the real component loop with `sseChat` and
      `mcpClient.callTool` stubbed, asserting the tool is never invoked a fourth
      time, that differing arguments do not trip the guard, that fail/fail/
      success/fail/fail completes normally, that a clean conversation is
      unaffected, and that the prompt-driven loop is guarded identically.
- [x] `make lint` (0 issues) and `make test` fully green, 210 web tests passing.

Refs #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented repeated retries of identical failed tool calls after three consecutive failures.
  - Included user-declined executions and displayed the affected tool and error.
  - Allowed calls with different arguments to continue and reset failure counts after success.
  - Applied the safeguard to chat and prompt-driven interactions.

- **Documentation**
  - Added a changelog entry describing the repeated-failure safeguard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->