### PR TITLE
chore: even up the provider credential options

### DIFF
--- a/cmd/pgedge-pg-mcp-cli/main.go
+++ b/cmd/pgedge-pg-mcp-cli/main.go
@@ -36,7 +36,9 @@ func main() {
 	llmProvider := flag.String("llm-provider", "", "LLM provider: anthropic, openai, gemini, or ollama (default: anthropic)")
 	llmModel := flag.String("llm-model", "", "LLM model to use")
 	anthropicAPIKey := flag.String("anthropic-api-key", "", "API key for Anthropic")
+	anthropicAPIKeyFile := flag.String("anthropic-api-key-file", "", "Path to a file containing the Anthropic API key")
 	openaiAPIKey := flag.String("openai-api-key", "", "API key for OpenAI")
+	openaiAPIKeyFile := flag.String("openai-api-key-file", "", "Path to a file containing the OpenAI API key")
 	geminiAPIKey := flag.String("gemini-api-key", "", "API key for Google Gemini")
 	geminiAPIKeyFile := flag.String("gemini-api-key-file", "", "Path to a file containing the Google Gemini API key")
 	ollamaURL := flag.String("ollama-url", "", "Ollama server URL (default: http://localhost:11434)")
@@ -94,30 +96,28 @@ func main() {
 	if *llmModel != "" {
 		cfg.LLM.Model = *llmModel
 	}
-	if *anthropicAPIKey != "" {
-		cfg.LLM.AnthropicAPIKey = *anthropicAPIKey
+	// The key files are read here rather than by the loader, because the
+	// loader resolves the files named in the configuration before any flag is
+	// seen. A key given directly on the command line wins over one in a file.
+	keyFlags := []struct {
+		provider string
+		key      string
+		keyFile  string
+		destKey  *string
+		destFile *string
+	}{
+		{"Anthropic", *anthropicAPIKey, *anthropicAPIKeyFile,
+			&cfg.LLM.AnthropicAPIKey, &cfg.LLM.AnthropicAPIKeyFile},
+		{"OpenAI", *openaiAPIKey, *openaiAPIKeyFile,
+			&cfg.LLM.OpenAIAPIKey, &cfg.LLM.OpenAIAPIKeyFile},
+		{"Gemini", *geminiAPIKey, *geminiAPIKeyFile,
+			&cfg.LLM.GeminiAPIKey, &cfg.LLM.GeminiAPIKeyFile},
 	}
-	if *openaiAPIKey != "" {
-		cfg.LLM.OpenAIAPIKey = *openaiAPIKey
-	}
-	// The key file is read here rather than by the loader, because the loader
-	// resolves the files named in the configuration before any flag is seen.
-	// A key given directly on the command line wins over one in a file.
-	if *geminiAPIKeyFile != "" {
-		cfg.LLM.GeminiAPIKeyFile = *geminiAPIKeyFile
-		key, err := chat.ReadAPIKeyFile(*geminiAPIKeyFile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading Gemini API key file: %v\n", err)
+	for _, f := range keyFlags {
+		if err := applyAPIKeyFlags(f.provider, f.key, f.keyFile, f.destKey, f.destFile); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
-		if key == "" {
-			fmt.Fprintf(os.Stderr, "Gemini API key file %s is missing or empty\n", *geminiAPIKeyFile)
-			os.Exit(1)
-		}
-		cfg.LLM.GeminiAPIKey = key
-	}
-	if *geminiAPIKey != "" {
-		cfg.LLM.GeminiAPIKey = *geminiAPIKey
 	}
 	if *ollamaURL != "" {
 		cfg.LLM.OllamaURL = *ollamaURL
@@ -167,4 +167,31 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error running chat client: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// applyAPIKeyFlags applies one provider's -<provider>-api-key and
+// -<provider>-api-key-file flags to the loaded configuration. The file named
+// on the command line is read here, because the loader has already resolved
+// the key files named in the configuration by the time any flag is seen, and
+// a path given on the command line that cannot be read or that yields an
+// empty key is an error rather than a silent fallback. A key supplied
+// directly beats one read from a file. Either flag may be empty, in which
+// case the corresponding configured value is left alone. The provider label
+// is used only to name the provider in the error messages.
+func applyAPIKeyFlags(provider, key, keyFile string, destKey, destKeyFile *string) error {
+	if keyFile != "" {
+		*destKeyFile = keyFile
+		fileKey, err := chat.ReadAPIKeyFile(keyFile)
+		if err != nil {
+			return fmt.Errorf("error reading %s API key file: %w", provider, err)
+		}
+		if fileKey == "" {
+			return fmt.Errorf("%s API key file %s is missing or empty", provider, keyFile)
+		}
+		*destKey = fileKey
+	}
+	if key != "" {
+		*destKey = key
+	}
+	return nil
 }

--- a/cmd/pgedge-pg-mcp-cli/main_test.go
+++ b/cmd/pgedge-pg-mcp-cli/main_test.go
@@ -1,0 +1,140 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyAPIKeyFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "provider-key")
+	if err := os.WriteFile(keyPath, []byte("key-from-file\n"), 0600); err != nil {
+		t.Fatalf("Failed to write the key file: %v", err)
+	}
+	emptyPath := filepath.Join(tmpDir, "empty-key")
+	if err := os.WriteFile(emptyPath, []byte("   \n"), 0600); err != nil {
+		t.Fatalf("Failed to write the empty key file: %v", err)
+	}
+	missingPath := filepath.Join(tmpDir, "no-such-file")
+	// Reading a directory always fails, whoever the test runs as, which a
+	// mode 0000 file would not guarantee under root.
+	unreadablePath := filepath.Join(tmpDir, "a-directory")
+	if err := os.Mkdir(unreadablePath, 0755); err != nil {
+		t.Fatalf("Failed to create the directory: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		key         string
+		keyFile     string
+		existingKey string
+		wantKey     string
+		wantKeyFile string
+		wantErr     string
+	}{
+		{
+			name:        "neither flag leaves the configuration alone",
+			existingKey: "configured-key",
+			wantKey:     "configured-key",
+		},
+		{
+			name:        "a direct key overrides the configuration",
+			key:         "flag-key",
+			existingKey: "configured-key",
+			wantKey:     "flag-key",
+		},
+		{
+			name:        "a key file is read and recorded",
+			keyFile:     keyPath,
+			existingKey: "configured-key",
+			wantKey:     "key-from-file",
+			wantKeyFile: keyPath,
+		},
+		{
+			name:        "a direct key beats a key file",
+			key:         "flag-key",
+			keyFile:     keyPath,
+			wantKey:     "flag-key",
+			wantKeyFile: keyPath,
+		},
+		{
+			name:        "a missing key file is an error rather than a silent fallback",
+			keyFile:     missingPath,
+			existingKey: "configured-key",
+			wantKeyFile: missingPath,
+			wantErr:     "Gemini API key file " + missingPath + " is missing or empty",
+		},
+		{
+			name:        "an unreadable key file is an error",
+			keyFile:     unreadablePath,
+			wantKeyFile: unreadablePath,
+			wantErr:     "error reading Gemini API key file",
+		},
+		{
+			name:        "an empty key file is an error",
+			keyFile:     emptyPath,
+			wantKeyFile: emptyPath,
+			wantErr:     "Gemini API key file " + emptyPath + " is missing or empty",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key := tc.existingKey
+			keyFile := ""
+
+			err := applyAPIKeyFlags("Gemini", tc.key, tc.keyFile, &key, &keyFile)
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("Expected an error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("Expected an error containing %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyAPIKeyFlags failed: %v", err)
+			}
+			if key != tc.wantKey {
+				t.Errorf("Expected the key '%s', got '%s'", tc.wantKey, key)
+			}
+			if keyFile != tc.wantKeyFile {
+				t.Errorf("Expected the key file '%s', got '%s'", tc.wantKeyFile, keyFile)
+			}
+		})
+	}
+}
+
+// The provider label must reach the error text, since the three providers
+// share one helper and an unlabelled message would be useless.
+func TestApplyAPIKeyFlagsNamesTheProvider(t *testing.T) {
+	unreadablePath := filepath.Join(t.TempDir(), "a-directory")
+	if err := os.Mkdir(unreadablePath, 0755); err != nil {
+		t.Fatalf("Failed to create the directory: %v", err)
+	}
+
+	for _, provider := range []string{"Anthropic", "OpenAI", "Gemini"} {
+		key, keyFile := "", ""
+		err := applyAPIKeyFlags(provider, "", unreadablePath, &key, &keyFile)
+		if err == nil {
+			t.Fatalf("Expected an error for provider %s, got nil", provider)
+		}
+		if !strings.Contains(err.Error(), provider) {
+			t.Errorf("Expected the error to name %s, got %q", provider, err.Error())
+		}
+	}
+}

--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -969,6 +969,7 @@ func main() {
 					providers["gemini"] = llm.Options{
 						APIKey:            cfg.LLM.GeminiAPIKey,
 						Model:             cfg.LLM.Model,
+						BaseURL:           cfg.LLM.GeminiBaseURL,
 						MaxTokens:         llm.Int(cfg.LLM.MaxTokens),
 						PerAttemptTimeout: time.Duration(cfg.LLM.PerAttemptTimeout) * time.Second,
 					}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,23 @@ and this project adheres to
   provider can also be switched at runtime with `/set provider
   gemini`, and defaults to the `gemini-2.5-flash` model. (#238)
 
+- Gemini can now be pointed at a proxy on the chat side, in the same way
+  that Anthropic and OpenAI already could. The server gains an
+  `llm.gemini_base_url` setting and the CLI client gains a
+  `gemini_base_url` setting, both of which also read the new
+  `PGEDGE_GEMINI_BASE_URL` environment variable, and both of which
+  default to `https://generativelanguage.googleapis.com`. The embedding
+  side is untouched and keeps its own separate variable, so routing chat
+  traffic through a proxy leaves embedding traffic alone.
+
+- The CLI client now accepts `-anthropic-api-key-file` and
+  `-openai-api-key-file`, so that every provider offers a key file flag
+  rather than Gemini alone. Each behaves as the Gemini flag does: the
+  file is read when the flag is applied, a direct `-<provider>-api-key`
+  flag beats the corresponding file, and a path given on the command
+  line that cannot be read, or that holds nothing, is an error rather
+  than a silent fallback.
+
 ### Changed
 
 - Dependencies across every ecosystem this project uses are now on their

--- a/docs/guide/cli-client.md
+++ b/docs/guide/cli-client.md
@@ -43,9 +43,11 @@ Before running the startup script, make sure you have:
 
 * **LLM Provider** (at least one):
    - Anthropic: Set `ANTHROPIC_API_KEY` or `PGEDGE_ANTHROPIC_API_KEY`
-     environment variable, OR create `~/.anthropic-api-key` file
+     environment variable, OR create `~/.anthropic-api-key` file, OR pass
+     `-anthropic-api-key-file` with the path to a key file
    - OpenAI: Set `OPENAI_API_KEY` or `PGEDGE_OPENAI_API_KEY` environment
-     variable, OR create `~/.openai-api-key` file
+     variable, OR create `~/.openai-api-key` file, OR pass
+     `-openai-api-key-file` with the path to a key file
    - Gemini: Set `GEMINI_API_KEY` or `PGEDGE_GEMINI_API_KEY` environment
      variable, OR pass `-gemini-api-key-file` with the path to a key file
    - Ollama: Set `PGEDGE_OLLAMA_URL` (e.g., `http://localhost:11434`)
@@ -110,15 +112,17 @@ API keys are loaded in the following order (highest to lowest):
    the unprefixed form (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
    `GEMINI_API_KEY`), which is consulted only when the prefixed
    variable is unset.
-2. API key files (`~/.anthropic-api-key`, `~/.openai-api-key`, and the file
-   named by `gemini_api_key_file` or `-gemini-api-key-file`)
+2. API key files (`~/.anthropic-api-key`, `~/.openai-api-key`, and the files
+   named by `anthropic_api_key_file`, `openai_api_key_file`,
+   `gemini_api_key_file`, or the matching `-<provider>-api-key-file` flag)
 3. Configuration file values (not recommended)
 
-The `-gemini-api-key` and `-gemini-api-key-file` flags override every other
-source, because command-line flags take precedence over the configuration
-the client has already loaded. Where both are given, `-gemini-api-key`
-wins, and a key file named on the command line that cannot be read is an
-error rather than a silent fallback.
+Every provider accepts both a direct key flag and a key file flag, and each
+pair overrides every other source, because command-line flags take
+precedence over the configuration the client has already loaded. Where both
+are given, the direct key wins, and a key file named on the command line
+that cannot be read, or that holds nothing, is an error rather than a
+silent fallback.
 
 ### Using Command-Line Flags
 
@@ -139,7 +143,11 @@ Flags:
   -llm-provider string      LLM provider: anthropic, openai, gemini, or ollama
   -llm-model string         LLM model to use
   -anthropic-api-key string API key for Anthropic
+  -anthropic-api-key-file string
+                            Path to a file containing the Anthropic API key
   -openai-api-key string    API key for OpenAI
+  -openai-api-key-file string
+                            Path to a file containing the OpenAI API key
   -gemini-api-key string    API key for Google Gemini
   -gemini-api-key-file string
                             Path to a file containing the Google Gemini API key
@@ -161,6 +169,9 @@ Flags:
 - `PGEDGE_OPENAI_API_KEY`: OpenAI API key (falls back to `OPENAI_API_KEY`)
 - `PGEDGE_GEMINI_API_KEY`: Google Gemini API key (falls back to
   `GEMINI_API_KEY`)
+- `PGEDGE_ANTHROPIC_BASE_URL`: Custom Anthropic API base URL (for proxies)
+- `PGEDGE_OPENAI_BASE_URL`: Custom OpenAI API base URL (for proxies)
+- `PGEDGE_GEMINI_BASE_URL`: Custom Gemini API base URL (for proxies)
 - `PGEDGE_OLLAMA_URL`: Ollama server URL (default: http://localhost:11434)
 - `NO_COLOR`: Disable colored output
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -189,7 +189,7 @@ client manages its own LLM connection and does not use these settings.
 | Configuration File Option | CLI Flag | Environment Variable | Description |
 |--------------------------|----------|---------------------|-------------|
 | `llm.enabled` | N/A | `PGEDGE_LLM_ENABLED` | Enable LLM proxy for web clients (default: false) |
-| `llm.provider` | N/A | `PGEDGE_LLM_PROVIDER` | LLM provider: "anthropic", "openai", or "ollama" (default: "anthropic") |
+| `llm.provider` | N/A | `PGEDGE_LLM_PROVIDER` | LLM provider: "anthropic", "openai", "gemini", or "ollama" (default: "anthropic") |
 | `llm.model` | N/A | `PGEDGE_LLM_MODEL` | Model name (default: provider-specific) |
 | `llm.anthropic_api_key` | N/A | `PGEDGE_ANTHROPIC_API_KEY`, `ANTHROPIC_API_KEY` | Anthropic API key (prefer key file or env var) |
 | `llm.anthropic_api_key_file` | N/A | N/A | Path to file containing Anthropic API key |
@@ -197,6 +197,9 @@ client manages its own LLM connection and does not use these settings.
 | `llm.openai_api_key` | N/A | `PGEDGE_OPENAI_API_KEY`, `OPENAI_API_KEY` | OpenAI API key (prefer key file or env var) |
 | `llm.openai_api_key_file` | N/A | N/A | Path to file containing OpenAI API key |
 | `llm.openai_base_url` | N/A | `PGEDGE_OPENAI_BASE_URL` | Custom OpenAI API base URL for proxies |
+| `llm.gemini_api_key` | N/A | `PGEDGE_GEMINI_API_KEY`, `GEMINI_API_KEY` | Google Gemini API key (prefer key file or env var) |
+| `llm.gemini_api_key_file` | N/A | N/A | Path to file containing Gemini API key |
+| `llm.gemini_base_url` | N/A | `PGEDGE_GEMINI_BASE_URL` | Custom Gemini API base URL for proxies |
 | `llm.ollama_url` | N/A | `PGEDGE_OLLAMA_URL` | Ollama server URL (default: "http://localhost:11434") |
 | `llm.max_tokens` | N/A | `PGEDGE_LLM_MAX_TOKENS` | Maximum tokens for LLM response (default: 4096) |
 

--- a/docs/guide/env_variable_config.md
+++ b/docs/guide/env_variable_config.md
@@ -127,7 +127,7 @@ configuration for the web client chat proxy:
 - **`PGEDGE_LLM_ENABLED`**: Enable LLM proxy for web clients
   ("true", "1", "yes" to enable)
 - **`PGEDGE_LLM_PROVIDER`**: LLM provider ("anthropic", "openai",
-  or "ollama")
+  "gemini", or "ollama")
 - **`PGEDGE_LLM_MODEL`**: Default model to use
 - **`PGEDGE_LLM_MAX_TOKENS`**: Maximum tokens for LLM response
   (default: 4096)
@@ -138,6 +138,10 @@ configuration for the web client chat proxy:
 - **`PGEDGE_OPENAI_API_KEY`**: OpenAI API key (or
   `OPENAI_API_KEY`)
 - **`PGEDGE_OPENAI_BASE_URL`**: Custom OpenAI API base URL
+  (for proxies)
+- **`PGEDGE_GEMINI_API_KEY`**: Google Gemini API key (or
+  `GEMINI_API_KEY`)
+- **`PGEDGE_GEMINI_BASE_URL`**: Custom Gemini API base URL
   (for proxies)
 - **`PGEDGE_OLLAMA_URL`**: Ollama server URL
 

--- a/docs/reference/config-examples/cli-client.md
+++ b/docs/reference/config-examples/cli-client.md
@@ -24,6 +24,7 @@ The chat client supports the following environment variables (in order of preced
 - `PGEDGE_OPENAI_API_KEY`: OpenAI API key
 - `PGEDGE_OPENAI_BASE_URL`: Custom OpenAI API base URL (for proxies)
 - `PGEDGE_GEMINI_API_KEY`: Google Gemini API key
+- `PGEDGE_GEMINI_BASE_URL`: Custom Gemini API base URL (for proxies)
 - `PGEDGE_OLLAMA_URL`: Ollama server URL
 
 ### Command Line Flags
@@ -43,15 +44,25 @@ All configuration options can be overridden with command line flags:
     -no-color
 ```
 
-The Gemini key can be given directly or read from a file, and either flag
-overrides the environment variable and the configuration file. Where both
-flags are given, `-gemini-api-key` takes precedence:
+Each provider's key can be given directly or read from a file, and either
+flag overrides the environment variable and the configuration file. Where
+both flags are given, the direct key takes precedence, and a key file named
+on the command line that cannot be read, or that holds nothing, is an error:
 
 ```bash
 ./bin/pgedge-nla-cli \
     -llm-provider gemini \
     -llm-model gemini-2.5-flash \
     -gemini-api-key-file ~/.gemini-api-key
+```
+
+The `-anthropic-api-key-file` and `-openai-api-key-file` flags behave
+identically for their own providers:
+
+```bash
+./bin/pgedge-nla-cli \
+    -llm-provider anthropic \
+    -anthropic-api-key-file ~/.anthropic-api-key
 ```
 
 Available MCP authentication flags:
@@ -318,11 +329,12 @@ llm:
     # Get your API key from: https://console.anthropic.com/
     #
     # Priority (highest to lowest):
-    # 1. Environment variable: PGEDGE_ANTHROPIC_API_KEY or ANTHROPIC_API_KEY
-    # 2. API key file: anthropic_api_key_file
-    # 3. Direct config value: anthropic_api_key (not recommended)
+    # 1. Command line flag: -anthropic-api-key or -anthropic-api-key-file
+    # 2. Environment variable: PGEDGE_ANTHROPIC_API_KEY or ANTHROPIC_API_KEY
+    # 3. API key file: anthropic_api_key_file
+    # 4. Direct config value: anthropic_api_key (not recommended)
     #
-    # Command line flag: -anthropic-api-key
+    # Command line flags: -anthropic-api-key, -anthropic-api-key-file
     #
     # Option 1: Environment variable (recommended for development)
     # export PGEDGE_ANTHROPIC_API_KEY="sk-ant-your-key-here"
@@ -345,11 +357,12 @@ llm:
     # Get your API key from: https://platform.openai.com/
     #
     # Priority (highest to lowest):
-    # 1. Environment variable: PGEDGE_OPENAI_API_KEY or OPENAI_API_KEY
-    # 2. API key file: openai_api_key_file
-    # 3. Direct config value: openai_api_key (not recommended)
+    # 1. Command line flag: -openai-api-key or -openai-api-key-file
+    # 2. Environment variable: PGEDGE_OPENAI_API_KEY or OPENAI_API_KEY
+    # 3. API key file: openai_api_key_file
+    # 4. Direct config value: openai_api_key (not recommended)
     #
-    # Command line flag: -openai-api-key
+    # Command line flags: -openai-api-key, -openai-api-key-file
     #
     # Option 1: Environment variable (recommended for development)
     # export PGEDGE_OPENAI_API_KEY="sk-proj-your-key-here"
@@ -385,6 +398,11 @@ llm:
     #
     # Option 3: Direct value (not recommended - use env var or file)
     # gemini_api_key: your-gemini-api-key-here
+    #
+    # Optional: Custom base URL for API proxy
+    # Environment variable: PGEDGE_GEMINI_BASE_URL
+    # Leave empty to use default (https://generativelanguage.googleapis.com)
+    # gemini_base_url: "https://your-proxy.example.com"
 
     # Maximum tokens for LLM response
     # For GPT-5 and o-series models, automatically uses max_completion_tokens

--- a/docs/reference/config-examples/server.md
+++ b/docs/reference/config-examples/server.md
@@ -395,6 +395,15 @@ llm:
     # Leave empty to use default (https://api.openai.com)
     # openai_base_url: "https://your-proxy.example.com"
 
+    # For Gemini
+    gemini_api_key_file: "~/.gemini-api-key"
+    # gemini_api_key: ""  # Not recommended - use file or env var
+
+    # Optional: Custom Gemini API base URL (for proxies)
+    # Leave empty to use default
+    # (https://generativelanguage.googleapis.com)
+    # gemini_base_url: "https://your-proxy.example.com"
+
     # For Ollama
     ollama_url: "http://localhost:11434"
 
@@ -581,6 +590,8 @@ custom_definitions_path: ""
 #   LLM providers:
 #     - PGEDGE_ANTHROPIC_BASE_URL (default: https://api.anthropic.com)
 #     - PGEDGE_OPENAI_BASE_URL (default: https://api.openai.com)
+#     - PGEDGE_GEMINI_BASE_URL
+#       (default: https://generativelanguage.googleapis.com)
 #   Embedding providers:
 #     - PGEDGE_VOYAGE_BASE_URL (default: https://api.voyageai.com/v1/embeddings)
 #     - PGEDGE_OPENAI_EMBEDDING_BASE_URL (default: https://api.openai.com/v1)

--- a/examples/pgedge-nla-cli-http.yaml.example
+++ b/examples/pgedge-nla-cli-http.yaml.example
@@ -45,6 +45,8 @@ llm:
     # Optional: Custom base URLs for API proxies
     # anthropic_base_url: ""  # Default: https://api.anthropic.com
     # openai_base_url: ""  # Default: https://api.openai.com
+    # gemini_base_url: ""  # Default: https://generativelanguage.googleapis.com
+    # gemini_base_url: ""  # Default: https://generativelanguage.googleapis.com
 
     max_tokens: 4096
 

--- a/examples/pgedge-nla-cli-stdio.yaml.example
+++ b/examples/pgedge-nla-cli-stdio.yaml.example
@@ -33,6 +33,8 @@ llm:
     # Optional: Custom base URLs for API proxies
     # anthropic_base_url: ""  # Default: https://api.anthropic.com
     # openai_base_url: ""  # Default: https://api.openai.com
+    # gemini_base_url: ""  # Default: https://generativelanguage.googleapis.com
+    # gemini_base_url: ""  # Default: https://generativelanguage.googleapis.com
 
     max_tokens: 4096
 

--- a/examples/pgedge-postgres-mcp-http.yaml.example
+++ b/examples/pgedge-postgres-mcp-http.yaml.example
@@ -148,7 +148,7 @@ embedding:
 # REQUIRED for the web client to function
 llm:
     enabled: true
-    provider: "anthropic"  # Options: "anthropic", "openai", "ollama"
+    provider: "anthropic"  # Options: "anthropic", "openai", "gemini", "ollama"
     model: "claude-sonnet-4-5"
 
     # API key files (recommended for production)
@@ -163,6 +163,8 @@ llm:
     # Optional: Custom base URLs for API proxies
     # anthropic_base_url: ""  # Default: https://api.anthropic.com
     # openai_base_url: ""  # Default: https://api.openai.com
+    # gemini_base_url: ""  # Default: https://generativelanguage.googleapis.com
+    # gemini_base_url: ""  # Default: https://generativelanguage.googleapis.com
 
     max_tokens: 4096
 

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -485,6 +485,7 @@ func (c *Client) newLLMClient(provider, model string, debug bool) (llmlib.Client
 		opts.BaseURL = c.config.LLM.OpenAIBaseURL
 	case "gemini":
 		opts.APIKey = c.config.LLM.GeminiAPIKey
+		opts.BaseURL = c.config.LLM.GeminiBaseURL
 	case "ollama":
 		// Ollama has no API key. Empty BaseURL keeps the library
 		// default (http://localhost:11434).

--- a/internal/chat/config.go
+++ b/internal/chat/config.go
@@ -60,6 +60,7 @@ type LLMConfig struct {
 	OpenAIBaseURL       string `yaml:"openai_base_url"`        // Base URL for OpenAI API (default: https://api.openai.com)
 	GeminiAPIKey        string `yaml:"gemini_api_key"`         // API key for Google Gemini (direct - discouraged, use api_key_file or env var)
 	GeminiAPIKeyFile    string `yaml:"gemini_api_key_file"`    // Path to file containing Gemini API key
+	GeminiBaseURL       string `yaml:"gemini_base_url"`        // Base URL for Gemini API (default: https://generativelanguage.googleapis.com)
 	OllamaURL           string `yaml:"ollama_url"`             // Ollama server URL
 	MaxTokens           int    `yaml:"max_tokens"`             // Max tokens for response
 }
@@ -94,6 +95,7 @@ func LoadConfig(configPath string) (*Config, error) {
 			OpenAIAPIKey:     getEnvWithFallback("PGEDGE_OPENAI_API_KEY", "OPENAI_API_KEY"),
 			OpenAIBaseURL:    os.Getenv("PGEDGE_OPENAI_BASE_URL"), // Empty string uses default
 			GeminiAPIKey:     getEnvWithFallback("PGEDGE_GEMINI_API_KEY", "GEMINI_API_KEY"),
+			GeminiBaseURL:    os.Getenv("PGEDGE_GEMINI_BASE_URL"), // Empty string uses default
 			OllamaURL:        getEnvOrDefault("PGEDGE_OLLAMA_URL", "http://localhost:11434"),
 			MaxTokens:        4096,
 		},

--- a/internal/chat/config_test.go
+++ b/internal/chat/config_test.go
@@ -362,6 +362,44 @@ func TestLoadConfig_GeminiAPIKeyFromEnvironment(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_LLMBaseURLsFromEnvironment(t *testing.T) {
+	t.Setenv("PGEDGE_ANTHROPIC_BASE_URL", "https://anthropic.proxy.example.com")
+	t.Setenv("PGEDGE_OPENAI_BASE_URL", "https://openai.proxy.example.com")
+	t.Setenv("PGEDGE_GEMINI_BASE_URL", "https://gemini.proxy.example.com")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if cfg.LLM.AnthropicBaseURL != "https://anthropic.proxy.example.com" {
+		t.Errorf("Expected the Anthropic base URL from the environment, got '%s'", cfg.LLM.AnthropicBaseURL)
+	}
+	if cfg.LLM.OpenAIBaseURL != "https://openai.proxy.example.com" {
+		t.Errorf("Expected the OpenAI base URL from the environment, got '%s'", cfg.LLM.OpenAIBaseURL)
+	}
+	if cfg.LLM.GeminiBaseURL != "https://gemini.proxy.example.com" {
+		t.Errorf("Expected the Gemini base URL from the environment, got '%s'", cfg.LLM.GeminiBaseURL)
+	}
+}
+
+// The embedding variables belong to the server, and carry an _EMBEDDING_
+// infix so that PGEDGE_GEMINI_BASE_URL stays free for the chat side; the CLI
+// must therefore ignore the embedding name entirely.
+func TestLoadConfig_GeminiEmbeddingBaseURLIgnored(t *testing.T) {
+	t.Setenv("PGEDGE_GEMINI_BASE_URL", "")
+	t.Setenv("PGEDGE_GEMINI_EMBEDDING_BASE_URL", "https://embed.proxy.example.com")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if cfg.LLM.GeminiBaseURL != "" {
+		t.Errorf("Expected an empty Gemini base URL, got '%s'", cfg.LLM.GeminiBaseURL)
+	}
+}
+
 func TestLoadConfig_GeminiAPIKeyFromFile(t *testing.T) {
 	t.Setenv("PGEDGE_GEMINI_API_KEY", "")
 	t.Setenv("GEMINI_API_KEY", "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -520,6 +520,7 @@ type LLMConfig struct {
 	OllamaURL           string `yaml:"ollama_url"`             // URL for Ollama service (default: http://localhost:11434)
 	GeminiAPIKey        string `yaml:"gemini_api_key"`         // API key for Google Gemini (direct - discouraged, use api_key_file or env var instead)
 	GeminiAPIKeyFile    string `yaml:"gemini_api_key_file"`    // Path to file containing Gemini API key
+	GeminiBaseURL       string `yaml:"gemini_base_url"`        // Base URL for Gemini API (default: https://generativelanguage.googleapis.com)
 	MaxTokens           int    `yaml:"max_tokens"`             // Maximum tokens for LLM response (default: 4096)
 	PerAttemptTimeout   int    `yaml:"per_attempt_timeout"`    // Per-attempt HTTP timeout in seconds (0 = unlimited; default: 60)
 }
@@ -879,6 +880,9 @@ func mergeConfig(dest, src *Config) {
 		}
 		if src.LLM.GeminiAPIKeyFile != "" {
 			dest.LLM.GeminiAPIKeyFile = src.LLM.GeminiAPIKeyFile
+		}
+		if src.LLM.GeminiBaseURL != "" {
+			dest.LLM.GeminiBaseURL = src.LLM.GeminiBaseURL
 		}
 		if src.LLM.MaxTokens != 0 {
 			dest.LLM.MaxTokens = src.LLM.MaxTokens
@@ -1278,6 +1282,7 @@ func applyEnvironmentVariables(cfg *Config) {
 	// Base URL overrides for LLM providers (useful for proxies)
 	setStringFromEnv(&cfg.LLM.AnthropicBaseURL, "PGEDGE_ANTHROPIC_BASE_URL")
 	setStringFromEnv(&cfg.LLM.OpenAIBaseURL, "PGEDGE_OPENAI_BASE_URL")
+	setStringFromEnv(&cfg.LLM.GeminiBaseURL, "PGEDGE_GEMINI_BASE_URL")
 	setIntFromEnv(&cfg.LLM.MaxTokens, "PGEDGE_LLM_MAX_TOKENS")
 	setIntFromEnv(&cfg.LLM.PerAttemptTimeout, "PGEDGE_LLM_PER_ATTEMPT_TIMEOUT")
 	// Knowledgebase

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -854,6 +854,92 @@ func TestMergePerAttemptTimeout(t *testing.T) {
 	}
 }
 
+func TestMergeLLMBaseURLs(t *testing.T) {
+	dest := defaultConfig()
+	src := &Config{
+		LLM: LLMConfig{
+			Provider:         "gemini",
+			AnthropicBaseURL: "https://anthropic.proxy.example.com",
+			OpenAIBaseURL:    "https://openai.proxy.example.com",
+			GeminiBaseURL:    "https://gemini.proxy.example.com",
+		},
+	}
+
+	mergeConfig(dest, src)
+
+	if dest.LLM.AnthropicBaseURL != "https://anthropic.proxy.example.com" {
+		t.Errorf("LLM.AnthropicBaseURL = %q, want the merged value", dest.LLM.AnthropicBaseURL)
+	}
+	if dest.LLM.OpenAIBaseURL != "https://openai.proxy.example.com" {
+		t.Errorf("LLM.OpenAIBaseURL = %q, want the merged value", dest.LLM.OpenAIBaseURL)
+	}
+	if dest.LLM.GeminiBaseURL != "https://gemini.proxy.example.com" {
+		t.Errorf("LLM.GeminiBaseURL = %q, want the merged value", dest.LLM.GeminiBaseURL)
+	}
+
+	// An empty source value must leave an already merged value alone.
+	mergeConfig(dest, &Config{LLM: LLMConfig{Provider: "gemini"}})
+	if dest.LLM.GeminiBaseURL != "https://gemini.proxy.example.com" {
+		t.Errorf("LLM.GeminiBaseURL = %q after an empty merge, want it preserved", dest.LLM.GeminiBaseURL)
+	}
+}
+
+func TestApplyEnvironmentVariables_LLMBaseURLs(t *testing.T) {
+	t.Setenv("PGEDGE_ANTHROPIC_BASE_URL", "https://anthropic.proxy.example.com")
+	t.Setenv("PGEDGE_OPENAI_BASE_URL", "https://openai.proxy.example.com")
+	t.Setenv("PGEDGE_GEMINI_BASE_URL", "https://gemini.proxy.example.com")
+
+	cfg := defaultConfig()
+	applyEnvironmentVariables(cfg)
+
+	if cfg.LLM.AnthropicBaseURL != "https://anthropic.proxy.example.com" {
+		t.Errorf("LLM.AnthropicBaseURL = %q, want the environment value", cfg.LLM.AnthropicBaseURL)
+	}
+	if cfg.LLM.OpenAIBaseURL != "https://openai.proxy.example.com" {
+		t.Errorf("LLM.OpenAIBaseURL = %q, want the environment value", cfg.LLM.OpenAIBaseURL)
+	}
+	if cfg.LLM.GeminiBaseURL != "https://gemini.proxy.example.com" {
+		t.Errorf("LLM.GeminiBaseURL = %q, want the environment value", cfg.LLM.GeminiBaseURL)
+	}
+}
+
+// TestGeminiBaseURLNamespaces guards the naming split between the chat side
+// and the embedding side. The embedding providers deliberately carry an
+// _EMBEDDING_ infix so that PGEDGE_GEMINI_BASE_URL stays free for the LLM,
+// and neither variable may bleed into the other's configuration.
+func TestGeminiBaseURLNamespaces(t *testing.T) {
+	t.Run("embedding variable leaves the LLM base URL alone", func(t *testing.T) {
+		t.Setenv("PGEDGE_GEMINI_BASE_URL", "")
+		t.Setenv("PGEDGE_GEMINI_EMBEDDING_BASE_URL", "https://embed.proxy.example.com")
+
+		cfg := defaultConfig()
+		applyEnvironmentVariables(cfg)
+
+		if cfg.LLM.GeminiBaseURL != "" {
+			t.Errorf("LLM.GeminiBaseURL = %q, want it untouched by the embedding variable",
+				cfg.LLM.GeminiBaseURL)
+		}
+	})
+
+	t.Run("LLM variable leaves the embedding settings alone", func(t *testing.T) {
+		t.Setenv("PGEDGE_GEMINI_EMBEDDING_BASE_URL", "")
+		t.Setenv("PGEDGE_GEMINI_BASE_URL", "https://gemini.proxy.example.com")
+
+		cfg := defaultConfig()
+		before := cfg.Embedding
+		applyEnvironmentVariables(cfg)
+
+		if cfg.LLM.GeminiBaseURL != "https://gemini.proxy.example.com" {
+			t.Errorf("LLM.GeminiBaseURL = %q, want the environment value", cfg.LLM.GeminiBaseURL)
+		}
+		// The embedding block has no Gemini provider of its own yet, so the
+		// assertion is simply that the LLM variable changes nothing there.
+		if cfg.Embedding != before {
+			t.Errorf("Embedding config = %+v, want it unchanged at %+v", cfg.Embedding, before)
+		}
+	})
+}
+
 func TestApplyCLIFlags(t *testing.T) {
 	cfg := defaultConfig()
 	flags := CLIFlags{

--- a/pkg/common/postgres-mcp.yaml
+++ b/pkg/common/postgres-mcp.yaml
@@ -103,9 +103,13 @@ http:
 # LLM proxy settings (optional - for web UI)
 llm:
   enabled: false
-  # provider: anthropic  # anthropic, openai, or ollama
+  # provider: anthropic  # anthropic, openai, gemini, or ollama
   # Set API keys via environment variables:
-  # ANTHROPIC_API_KEY or OPENAI_API_KEY
+  # ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY
+  # Optional: Custom base URLs for API proxies
+  # anthropic_base_url: ""  # Default: https://api.anthropic.com
+  # openai_base_url: ""  # Default: https://api.openai.com
+  # gemini_base_url: ""  # Default: https://generativelanguage.googleapis.com
 
 # Knowledgebase database (for similarity_search tool)
 # Requires pgedge-ai-kb package


### PR DESCRIPTION
> **Stacked on #241.** The base branch is `feat/issue-238-cli-gemini`, because this
> builds on the `chat.ReadAPIKeyFile` export and the Gemini config fields added
> there. Merge #241 first; GitHub will retarget this to `main` automatically.

## Summary

An audit of how API keys can be supplied turned up two asymmetries. Both fixes
are purely additive and change no existing behaviour.

**Gemini had no way to reach a proxy.** Every other LLM provider carries a base
URL override on both the server and the CLI, but neither `LLMConfig` had a
`GeminiBaseURL` field and no environment variable set one. The server's
`providers["gemini"]` block did not pass a `BaseURL` either, whilst the
anthropic, openai and ollama blocks all did, so the wiring was missing as well
as the setting. Both sides now read `gemini_base_url`, or
`PGEDGE_GEMINI_BASE_URL` from the environment.

**The CLI offered a key-file flag for Gemini alone**, even though the config
file has honoured `anthropic_api_key_file` and `openai_api_key_file` all along.
All three providers now have both flags, behaving identically: the file named on
the command line is read where the flag is applied (the loader resolves
configured key files before any flag is seen), a direct key beats one read from
a file, and a command-line path that cannot be read or yields an empty key is an
error rather than the silent fallback the loader allows for a configured path.
That logic moves into `applyAPIKeyFlags`, which returns an error and leaves
`os.Exit` to `main`, making it testable without contorting the flag parsing.

## Note on the naming, and on #239

`PGEDGE_GEMINI_BASE_URL` was deliberately left unused when the embedding side
took the `PGEDGE_GEMINI_EMBEDDING_BASE_URL` form, so this claims a reserved name
rather than renaming anything.

Worth flagging for merge order: the Gemini *embedding* support lives in #239,
which is still open, so `EmbeddingConfig.GeminiBaseURL` does not exist on this
branch at all. The two are complementary by design, but both touch
`internal/config/config.go` and the same documentation tables, so expect textual
conflicts depending on merge order. The tests here assert the two namespaces stay
independent in the only direction currently observable, with comments saying so,
so whoever merges second can tighten the other half.

Whilst updating the configuration tables it also became apparent that the
server's LLM section had never documented Gemini at all despite supporting it,
so the `gemini_api_key` and `gemini_api_key_file` rows are added alongside the
new `gemini_base_url`.

## Test plan

- [x] New config tests: `PGEDGE_GEMINI_BASE_URL` reaching both loaders, the
      server's `mergeConfig` carrying the field, and the LLM and embedding
      namespaces staying independent.
- [x] New `TestApplyAPIKeyFlags` covering all seven cases (neither flag, direct
      key, key file, both together, missing file, unreadable file, empty file)
      plus provider naming in the error text.
- [x] Flag wiring verified manually against the built binary: `-help` lists all
      six flags, the three error paths exit 1 with the right provider named, and
      a good key file gets the client past `Validate()` with no key in the
      environment.
- [x] `make lint` reports 0 issues and `make test` is fully green.