### PR TITLE
feat(cli): add Gemini as an LLM provider

### DIFF
--- a/cmd/pgedge-pg-mcp-cli/main.go
+++ b/cmd/pgedge-pg-mcp-cli/main.go
@@ -33,10 +33,12 @@ func main() {
 	mcpToken := flag.String("mcp-token", "", "MCP server authentication token (for token mode)")
 	mcpUsername := flag.String("mcp-username", "", "MCP server username (for user mode)")
 	mcpPassword := flag.String("mcp-password", "", "MCP server password (for user mode)")
-	llmProvider := flag.String("llm-provider", "", "LLM provider: anthropic, openai, or ollama (default: anthropic)")
+	llmProvider := flag.String("llm-provider", "", "LLM provider: anthropic, openai, gemini, or ollama (default: anthropic)")
 	llmModel := flag.String("llm-model", "", "LLM model to use")
 	anthropicAPIKey := flag.String("anthropic-api-key", "", "API key for Anthropic")
 	openaiAPIKey := flag.String("openai-api-key", "", "API key for OpenAI")
+	geminiAPIKey := flag.String("gemini-api-key", "", "API key for Google Gemini")
+	geminiAPIKeyFile := flag.String("gemini-api-key-file", "", "Path to a file containing the Google Gemini API key")
 	ollamaURL := flag.String("ollama-url", "", "Ollama server URL (default: http://localhost:11434)")
 	noColor := flag.Bool("no-color", false, "Disable colored output")
 
@@ -98,12 +100,35 @@ func main() {
 	if *openaiAPIKey != "" {
 		cfg.LLM.OpenAIAPIKey = *openaiAPIKey
 	}
+	// The key file is read here rather than by the loader, because the loader
+	// resolves the files named in the configuration before any flag is seen.
+	// A key given directly on the command line wins over one in a file.
+	if *geminiAPIKeyFile != "" {
+		cfg.LLM.GeminiAPIKeyFile = *geminiAPIKeyFile
+		key, err := chat.ReadAPIKeyFile(*geminiAPIKeyFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading Gemini API key file: %v\n", err)
+			os.Exit(1)
+		}
+		if key == "" {
+			fmt.Fprintf(os.Stderr, "Gemini API key file %s is missing or empty\n", *geminiAPIKeyFile)
+			os.Exit(1)
+		}
+		cfg.LLM.GeminiAPIKey = key
+	}
+	if *geminiAPIKey != "" {
+		cfg.LLM.GeminiAPIKey = *geminiAPIKey
+	}
 	if *ollamaURL != "" {
 		cfg.LLM.OllamaURL = *ollamaURL
 	}
 	if *noColor {
 		cfg.UI.NoColor = true
 	}
+
+	// Re-register the credentials for redaction, since the flags above may
+	// have supplied keys that LoadConfig never saw.
+	cfg.RegisterSecrets()
 
 	// Validate configuration
 	if err := cfg.Validate(); err != nil {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,16 @@ and this project adheres to
   databases built before the column existed continue to work with the
   other providers.
 
+- The CLI client now supports Google Gemini as an LLM provider, which
+  the server has offered for some time. Select it with `-llm-provider
+  gemini`, with `PGEDGE_LLM_PROVIDER=gemini`, or with `provider:
+  gemini` in the configuration file, and supply the key through the
+  new `-gemini-api-key` and `-gemini-api-key-file` flags, the
+  `PGEDGE_GEMINI_API_KEY` or `GEMINI_API_KEY` environment variables,
+  or the `gemini_api_key` and `gemini_api_key_file` settings. The
+  provider can also be switched at runtime with `/set provider
+  gemini`, and defaults to the `gemini-2.5-flash` model. (#238)
+
 ### Changed
 
 - Dependencies across every ecosystem this project uses are now on their

--- a/docs/guide/cli-client.md
+++ b/docs/guide/cli-client.md
@@ -106,14 +106,19 @@ You can configure the chat client in three ways (in order of precedence):
 API keys are loaded in the following order (highest to lowest):
 
 1. Environment variables (`PGEDGE_ANTHROPIC_API_KEY`,
-   `PGEDGE_OPENAI_API_KEY`, `PGEDGE_GEMINI_API_KEY`)
+   `PGEDGE_OPENAI_API_KEY`, `PGEDGE_GEMINI_API_KEY`). Each falls back to
+   the unprefixed form (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+   `GEMINI_API_KEY`), which is consulted only when the prefixed
+   variable is unset.
 2. API key files (`~/.anthropic-api-key`, `~/.openai-api-key`, and the file
    named by `gemini_api_key_file` or `-gemini-api-key-file`)
 3. Configuration file values (not recommended)
 
 The `-gemini-api-key` and `-gemini-api-key-file` flags override every other
 source, because command-line flags take precedence over the configuration
-the client has already loaded.
+the client has already loaded. Where both are given, `-gemini-api-key`
+wins, and a key file named on the command line that cannot be read is an
+error rather than a silent fallback.
 
 ### Using Command-Line Flags
 
@@ -151,9 +156,11 @@ Flags:
 - `PGEDGE_MCP_TOKEN`: Authentication token (for HTTP mode)
 - `PGEDGE_LLM_PROVIDER`: LLM provider (anthropic, openai, gemini, or ollama)
 - `PGEDGE_LLM_MODEL`: LLM model name
-- `PGEDGE_ANTHROPIC_API_KEY`: Anthropic API key
-- `PGEDGE_OPENAI_API_KEY`: OpenAI API key
-- `PGEDGE_GEMINI_API_KEY`: Google Gemini API key
+- `PGEDGE_ANTHROPIC_API_KEY`: Anthropic API key (falls back to
+  `ANTHROPIC_API_KEY`)
+- `PGEDGE_OPENAI_API_KEY`: OpenAI API key (falls back to `OPENAI_API_KEY`)
+- `PGEDGE_GEMINI_API_KEY`: Google Gemini API key (falls back to
+  `GEMINI_API_KEY`)
 - `PGEDGE_OLLAMA_URL`: Ollama server URL (default: http://localhost:11434)
 - `NO_COLOR`: Disable colored output
 
@@ -289,7 +296,11 @@ You can keep the key in a file instead, which avoids exposing it in the
 environment:
 
 ```bash
-echo "your-api-key-here" > ~/.gemini-api-key
+umask 077
+read -r -s -p 'Gemini API key: ' key
+printf '\n'
+printf '%s\n' "$key" > ~/.gemini-api-key
+unset key
 chmod 600 ~/.gemini-api-key
 
 ./bin/pgedge-nla-cli \

--- a/docs/guide/cli-client.md
+++ b/docs/guide/cli-client.md
@@ -46,6 +46,8 @@ Before running the startup script, make sure you have:
      environment variable, OR create `~/.anthropic-api-key` file
    - OpenAI: Set `OPENAI_API_KEY` or `PGEDGE_OPENAI_API_KEY` environment
      variable, OR create `~/.openai-api-key` file
+   - Gemini: Set `GEMINI_API_KEY` or `PGEDGE_GEMINI_API_KEY` environment
+     variable, OR pass `-gemini-api-key-file` with the path to a key file
    - Ollama: Set `PGEDGE_OLLAMA_URL` (e.g., `http://localhost:11434`)
 
 * **Database Connection** (optional, uses defaults if not set):
@@ -103,9 +105,15 @@ You can configure the chat client in three ways (in order of precedence):
 
 API keys are loaded in the following order (highest to lowest):
 
-1. Environment variables (`PGEDGE_ANTHROPIC_API_KEY`, `PGEDGE_OPENAI_API_KEY`)
-2. API key files (`~/.anthropic-api-key`, `~/.openai-api-key`)
+1. Environment variables (`PGEDGE_ANTHROPIC_API_KEY`,
+   `PGEDGE_OPENAI_API_KEY`, `PGEDGE_GEMINI_API_KEY`)
+2. API key files (`~/.anthropic-api-key`, `~/.openai-api-key`, and the file
+   named by `gemini_api_key_file` or `-gemini-api-key-file`)
 3. Configuration file values (not recommended)
+
+The `-gemini-api-key` and `-gemini-api-key-file` flags override every other
+source, because command-line flags take precedence over the configuration
+the client has already loaded.
 
 ### Using Command-Line Flags
 
@@ -119,10 +127,17 @@ Flags:
   -mcp-url string           MCP server URL (for HTTP mode)
   -mcp-server-path string   Path to MCP server binary (for stdio mode)
   -mcp-server-config string Path to MCP server config file (for stdio mode)
-  -llm-provider string      LLM provider: anthropic, openai, or ollama
+  -mcp-auth-mode string     MCP authentication mode: none, token, or user
+  -mcp-token string         MCP server authentication token (for token mode)
+  -mcp-username string      MCP server username (for user mode)
+  -mcp-password string      MCP server password (for user mode)
+  -llm-provider string      LLM provider: anthropic, openai, gemini, or ollama
   -llm-model string         LLM model to use
   -anthropic-api-key string API key for Anthropic
   -openai-api-key string    API key for OpenAI
+  -gemini-api-key string    API key for Google Gemini
+  -gemini-api-key-file string
+                            Path to a file containing the Google Gemini API key
   -ollama-url string        Ollama server URL
   -no-color                 Disable colored output
 ```
@@ -134,10 +149,11 @@ Flags:
 - `PGEDGE_MCP_SERVER_PATH`: Path to MCP server binary (for stdio mode)
 - `PGEDGE_MCP_SERVER_CONFIG_PATH`: Path to MCP server config file (for stdio mode)
 - `PGEDGE_MCP_TOKEN`: Authentication token (for HTTP mode)
-- `PGEDGE_LLM_PROVIDER`: LLM provider (anthropic, openai, or ollama)
+- `PGEDGE_LLM_PROVIDER`: LLM provider (anthropic, openai, gemini, or ollama)
 - `PGEDGE_LLM_MODEL`: LLM model name
 - `PGEDGE_ANTHROPIC_API_KEY`: Anthropic API key
 - `PGEDGE_OPENAI_API_KEY`: OpenAI API key
+- `PGEDGE_GEMINI_API_KEY`: Google Gemini API key
 - `PGEDGE_OLLAMA_URL`: Ollama server URL (default: http://localhost:11434)
 - `NO_COLOR`: Disable colored output
 
@@ -161,7 +177,7 @@ mcp:
     # token: your-token-here
 
 llm:
-    provider: anthropic  # Options: anthropic, openai, or ollama
+    provider: anthropic  # Options: anthropic, openai, gemini, or ollama
     model: claude-sonnet-4-20250514
 
     # API keys (priority: env vars > key files > direct config values)
@@ -169,9 +185,11 @@ llm:
     # Option 2: API key files (recommended for production)
     anthropic_api_key_file: ~/.anthropic-api-key
     openai_api_key_file: ~/.openai-api-key
+    gemini_api_key_file: ~/.gemini-api-key
     # Option 3: Direct values (not recommended - use env vars or files)
     # anthropic_api_key: your-anthropic-key-here
     # openai_api_key: your-openai-key-here
+    # gemini_api_key: your-gemini-key-here
 
     max_tokens: 4096
 
@@ -252,6 +270,35 @@ Note: GPT-5 and o-series models (o1, o3) have specific API constraints:
 - Use `max_completion_tokens` instead of `max_tokens`
 
 The client automatically handles these differences.
+
+### Example 2b: Stdio Mode with Google Gemini
+
+Use Google's Gemini models for natural language processing.
+
+```bash
+# Set your Gemini API key
+export PGEDGE_GEMINI_API_KEY="your-api-key-here"
+
+# Run the chat client with Gemini
+./bin/pgedge-nla-cli \
+  -llm-provider gemini \
+  -llm-model gemini-2.5-flash
+```
+
+You can keep the key in a file instead, which avoids exposing it in the
+environment:
+
+```bash
+echo "your-api-key-here" > ~/.gemini-api-key
+chmod 600 ~/.gemini-api-key
+
+./bin/pgedge-nla-cli \
+  -llm-provider gemini \
+  -gemini-api-key-file ~/.gemini-api-key
+```
+
+The client defaults to the `gemini-2.5-flash` model when you do not name one;
+use `/list models` to see everything the account can reach.
 
 ### Example 3: HTTP Mode with Authentication
 
@@ -475,7 +522,7 @@ colors but still with formatting structure.
 ```
 
 Change the LLM provider at runtime without restarting the client. Valid
-providers: `anthropic`, `openai`, `ollama`.
+providers: `anthropic`, `openai`, `gemini`, `ollama`.
 
 **Examples:**
 

--- a/docs/guide/deploy_docker.md
+++ b/docs/guide/deploy_docker.md
@@ -169,12 +169,13 @@ You also need to specify the LLM provider information in the `LLM CONFIGURATION 
 # ============================================================================
 # LLM CONFIGURATION FOR CLIENTS
 # ============================================================================
-# Default LLM provider for chat clients: anthropic, openai, or ollama
+# Default LLM provider for chat clients: anthropic, openai, gemini, or ollama
 PGEDGE_LLM_PROVIDER=anthropic
 
 # Default LLM model for chat clients
 # Anthropic: claude-sonnet-4-20250514, claude-opus-4-20250514, etc.
 # OpenAI: gpt-4o, gpt-4-turbo, gpt-4o-mini, etc.
+# Gemini: gemini-2.5-flash, gemini-2.5-pro, etc.
 # Ollama: llama3, mistral, etc.
 PGEDGE_LLM_MODEL=claude-sonnet-4-20250514
 ```

--- a/docs/guide/deploy_source.md
+++ b/docs/guide/deploy_source.md
@@ -145,14 +145,15 @@ You also need to specify the LLM provider information in the
 # ============================================================================
 # LLM CONFIGURATION FOR CLIENTS
 # ============================================================================
-# Default LLM provider for chat clients: anthropic, openai, or
-# ollama
+# Default LLM provider for chat clients: anthropic, openai,
+# gemini, or ollama
 PGEDGE_LLM_PROVIDER=anthropic
 
 # Default LLM model for chat clients
 # Anthropic: claude-sonnet-4-20250514, claude-opus-4-20250514,
 #             etc.
 # OpenAI: gpt-5-main, gpt-4o, gpt-4-turbo, etc.
+# Gemini: gemini-2.5-flash, gemini-2.5-pro, etc.
 # Ollama: llama3, mistral, etc.
 PGEDGE_LLM_MODEL=claude-sonnet-4-20250514
 ```

--- a/docs/reference/config-examples/cli-client.md
+++ b/docs/reference/config-examples/cli-client.md
@@ -44,7 +44,8 @@ All configuration options can be overridden with command line flags:
 ```
 
 The Gemini key can be given directly or read from a file, and either flag
-overrides the environment variable and the configuration file:
+overrides the environment variable and the configuration file. Where both
+flags are given, `-gemini-api-key` takes precedence:
 
 ```bash
 ./bin/pgedge-nla-cli \
@@ -304,8 +305,8 @@ llm:
     # OpenAI models: gpt-5-main, gpt-5-thinking, gpt-4o, gpt-4-turbo, gpt-3.5-turbo, etc.
     # Gemini models: gemini-2.5-flash, gemini-2.5-pro, etc.
     # Ollama models: llama3, llama3.1, mistral, gpt-oss:20b, etc.
-    # Default: claude-sonnet-4-20250514 (anthropic), gpt-5-main (openai),
-    # gemini-2.5-flash (gemini), or llama3 (ollama)
+    # Default: claude-sonnet-4-5-20250929 (anthropic), gpt-4o (openai),
+    # gemini-2.5-flash (gemini), or qwen3-coder:latest (ollama)
     # Environment variable: PGEDGE_LLM_MODEL
     # Command line flag: -llm-model
     model: claude-sonnet-4-20250514

--- a/docs/reference/config-examples/cli-client.md
+++ b/docs/reference/config-examples/cli-client.md
@@ -16,12 +16,14 @@ The chat client supports the following environment variables (in order of preced
 
 ### LLM Configuration
 
-- `PGEDGE_LLM_PROVIDER`: LLM provider (`anthropic`, `openai`, or `ollama`)
+- `PGEDGE_LLM_PROVIDER`: LLM provider (`anthropic`, `openai`, `gemini`, or
+  `ollama`)
 - `PGEDGE_LLM_MODEL`: Model to use
 - `PGEDGE_ANTHROPIC_API_KEY`: Anthropic API key
 - `PGEDGE_ANTHROPIC_BASE_URL`: Custom Anthropic API base URL (for proxies)
 - `PGEDGE_OPENAI_API_KEY`: OpenAI API key
 - `PGEDGE_OPENAI_BASE_URL`: Custom OpenAI API base URL (for proxies)
+- `PGEDGE_GEMINI_API_KEY`: Google Gemini API key
 - `PGEDGE_OLLAMA_URL`: Ollama server URL
 
 ### Command Line Flags
@@ -39,6 +41,16 @@ All configuration options can be overridden with command line flags:
     -llm-model claude-opus-4-20250514 \
     -anthropic-api-key your-anthropic-key \
     -no-color
+```
+
+The Gemini key can be given directly or read from a file, and either flag
+overrides the environment variable and the configuration file:
+
+```bash
+./bin/pgedge-nla-cli \
+    -llm-provider gemini \
+    -llm-model gemini-2.5-flash \
+    -gemini-api-key-file ~/.gemini-api-key
 ```
 
 Available MCP authentication flags:
@@ -277,9 +289,10 @@ mcp:
 # LLM PROVIDER CONFIGURATION
 # ============================================================================
 llm:
-    # Provider: "anthropic", "openai", or "ollama"
+    # Provider: "anthropic", "openai", "gemini", or "ollama"
     # anthropic: Uses Anthropic's Claude API (requires API key)
     # openai: Uses OpenAI's GPT API (requires API key)
+    # gemini: Uses Google's Gemini API (requires API key)
     # ollama: Uses locally running Ollama server (no API key needed)
     # Default: anthropic
     # Environment variable: PGEDGE_LLM_PROVIDER
@@ -289,8 +302,10 @@ llm:
     # Model to use
     # Anthropic models: claude-sonnet-4-20250514, claude-opus-4-20250514, etc.
     # OpenAI models: gpt-5-main, gpt-5-thinking, gpt-4o, gpt-4-turbo, gpt-3.5-turbo, etc.
+    # Gemini models: gemini-2.5-flash, gemini-2.5-pro, etc.
     # Ollama models: llama3, llama3.1, mistral, gpt-oss:20b, etc.
-    # Default: claude-sonnet-4-20250514 (anthropic), gpt-5-main (openai), or llama3 (ollama)
+    # Default: claude-sonnet-4-20250514 (anthropic), gpt-5-main (openai),
+    # gemini-2.5-flash (gemini), or llama3 (ollama)
     # Environment variable: PGEDGE_LLM_MODEL
     # Command line flag: -llm-model
     model: claude-sonnet-4-20250514
@@ -348,6 +363,27 @@ llm:
     # Environment variable: PGEDGE_OPENAI_BASE_URL
     # Leave empty to use default (https://api.openai.com)
     # openai_base_url: "https://your-proxy.example.com"
+
+    # -------------------------
+    # Gemini Configuration
+    # -------------------------
+    # API key for Google Gemini
+    # Get your API key from: https://aistudio.google.com/
+    #
+    # Priority (highest to lowest):
+    # 1. Command line flag: -gemini-api-key or -gemini-api-key-file
+    # 2. Environment variable: PGEDGE_GEMINI_API_KEY or GEMINI_API_KEY
+    # 3. API key file: gemini_api_key_file
+    # 4. Direct config value: gemini_api_key (not recommended)
+    #
+    # Option 1: Environment variable (recommended for development)
+    # export PGEDGE_GEMINI_API_KEY="your-key-here"
+    #
+    # Option 2: API key file (recommended for production)
+    gemini_api_key_file: ~/.gemini-api-key
+    #
+    # Option 3: Direct value (not recommended - use env var or file)
+    # gemini_api_key: your-gemini-api-key-here
 
     # Maximum tokens for LLM response
     # For GPT-5 and o-series models, automatically uses max_completion_tokens

--- a/examples/pgedge-nla-cli-http.yaml.example
+++ b/examples/pgedge-nla-cli-http.yaml.example
@@ -28,14 +28,16 @@ mcp:
 
 # LLM provider configuration
 llm:
-    provider: "anthropic"  # Options: "anthropic", "openai", "ollama"
+    provider: "anthropic"  # Options: "anthropic", "openai", "gemini", "ollama"
     model: "claude-sonnet-4-5"
 
     # API key files (recommended for production)
     anthropic_api_key_file: "~/.anthropic-api-key"
     openai_api_key_file: "~/.openai-api-key"
+    gemini_api_key_file: "~/.gemini-api-key"
 
-    # Or use environment variables: ANTHROPIC_API_KEY, OPENAI_API_KEY
+    # Or use environment variables: ANTHROPIC_API_KEY, OPENAI_API_KEY,
+    # GEMINI_API_KEY
 
     # Ollama configuration (for local LLM)
     ollama_url: "http://127.0.0.1:11434"

--- a/examples/pgedge-nla-cli-stdio.yaml.example
+++ b/examples/pgedge-nla-cli-stdio.yaml.example
@@ -16,14 +16,16 @@ mcp:
 
 # LLM provider configuration
 llm:
-    provider: "anthropic"  # Options: "anthropic", "openai", "ollama"
+    provider: "anthropic"  # Options: "anthropic", "openai", "gemini", "ollama"
     model: "claude-sonnet-4-5"
 
     # API key files (recommended for production)
     anthropic_api_key_file: "~/.anthropic-api-key"
     openai_api_key_file: "~/.openai-api-key"
+    gemini_api_key_file: "~/.gemini-api-key"
 
-    # Or use environment variables: ANTHROPIC_API_KEY, OPENAI_API_KEY
+    # Or use environment variables: ANTHROPIC_API_KEY, OPENAI_API_KEY,
+    # GEMINI_API_KEY
 
     # Ollama configuration (for local LLM)
     ollama_url: "http://127.0.0.1:11434"

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/chzyer/readline"
 	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
 	"github.com/pgEdge/pgedge-go-llm-lib/llm/provider/anthropic"
+	_ "github.com/pgEdge/pgedge-go-llm-lib/llm/provider/gemini"
 	_ "github.com/pgEdge/pgedge-go-llm-lib/llm/provider/ollama"
 	_ "github.com/pgEdge/pgedge-go-llm-lib/llm/provider/openai"
 )
@@ -87,10 +88,10 @@ func NewClient(cfg *Config, overrides *ConfigOverrides) (*Client, error) {
 		if prefs.LastProvider != "" && cfg.IsProviderConfigured(prefs.LastProvider) {
 			cfg.LLM.Provider = prefs.LastProvider
 		} else {
-			// Use first configured provider (anthropic > openai > ollama)
+			// Use first configured provider (anthropic > openai > gemini > ollama)
 			configuredProviders := cfg.GetConfiguredProviders()
 			if len(configuredProviders) == 0 {
-				return nil, fmt.Errorf("no LLM provider configured (set API key for anthropic, openai, or ollama URL)")
+				return nil, fmt.Errorf("no LLM provider configured (set API key for anthropic, openai or gemini, or an ollama URL)")
 			}
 			cfg.LLM.Provider = configuredProviders[0]
 		}
@@ -482,6 +483,8 @@ func (c *Client) newLLMClient(provider, model string, debug bool) (llmlib.Client
 	case "openai":
 		opts.APIKey = c.config.LLM.OpenAIAPIKey
 		opts.BaseURL = c.config.LLM.OpenAIBaseURL
+	case "gemini":
+		opts.APIKey = c.config.LLM.GeminiAPIKey
 	case "ollama":
 		// Ollama has no API key. Empty BaseURL keeps the library
 		// default (http://localhost:11434).
@@ -502,7 +505,7 @@ func (c *Client) initializeLLM() error {
 	// Validate provider up-front so unsupported values surface a clear
 	// error before any client construction is attempted.
 	switch provider {
-	case "anthropic", "openai", "ollama":
+	case "anthropic", "openai", "gemini", "ollama":
 		// ok
 	default:
 		return fmt.Errorf("unsupported LLM provider: %s", provider)
@@ -1441,6 +1444,8 @@ func getDefaultModelForProvider(provider string) string {
 		return "claude-sonnet-4-5-20250929"
 	case "openai":
 		return "gpt-4o"
+	case "gemini":
+		return "gemini-2.5-flash"
 	case "ollama":
 		return "qwen3-coder:latest"
 	default:

--- a/internal/chat/client_test.go
+++ b/internal/chat/client_test.go
@@ -184,6 +184,7 @@ func TestGetDefaultModelForProvider(t *testing.T) {
 	}{
 		{"anthropic", "anthropic", "claude-sonnet-4-5-20250929"},
 		{"openai", "openai", "gpt-4o"},
+		{"gemini", "gemini", "gemini-2.5-flash"},
 		{"ollama", "ollama", "qwen3-coder:latest"},
 		{"unknown", "unknown", ""},
 		{"empty", "", ""},

--- a/internal/chat/commands.go
+++ b/internal/chat/commands.go
@@ -170,7 +170,8 @@ Available Commands:
   LLM Settings:
     /list providers             List available LLM providers
     /list models                List available models for current provider
-    /set provider <name>        Set LLM provider (anthropic, openai, ollama)
+    /set provider <name>        Set LLM provider (anthropic, openai,
+                                gemini, ollama)
     /set model <name>           Set LLM model
     /show provider              Show current LLM provider
     /show model                 Show current LLM model
@@ -395,12 +396,13 @@ func (c *Client) handleSetLLMProvider(provider string) bool {
 	validProviders := map[string]bool{
 		"anthropic": true,
 		"openai":    true,
+		"gemini":    true,
 		"ollama":    true,
 	}
 
 	if !validProviders[provider] {
 		c.ui.PrintError(fmt.Sprintf("Invalid LLM provider: %s", provider))
-		c.ui.PrintSystemMessage("Valid providers: anthropic, openai, ollama")
+		c.ui.PrintSystemMessage("Valid providers: anthropic, openai, gemini, ollama")
 		return true
 	}
 

--- a/internal/chat/commands_test.go
+++ b/internal/chat/commands_test.go
@@ -253,6 +253,7 @@ func TestHandleSetLLMProvider(t *testing.T) {
 	}{
 		{"anthropic", "anthropic", false},
 		{"openai", "openai", false},
+		{"gemini", "gemini", false},
 		{"ollama", "ollama", false},
 		{"ANTHROPIC uppercase", "ANTHROPIC", false},
 		{"invalid provider", "invalid", true},
@@ -267,6 +268,7 @@ func TestHandleSetLLMProvider(t *testing.T) {
 					Model:           "claude-sonnet-4-5-20250929",
 					AnthropicAPIKey: "test-key",
 					OpenAIAPIKey:    "test-key",
+					GeminiAPIKey:    "test-key",
 					OllamaURL:       "http://localhost:11434",
 				},
 				UI: UIConfig{

--- a/internal/chat/config.go
+++ b/internal/chat/config.go
@@ -50,7 +50,7 @@ type MCPConfig struct {
 
 // LLMConfig holds LLM provider configuration
 type LLMConfig struct {
-	Provider            string `yaml:"provider"`               // anthropic, openai, or ollama
+	Provider            string `yaml:"provider"`               // anthropic, openai, gemini, or ollama
 	Model               string `yaml:"model"`                  // Model to use
 	AnthropicAPIKey     string `yaml:"anthropic_api_key"`      // API key for Anthropic (direct - discouraged, use api_key_file or env var)
 	AnthropicAPIKeyFile string `yaml:"anthropic_api_key_file"` // Path to file containing Anthropic API key
@@ -58,6 +58,8 @@ type LLMConfig struct {
 	OpenAIAPIKey        string `yaml:"openai_api_key"`         // API key for OpenAI (direct - discouraged, use api_key_file or env var)
 	OpenAIAPIKeyFile    string `yaml:"openai_api_key_file"`    // Path to file containing OpenAI API key
 	OpenAIBaseURL       string `yaml:"openai_base_url"`        // Base URL for OpenAI API (default: https://api.openai.com)
+	GeminiAPIKey        string `yaml:"gemini_api_key"`         // API key for Google Gemini (direct - discouraged, use api_key_file or env var)
+	GeminiAPIKeyFile    string `yaml:"gemini_api_key_file"`    // Path to file containing Gemini API key
 	OllamaURL           string `yaml:"ollama_url"`             // Ollama server URL
 	MaxTokens           int    `yaml:"max_tokens"`             // Max tokens for response
 }
@@ -91,6 +93,7 @@ func LoadConfig(configPath string) (*Config, error) {
 			AnthropicBaseURL: os.Getenv("PGEDGE_ANTHROPIC_BASE_URL"), // Empty string uses default
 			OpenAIAPIKey:     getEnvWithFallback("PGEDGE_OPENAI_API_KEY", "OPENAI_API_KEY"),
 			OpenAIBaseURL:    os.Getenv("PGEDGE_OPENAI_BASE_URL"), // Empty string uses default
+			GeminiAPIKey:     getEnvWithFallback("PGEDGE_GEMINI_API_KEY", "GEMINI_API_KEY"),
 			OllamaURL:        getEnvOrDefault("PGEDGE_OLLAMA_URL", "http://localhost:11434"),
 			MaxTokens:        4096,
 		},
@@ -138,19 +141,34 @@ func LoadConfig(configPath string) (*Config, error) {
 		}
 		// Note: errors are silently ignored - file may not exist and that's ok
 	}
-	// 2. Direct config value (if set) is already in cfg.LLM.AnthropicAPIKey/OpenAIAPIKey from loadConfigFile
+	if cfg.LLM.GeminiAPIKey == "" && cfg.LLM.GeminiAPIKeyFile != "" {
+		if key, err := readAPIKeyFromFile(cfg.LLM.GeminiAPIKeyFile); err == nil && key != "" {
+			cfg.LLM.GeminiAPIKey = key
+		}
+		// Note: errors are silently ignored - file may not exist and that's ok
+	}
+	// 2. Direct config value (if set) is already in cfg.LLM.AnthropicAPIKey/OpenAIAPIKey/GeminiAPIKey from loadConfigFile
 
 	// Load authentication token with priority
 	cfg.MCP.Token = loadAuthToken()
 
 	// Register the credentials for redaction, so that a provider quoting a key
 	// back in an error cannot reach the terminal or a redirected log.
-	redact.Register(
-		cfg.LLM.AnthropicAPIKey,
-		cfg.LLM.OpenAIAPIKey,
-	)
+	cfg.RegisterSecrets()
 
 	return cfg, nil
+}
+
+// RegisterSecrets registers the configured provider API keys for redaction, so
+// that a provider quoting a key back in an error cannot reach the terminal or
+// a redirected log. LoadConfig calls it, and a caller that overrides a key
+// afterwards (the CLI does so from its flags) must call it again.
+func (c *Config) RegisterSecrets() {
+	redact.Register(
+		c.LLM.AnthropicAPIKey,
+		c.LLM.OpenAIAPIKey,
+		c.LLM.GeminiAPIKey,
+	)
 }
 
 // loadConfigFile loads configuration from a YAML file
@@ -205,8 +223,9 @@ func (c *Config) Validate() error {
 	}
 
 	// Validate LLM provider
-	if c.LLM.Provider != "anthropic" && c.LLM.Provider != "openai" && c.LLM.Provider != "ollama" {
-		return fmt.Errorf("invalid llm-provider: %s (must be anthropic, openai, or ollama)", c.LLM.Provider)
+	if c.LLM.Provider != "anthropic" && c.LLM.Provider != "openai" &&
+		c.LLM.Provider != "gemini" && c.LLM.Provider != "ollama" {
+		return fmt.Errorf("invalid llm-provider: %s (must be anthropic, openai, gemini, or ollama)", c.LLM.Provider)
 	}
 
 	// Validate LLM configuration based on provider
@@ -224,6 +243,13 @@ func (c *Config) Validate() error {
 		}
 		if c.LLM.Model == "" {
 			c.LLM.Model = "gpt-4o"
+		}
+	case "gemini":
+		if c.LLM.GeminiAPIKey == "" {
+			return fmt.Errorf("PGEDGE_GEMINI_API_KEY environment variable or gemini_api_key config is required for Gemini")
+		}
+		if c.LLM.Model == "" {
+			c.LLM.Model = "gemini-2.5-flash"
 		}
 	default:
 		if c.LLM.OllamaURL == "" {
@@ -244,6 +270,8 @@ func (c *Config) IsProviderConfigured(provider string) bool {
 		return c.LLM.AnthropicAPIKey != ""
 	case "openai":
 		return c.LLM.OpenAIAPIKey != ""
+	case "gemini":
+		return c.LLM.GeminiAPIKey != ""
 	case "ollama":
 		// Ollama is configured if URL is set (defaults to localhost)
 		return c.LLM.OllamaURL != ""
@@ -253,7 +281,7 @@ func (c *Config) IsProviderConfigured(provider string) bool {
 }
 
 // GetConfiguredProviders returns a list of providers that are configured
-// in priority order: anthropic, openai, ollama
+// in priority order: anthropic, openai, gemini, ollama
 func (c *Config) GetConfiguredProviders() []string {
 	providers := []string{}
 	if c.IsProviderConfigured("anthropic") {
@@ -261,6 +289,9 @@ func (c *Config) GetConfiguredProviders() []string {
 	}
 	if c.IsProviderConfigured("openai") {
 		providers = append(providers, "openai")
+	}
+	if c.IsProviderConfigured("gemini") {
+		providers = append(providers, "gemini")
 	}
 	if c.IsProviderConfigured("ollama") {
 		providers = append(providers, "ollama")
@@ -284,6 +315,15 @@ func getEnvWithFallback(keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// ReadAPIKeyFile reads an API key from the named file, expanding a leading
+// tilde to the user's home directory. It exists for callers outside the
+// package, such as the CLI's key file flags, which apply after LoadConfig has
+// already resolved the key files named in the configuration. An empty string
+// is returned when the file does not exist.
+func ReadAPIKeyFile(filePath string) (string, error) {
+	return readAPIKeyFromFile(filePath)
 }
 
 // readAPIKeyFromFile reads an API key from a file

--- a/internal/chat/config_test.go
+++ b/internal/chat/config_test.go
@@ -256,3 +256,160 @@ func TestValidate_MissingAPIKey(t *testing.T) {
 		t.Error("Expected validation error for missing API key for Anthropic")
 	}
 }
+
+func TestValidate_Gemini(t *testing.T) {
+	cfg := &Config{
+		MCP: MCPConfig{
+			Mode:       "stdio",
+			ServerPath: "/path/to/server",
+		},
+		LLM: LLMConfig{
+			Provider:     "gemini",
+			GeminiAPIKey: "test-key",
+		},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+
+	if cfg.LLM.Model != "gemini-2.5-flash" {
+		t.Errorf("Expected default Gemini model 'gemini-2.5-flash', got '%s'", cfg.LLM.Model)
+	}
+}
+
+func TestValidate_GeminiMissingAPIKey(t *testing.T) {
+	cfg := &Config{
+		MCP: MCPConfig{
+			Mode:       "stdio",
+			ServerPath: "/path/to/server",
+		},
+		LLM: LLMConfig{
+			Provider: "gemini",
+			// GeminiAPIKey is missing
+		},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("Expected validation error for missing API key for Gemini")
+	}
+}
+
+func TestIsProviderConfigured(t *testing.T) {
+	cfg := &Config{
+		LLM: LLMConfig{
+			GeminiAPIKey: "test-key",
+		},
+	}
+
+	if !cfg.IsProviderConfigured("gemini") {
+		t.Error("Expected gemini to be configured when the API key is set")
+	}
+	if cfg.IsProviderConfigured("anthropic") {
+		t.Error("Expected anthropic to be unconfigured without an API key")
+	}
+	if cfg.IsProviderConfigured("unknown") {
+		t.Error("Expected an unknown provider to be unconfigured")
+	}
+}
+
+func TestGetConfiguredProviders_IncludesGemini(t *testing.T) {
+	cfg := &Config{
+		LLM: LLMConfig{
+			AnthropicAPIKey: "test-key",
+			OpenAIAPIKey:    "test-key",
+			GeminiAPIKey:    "test-key",
+			OllamaURL:       "http://localhost:11434",
+		},
+	}
+
+	providers := cfg.GetConfiguredProviders()
+	expected := []string{"anthropic", "openai", "gemini", "ollama"}
+
+	if len(providers) != len(expected) {
+		t.Fatalf("Expected %d providers, got %d (%v)", len(expected), len(providers), providers)
+	}
+	for i, want := range expected {
+		if providers[i] != want {
+			t.Errorf("Expected provider %d to be %q, got %q", i, want, providers[i])
+		}
+	}
+}
+
+func TestLoadConfig_GeminiAPIKeyFromEnvironment(t *testing.T) {
+	t.Setenv("PGEDGE_GEMINI_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "env-gemini-key")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if cfg.LLM.GeminiAPIKey != "env-gemini-key" {
+		t.Errorf("Expected Gemini API key 'env-gemini-key', got '%s'", cfg.LLM.GeminiAPIKey)
+	}
+
+	// The prefixed variable takes priority over the bare one.
+	t.Setenv("PGEDGE_GEMINI_API_KEY", "prefixed-gemini-key")
+
+	cfg, err = LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if cfg.LLM.GeminiAPIKey != "prefixed-gemini-key" {
+		t.Errorf("Expected Gemini API key 'prefixed-gemini-key', got '%s'", cfg.LLM.GeminiAPIKey)
+	}
+}
+
+func TestLoadConfig_GeminiAPIKeyFromFile(t *testing.T) {
+	t.Setenv("PGEDGE_GEMINI_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "gemini-key")
+	if err := os.WriteFile(keyPath, []byte("file-gemini-key\n"), 0600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "test-config.yaml")
+	configContent := "llm:\n  provider: gemini\n  gemini_api_key_file: " + keyPath + "\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if cfg.LLM.GeminiAPIKey != "file-gemini-key" {
+		t.Errorf("Expected Gemini API key 'file-gemini-key', got '%s'", cfg.LLM.GeminiAPIKey)
+	}
+}
+
+func TestReadAPIKeyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "gemini-key")
+	if err := os.WriteFile(keyPath, []byte("  file-gemini-key\n"), 0600); err != nil {
+		t.Fatalf("Failed to write key file: %v", err)
+	}
+
+	key, err := ReadAPIKeyFile(keyPath)
+	if err != nil {
+		t.Fatalf("ReadAPIKeyFile failed: %v", err)
+	}
+	if key != "file-gemini-key" {
+		t.Errorf("Expected 'file-gemini-key', got '%s'", key)
+	}
+
+	// A missing file is reported as an empty key rather than an error, so
+	// that the caller can decide how to treat it.
+	key, err = ReadAPIKeyFile(filepath.Join(tmpDir, "no-such-file"))
+	if err != nil {
+		t.Fatalf("ReadAPIKeyFile failed for a missing file: %v", err)
+	}
+	if key != "" {
+		t.Errorf("Expected an empty key for a missing file, got '%s'", key)
+	}
+}

--- a/internal/chat/preferences.go
+++ b/internal/chat/preferences.go
@@ -128,6 +128,7 @@ func getDefaultPreferences() *Preferences {
 		ProviderModels: map[string]string{
 			"anthropic": "claude-sonnet-4-5-20250929",
 			"openai":    "gpt-4o",
+			"gemini":    "gemini-2.5-flash",
 			"ollama":    "qwen3-coder:latest",
 		},
 		LastProvider: "anthropic",
@@ -153,6 +154,7 @@ func sanitizePreferences(prefs *Preferences) *Preferences {
 	validProviders := map[string]bool{
 		"anthropic": true,
 		"openai":    true,
+		"gemini":    true,
 		"ollama":    true,
 	}
 	if !validProviders[prefs.LastProvider] {

--- a/internal/chat/preferences_test.go
+++ b/internal/chat/preferences_test.go
@@ -45,6 +45,9 @@ func TestGetDefaultPreferences(t *testing.T) {
 	if prefs.ProviderModels["openai"] != "gpt-4o" {
 		t.Errorf("Expected openai model to be 'gpt-4o', got %q", prefs.ProviderModels["openai"])
 	}
+	if prefs.ProviderModels["gemini"] != "gemini-2.5-flash" {
+		t.Errorf("Expected gemini model to be 'gemini-2.5-flash', got %q", prefs.ProviderModels["gemini"])
+	}
 	if prefs.ProviderModels["ollama"] != "qwen3-coder:latest" {
 		t.Errorf("Expected ollama model to be 'qwen3-coder:latest', got %q", prefs.ProviderModels["ollama"])
 	}
@@ -77,6 +80,18 @@ func TestSanitizePreferences(t *testing.T) {
 			check: func(p *Preferences, t *testing.T) {
 				if p.LastProvider != "anthropic" {
 					t.Errorf("Expected LastProvider to be reset to 'anthropic', got %q", p.LastProvider)
+				}
+			},
+		},
+		{
+			name: "gemini last provider",
+			prefs: &Preferences{
+				ProviderModels: make(map[string]string),
+				LastProvider:   "gemini",
+			},
+			check: func(p *Preferences, t *testing.T) {
+				if p.LastProvider != "gemini" {
+					t.Errorf("Expected LastProvider to remain 'gemini', got %q", p.LastProvider)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

The server has supported Gemini for chat for some time, but the CLI client never
exposed it: `--llm-provider` rejected the value, there was no way to supply a
key, and `/set provider gemini` failed. The single `case "gemini"` that already
existed, in the provider display helper, was unreachable.

The gap ran deeper than the missing flags. `chat.LLMConfig` is a separate type
from the server's `config.LLMConfig` and carried no Gemini fields at all, so
`Validate`, `IsProviderConfigured` and `GetConfiguredProviders` each rejected the
provider; the last of those gates `/set provider`, so the command would have
failed even if the name had been accepted. The library's Gemini provider was also
never imported, so client construction would have failed at runtime regardless of
the switches.

- New `--gemini-api-key` and `--gemini-api-key-file` flags, with
  `PGEDGE_GEMINI_API_KEY` falling back to `GEMINI_API_KEY`, and a default model
  of `gemini-2.5-flash`.
- `gemini` accepted by `--llm-provider`, by `/set provider`, and listed in
  `/help`; included in the configured-provider priority order as
  anthropic > openai > gemini > ollama.
- Documentation, config examples and both CLI example YAML files updated.

## Notes for the reviewer

Two things worth flagging, both small and both deliberate.

The key file is read where the flag is applied rather than being left to the
loader, because `LoadConfig` resolves the files named in the configuration before
any flag has been seen. Unlike the loader, which treats a missing key file as an
optional fallback and ignores the error, a path given explicitly on the command
line that does not resolve exits with an error, since that is a mistake rather
than a fallback.

Registering keys for redaction moves into `Config.RegisterSecrets`, which the CLI
calls again after applying its flags. That closes a small pre-existing hole:
keys supplied via `--anthropic-api-key` or `--openai-api-key` land after
`LoadConfig` has run and so were never registered for redaction at all.

Also, whilst documenting the new flags it emerged that `--mcp-auth-mode`,
`--mcp-token`, `--mcp-username` and `--mcp-password` had never been documented,
which breaches the project's rule that every command-line option is documented,
so they are listed now.

`--gemini-api-key-file` does leave the flag set slightly uneven, since no other
provider has a key-file flag even though `anthropic_api_key_file` and
`openai_api_key_file` exist in the config file. The issue asks for it explicitly,
so it is here; adding the matching flags for the other two providers would even
things up and is a few lines, but it is outside this issue and I have left it.

## Test plan

- [x] New tests for Gemini validation, the missing-key error, environment and
      key-file loading, `IsProviderConfigured`, `GetConfiguredProviders` ordering
      and `ReadAPIKeyFile`; existing provider tables in `client_test.go`,
      `commands_test.go` and `preferences_test.go` extended to cover gemini.
- [x] `make lint` reports 0 issues and `make test` is fully green.

Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Gemini as a supported LLM provider.
  * Configure Gemini with an API key, environment variable, or key file.
  * Added runtime provider switching and the default `gemini-2.5-flash` model.
  * Command-line API keys take precedence over other credential sources.
  * Improved validation and error handling for missing, empty, or unreadable key files.

* **Documentation**
  * Updated CLI, deployment, configuration, and example guides with Gemini setup instructions and supported models.

* **Tests**
  * Added coverage for Gemini configuration, provider selection, credentials, and default model behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->