### PR TITLE
docs: show the SSL certificate settings in the example configs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,15 @@ and this project adheres to
 
 ### Changed
 
+- The example configuration files now show the `sslcert`, `sslkey`, and
+  `sslrootcert` database settings, commented out alongside `sslmode`,
+  together with the matching `PGEDGE_DB_SSLCERT`, `PGEDGE_DB_SSLKEY`,
+  and `PGEDGE_DB_SSLROOTCERT` environment variables. The settings have
+  always been supported; showing only `sslmode` left client certificate
+  authentication undiscoverable for anyone working from the examples.
+
+### Changed
+
 - Dependencies across every ecosystem this project uses are now on their
   latest releases. The GitHub Actions pins move to the current major of
   each action, which also resolves the split where `actions/checkout`,

--- a/docs/reference/config-examples/server.md
+++ b/docs/reference/config-examples/server.md
@@ -248,6 +248,15 @@ databases:
       # Default: prefer
       sslmode: "prefer"
 
+      # Client certificate authentication, used instead of, or alongside,
+      # a password. sslcert and sslkey must be set together.
+      # sslcert: "/path/to/client.crt"
+      # sslkey: "/path/to/client.key"
+
+      # CA certificate used to verify the server. Only consulted when
+      # sslmode is require, verify-ca, or verify-full.
+      # sslrootcert: "/path/to/ca.crt"
+
       # Connection pool settings
       # Default: 4 max connections, 0 min connections, 30m idle time
       pool_max_conns: 4

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -16,6 +16,15 @@ PGEDGE_HTTP_ENABLED=true
 SERVER_PORT=8080
 LOG_LEVEL=info
 
+# Database TLS (applies to the first configured database)
+# Client certificate authentication, used instead of, or alongside, a
+# password. PGEDGE_DB_SSLCERT and PGEDGE_DB_SSLKEY must be set together.
+# PGEDGE_DB_SSLCERT=/path/to/client.crt
+# PGEDGE_DB_SSLKEY=/path/to/client.key
+# CA certificate used to verify the server. Only consulted when the SSL
+# mode is require, verify-ca, or verify-full.
+# PGEDGE_DB_SSLROOTCERT=/path/to/ca.crt
+
 # Web UI Configuration
 WEB_PORT=80
 

--- a/examples/pgedge-postgres-mcp-http.yaml.example
+++ b/examples/pgedge-postgres-mcp-http.yaml.example
@@ -59,6 +59,13 @@ databases:
       user: "postgres"
       password: ""  # Leave empty to use .pgpass file
       sslmode: "prefer"
+      # Client certificate authentication, used instead of, or alongside,
+      # a password. sslcert and sslkey must be set together.
+      # sslcert: "/path/to/client.crt"
+      # sslkey: "/path/to/client.key"
+      # CA certificate used to verify the server. Only consulted when
+      # sslmode is require, verify-ca, or verify-full.
+      # sslrootcert: "/path/to/ca.crt"
       pool_max_conns: 10
       pool_min_conns: 2
       pool_max_conn_idle_time: "5m"

--- a/examples/pgedge-postgres-mcp-stdio.yaml.example
+++ b/examples/pgedge-postgres-mcp-stdio.yaml.example
@@ -20,6 +20,13 @@ databases:
       user: "postgres"
       password: ""  # Leave empty to use .pgpass file
       sslmode: "prefer"
+      # Client certificate authentication, used instead of, or alongside,
+      # a password. sslcert and sslkey must be set together.
+      # sslcert: "/path/to/client.crt"
+      # sslkey: "/path/to/client.key"
+      # CA certificate used to verify the server. Only consulted when
+      # sslmode is require, verify-ca, or verify-full.
+      # sslrootcert: "/path/to/ca.crt"
       connect_timeout: "10s"
       # metadata_ttl: "5m"
       pool_max_conns: 10

--- a/pkg/common/postgres-mcp.yaml
+++ b/pkg/common/postgres-mcp.yaml
@@ -10,6 +10,13 @@ databases:
     user: postgres
     # Password can be set via PGEDGE_DB_PASSWORD environment variable
     sslmode: prefer
+    # Client certificate authentication, used instead of, or alongside,
+    # a password. sslcert and sslkey must be set together.
+    # sslcert: "/path/to/client.crt"
+    # sslkey: "/path/to/client.key"
+    # CA certificate used to verify the server. Only consulted when
+    # sslmode is require, verify-ca, or verify-full.
+    # sslrootcert: "/path/to/ca.crt"
     pool_max_conns: 10
     pool_min_conns: 2
     pool_max_conn_idle_time: "5m"


### PR DESCRIPTION
## Summary

The `sslcert`, `sslkey` and `sslrootcert` database settings have been supported
for a while, but no example configuration mentioned them, so anyone working from
the examples saw only `sslmode` and client certificate authentication was
effectively undiscoverable.

Each active database entry now carries the three settings commented out
alongside `sslmode`, noting that `sslcert` and `sslkey` must be set together
(which `internal/config/config.go:475` enforces) and that `sslrootcert` is only
consulted for the `sslmode` values that verify the server. The environment
example gains the matching `PGEDGE_DB_SSLCERT`, `PGEDGE_DB_SSLKEY` and
`PGEDGE_DB_SSLROOTCERT` variables.

All names were checked against the code rather than taken from the issue: the
YAML keys are at `config.go:281-283` and the environment variables at
`config.go:1128-1130`.

## Two judgement calls

The issue names three files. I have also updated `pkg/common/postgres-mcp.yaml`
and `docs/reference/config-examples/server.md`, because they are the same class
of file with the same gap, and the packaged default config is arguably the most
widely read of the lot. Say the word if you would rather they were dropped.

The commented-out illustrative database entries further down each example are
deliberately left alone. They exist to demonstrate multi-host connections and
per-user access rather than TLS, and nesting comments inside already-commented
blocks (`#   # sslcert: ...`) would cost more in readability than it gained in
discoverability.

## Test plan

- [x] All three YAML files still parse, and the first database entry still
      resolves as expected.
- [x] `make lint` reports 0 issues and `make test` is fully green.

Closes #237