### PR TITLE
fix(web): carry Gemini's tool-call arguments and signature through sseChat

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,12 @@ and this project adheres to
 
 ### Changed
 
+- The LLM library moves to `pgedge-go-llm-lib` v0.3.0, which adds the
+  `signature` field to a tool call and carries it through the streaming
+  API, the SSE proxy, and the outbound Gemini request as that provider's
+  `thoughtSignature`. The web client needs the field on the wire for its
+  own signature handling to have anything to preserve.
+
 - The example configuration files now show the `sslcert`, `sslkey`, and
   `sslrootcert` database settings, commented out alongside `sslmode`,
   together with the matching `PGEDGE_DB_SSLCERT`, `PGEDGE_DB_SSLKEY`,
@@ -101,14 +107,15 @@ and this project adheres to
   on the start event itself and never sends a single delta chunk (unlike
   Anthropic and OpenAI, which stream them incrementally), so every Gemini
   tool call ran with empty arguments regardless of what the model actually
-  asked for — the root cause behind issue #235's reported retry loop. The
-  handler now seeds the argument buffer from the start event when it
-  already carries complete arguments. Separately, the handler never
-  captured a tool call's provider signature at all, so a Gemini thinking
-  model's required `thought_signature` was dropped before it was ever
-  stored, breaking the next tool-calling turn regardless of whether the
-  underlying library sends it correctly. Both are fixed; a response with
-  no signature is unaffected.
+  asked for; this was the root cause behind issue #235's reported retry
+  loop. The handler now seeds the argument buffer from the start event when
+  it already carries complete arguments. Ollama delivers its arguments the
+  same way, so its tool calls are fixed by the same change. Separately, the
+  handler never captured a tool call's provider signature at all, so a
+  Gemini thinking model's required `thought_signature` was dropped before
+  it was ever stored, breaking the next tool-calling turn. The signature is
+  now carried through unchanged, and a response that has none is
+  unaffected. (#244)
 
 - The web client no longer keeps re-running a tool call that cannot
   succeed. Where a model responded to a tool error by reissuing the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -95,6 +95,21 @@ and this project adheres to
 
 ### Fixed
 
+- Gemini tool calls now work through the web client. `sseChat.js`'s
+  `tool_use_start` handler only ever populated a tool call's arguments from
+  later `tool_use_delta` chunks, but Gemini delivers the complete arguments
+  on the start event itself and never sends a single delta chunk (unlike
+  Anthropic and OpenAI, which stream them incrementally), so every Gemini
+  tool call ran with empty arguments regardless of what the model actually
+  asked for — the root cause behind issue #235's reported retry loop. The
+  handler now seeds the argument buffer from the start event when it
+  already carries complete arguments. Separately, the handler never
+  captured a tool call's provider signature at all, so a Gemini thinking
+  model's required `thought_signature` was dropped before it was ever
+  stored, breaking the next tool-calling turn regardless of whether the
+  underlying library sends it correctly. Both are fixed; a response with
+  no signature is unaffected.
+
 - The web client no longer keeps re-running a tool call that cannot
   succeed. Where a model responded to a tool error by reissuing the
   identical call, the agentic loop would repeat it up to fifty times,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
-	github.com/pgEdge/pgedge-go-llm-lib v0.2.0
+	github.com/pgEdge/pgedge-go-llm-lib v0.3.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/pgEdge/pgedge-go-llm-lib v0.2.0 h1:cSLZf0bui8l0onAKCX7vsXGUIGXWRI5z3F+/BLd+QhE=
-github.com/pgEdge/pgedge-go-llm-lib v0.2.0/go.mod h1:41rtSLcp/wwSUlBqetVHLQKisDZfzBmgSWt84WA+Eys=
+github.com/pgEdge/pgedge-go-llm-lib v0.3.0 h1:AgjKkWD2ICW9G/H1AWXCcPBEvKobn4jmBZljcjfmrF8=
+github.com/pgEdge/pgedge-go-llm-lib v0.3.0/go.mod h1:NBvb+aXY/ImYuIUjpQnZ/R4l6RvdK9xm7h6hv2c2HSs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/web/src/utils/sseChat.js
+++ b/web/src/utils/sseChat.js
@@ -28,9 +28,18 @@
  *   - "text"            -> appended to the current text block; also
  *                          surfaced via the onTextChunk callback so the
  *                          UI can update incrementally.
- *   - "tool_use_start"  -> begins a new tool_use block (id + name).
+ *   - "tool_use_start"  -> begins a new tool_use block (id, name, and
+ *                          an optional provider-specific signature that
+ *                          must be carried through unchanged; Gemini's
+ *                          thinking models require it back on this same
+ *                          call the next time it appears in history). May
+ *                          also carry the complete arguments directly, for
+ *                          providers (Gemini) that never stream them
+ *                          incrementally.
  *   - "tool_use_delta"  -> accumulates partial JSON input string for
- *                          the current tool_use; parsed at done.
+ *                          the current tool_use; parsed at done. Providers
+ *                          that deliver complete arguments on the start
+ *                          event send no delta chunks at all.
  *
  * @param {object} body - Request body matching the /v1/chat schema
  *     (messages, tools, provider, model, etc.).
@@ -89,7 +98,7 @@ export async function sseChat(body, options = {}) {
     let pendingTextBlock = null;
     // Ordered list of tool_use ids so we preserve emission order at done.
     const toolOrder = [];
-    // Map of tool_use id -> { name, partial } accumulator.
+    // Map of tool_use id -> { name, partial, signature } accumulator.
     const pendingTools = new Map();
     let currentToolId = null;
     let streamError = null;
@@ -117,9 +126,18 @@ export async function sseChat(body, options = {}) {
                     input = { _raw: partial };
                 }
             }
+            const toolUse = { id, name: info.name, input };
+            // Gemini's thinking models attach an opaque signature to a
+            // function call and require it echoed back unchanged on
+            // that same call the next time it appears in conversation
+            // history, or the next turn is rejected outright; carry it
+            // through rather than reconstructing the block without it.
+            if (info.signature) {
+                toolUse.signature = info.signature;
+            }
             assembled.content.push({
                 type: 'tool_use',
-                tool_use: { id, name: info.name, input },
+                tool_use: toolUse,
             });
         }
     };
@@ -193,7 +211,16 @@ export async function sseChat(body, options = {}) {
                 }
                 pendingTools.set(id, {
                     name: tu.name || '',
-                    partial: '',
+                    // Some providers (Gemini) deliver the complete
+                    // arguments on this event and send no delta chunks
+                    // at all; seed the buffer from them when present
+                    // rather than assuming a delta always follows. The
+                    // wire format sends `input: null` (no omitempty on
+                    // the Go side) for providers still to come via
+                    // deltas, so null must be treated the same as
+                    // absent rather than as a literal complete value.
+                    partial: tu.input != null ? JSON.stringify(tu.input) : '',
+                    signature: tu.signature || '',
                 });
                 break;
             }

--- a/web/src/utils/sseChat.js
+++ b/web/src/utils/sseChat.js
@@ -9,6 +9,27 @@
  */
 
 /**
+ * Normalises a tool call's arguments as they arrive on a
+ * `tool_use_start` event into the same partial-JSON string that
+ * `tool_use_delta` chunks accumulate, so both delivery styles converge
+ * on one representation before being parsed.
+ *
+ * A missing or null `input` yields the empty string, because the wire
+ * format sends `input: null` for the providers that stream arguments as
+ * deltas instead. Arguments already encoded as a JSON string are passed
+ * through untouched rather than re-encoded, which would otherwise parse
+ * back to a quoted string instead of an object.
+ *
+ * @param {*} input - The start event's `tool_use.input`, if any.
+ * @returns {string} Partial JSON to seed the accumulator with.
+ */
+function encodeStartArgs(input) {
+    if (input == null) return '';
+    if (typeof input === 'string') return input;
+    return JSON.stringify(input);
+}
+
+/**
  * Posts to the library proxy's streaming chat endpoint
  * (/api/llm/v1/chat/stream), parses Server-Sent Events, and assembles
  * the final response into the same shape returned by the non-streaming
@@ -34,8 +55,8 @@
  *                          thinking models require it back on this same
  *                          call the next time it appears in history). May
  *                          also carry the complete arguments directly, for
- *                          providers (Gemini) that never stream them
- *                          incrementally.
+ *                          providers (Gemini, Ollama) that never stream
+ *                          them incrementally.
  *   - "tool_use_delta"  -> accumulates partial JSON input string for
  *                          the current tool_use; parsed at done. Providers
  *                          that deliver complete arguments on the start
@@ -211,15 +232,19 @@ export async function sseChat(body, options = {}) {
                 }
                 pendingTools.set(id, {
                     name: tu.name || '',
-                    // Some providers (Gemini) deliver the complete
-                    // arguments on this event and send no delta chunks
-                    // at all; seed the buffer from them when present
-                    // rather than assuming a delta always follows. The
-                    // wire format sends `input: null` (no omitempty on
-                    // the Go side) for providers still to come via
-                    // deltas, so null must be treated the same as
-                    // absent rather than as a literal complete value.
-                    partial: tu.input != null ? JSON.stringify(tu.input) : '',
+                    // Some providers (Gemini, Ollama) deliver the
+                    // complete arguments on this event and send no delta
+                    // chunks at all; seed the buffer from them when
+                    // present rather than assuming a delta always
+                    // follows. The wire format sends `input: null` (no
+                    // omitempty on the Go side) for providers still to
+                    // come via deltas, so null must be treated the same
+                    // as absent rather than as a literal complete value.
+                    // A provider sending pre-encoded arguments as a JSON
+                    // string is taken as-is, since re-encoding it would
+                    // yield a quoted string rather than the object the
+                    // caller expects.
+                    partial: encodeStartArgs(tu.input),
                     signature: tu.signature || '',
                 });
                 break;

--- a/web/src/utils/sseChat.test.js
+++ b/web/src/utils/sseChat.test.js
@@ -102,6 +102,62 @@ describe('sseChat', () => {
         ]);
     });
 
+    it('reads tool_use arguments delivered complete on the start event, with no deltas', async () => {
+        // Gemini sends the complete arguments on tool_use_start and never
+        // emits a single tool_use_delta; unlike Anthropic/OpenAI's
+        // incremental-delta style, this must not require a delta to
+        // populate the tool call's input.
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'data: {"type":"tool_use_start","tool_use":{"id":"tu_1","name":"count_rows","input":{"table":"docs"}}}\n\n',
+            'event: done\ndata: {"stop_reason":"tool_use","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.content).toEqual([
+            {
+                type: 'tool_use',
+                tool_use: {
+                    id: 'tu_1',
+                    name: 'count_rows',
+                    input: { table: 'docs' },
+                },
+            },
+        ]);
+    });
+
+    it('carries a provider signature on tool_use through to the assembled block', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'data: {"type":"tool_use_start","tool_use":{"id":"tu_1","name":"get_weather","input":{"city":"Rome"},"signature":"sig-abc123"}}\n\n',
+            'event: done\ndata: {"stop_reason":"tool_use","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.content).toEqual([
+            {
+                type: 'tool_use',
+                tool_use: {
+                    id: 'tu_1',
+                    name: 'get_weather',
+                    input: { city: 'Rome' },
+                    signature: 'sig-abc123',
+                },
+            },
+        ]);
+    });
+
+    it('omits the signature field entirely when the server sends none', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'data: {"type":"tool_use_start","tool_use":{"id":"tu_1","name":"count_rows","input":{"table":"docs"}}}\n\n',
+            'event: done\ndata: {"stop_reason":"tool_use"}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.content[0].tool_use).not.toHaveProperty('signature');
+    });
+
     it('throws when the server emits an error event', async () => {
         globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
             'data: {"type":"text","text":"partial"}\n\n',

--- a/web/src/utils/sseChat.test.js
+++ b/web/src/utils/sseChat.test.js
@@ -126,6 +126,20 @@ describe('sseChat', () => {
         ]);
     });
 
+    it('takes start-event arguments already encoded as a JSON string as-is', async () => {
+        // A provider delivering pre-encoded arguments must not have them
+        // re-encoded, which would parse back to a quoted string rather
+        // than the object the tool executor expects.
+        globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
+            'data: {"type":"tool_use_start","tool_use":{"id":"tu_1","name":"count_rows","input":"{\\"table\\":\\"docs\\"}"}}\n\n',
+            'event: done\ndata: {"stop_reason":"tool_use"}\n\n',
+        ]));
+
+        const result = await sseChat({ messages: [] });
+
+        expect(result.content[0].tool_use.input).toEqual({ table: 'docs' });
+    });
+
     it('carries a provider signature on tool_use through to the assembled block', async () => {
         globalThis.fetch = vi.fn().mockResolvedValue(buildStreamResponse([
             'data: {"type":"tool_use_start","tool_use":{"id":"tu_1","name":"get_weather","input":{"city":"Rome"},"signature":"sig-abc123"}}\n\n',


### PR DESCRIPTION
## Summary

Issue #244: two distinct bugs in `sseChat.js`'s `tool_use_start` handler
that together make Gemini tool-calling not work through the web client,
even though the underlying library (`pgedge-go-llm-lib`) is correct.

**Arguments dropped.** The handler only ever populated a tool call's
arguments from later `tool_use_delta` chunks. Anthropic and OpenAI stream
arguments incrementally so this held for them, but Gemini delivers the
complete arguments on the start event itself and never sends a single
delta chunk (confirmed zero `ChunkToolUseDelta` references anywhere in
`gemini.go`). Every Gemini tool call ran with empty arguments regardless of
what the model actually asked for — the root cause behind issue #235's
reported retry loop. Fix: seed the buffer from the start event's `input`
when it's already present. The wire format sends `input: null` (no
`omitempty` on the Go side) for providers still to come via deltas, so
`null` is treated the same as absent, not as a literal complete value —
an early version of this fix broke the existing incremental-delta test by
missing that distinction; the test suite caught it immediately.

**Signature dropped.** Separately, the handler never captured
`tool_use.signature` at all. Gemini's thinking models attach an opaque
signature to a function call and require it echoed back unchanged the next
time that call appears in history, or the next turn is rejected outright.
Even once `pgedge-go-llm-lib` sends the signature correctly (#34/#36/#38,
all merged upstream), the browser dropped it before it was ever stored.
Fix: capture it into the pending-tool record, include it on the assembled
block only when present.

## Verification

- Live, against the real app, not just mocks: ran the actual web client
  against a real MCP server, a real Postgres database, and the real Gemini
  API. Confirmed via server-side trace that the model generates correct
  arguments (e.g. `{"table": "docs"}`), but the tool previously executed
  with `{}` and failed with `Missing or invalid 'table' parameter`. With
  this fix, the same question executes the tool correctly and returns a
  real answer.
- 3 new unit tests, mutation-tested: reverted each fix individually and
  confirmed only its own test(s) fail, restored and confirmed all pass.
- Full web test suite: 214/214 passing (was 211 before this PR).

## Test plan

- [x] New tests: complete-args-on-start-with-no-deltas, signature carried
      through, signature omitted when absent
- [x] Mutation-tested both fixes independently
- [x] Existing incremental-delta test (Anthropic/OpenAI-style) still
      passes — confirms the `null`-vs-absent distinction doesn't regress
      the other providers
- [x] Live end-to-end verification against a real Gemini key and database
- [x] Full web suite: 214/214

Fixes #244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Gemini and Ollama tool-call handling by preserving complete arguments and provider signatures across follow-up turns.
  - Correctly processes complete tool arguments provided at the start of a tool call, including JSON strings.
  - Handles missing or null tool inputs without generating incomplete data.

- **Documentation**
  - Added changelog details describing tool-call improvements and provider-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->