### PR TITLE
fix(web): block sending while the new provider's model list loads

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -107,8 +107,13 @@ and this project adheres to
   neither the send handlers nor the message input were gated on that
   fetch still being in flight, so a fast switch-and-send could reach the
   server as e.g. `{"provider": "openai", "model": "gemini-flash-latest"}`.
-  The chat input and Send button are now disabled while the new
-  provider's model list is loading.
+  The chat input, the Send button, and prompt execution are now disabled
+  whilst the new provider's model list is loading. The same mismatch was
+  reachable when that fetch failed outright, or when a provider returned
+  no models at all, because sending was re-enabled whilst the previous
+  provider's model was still selected; the selection is now cleared in
+  both cases, which leaves the server to fall back to the provider's own
+  configured default.
 
 - Gemini tool calls now work through the web client. `sseChat.js`'s
   `tool_use_start` handler only ever populated a tool call's arguments from

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -101,6 +101,15 @@ and this project adheres to
 
 ### Fixed
 
+- Switching LLM providers and sending a message immediately afterwards no
+  longer pairs the new provider with the previous provider's model. The
+  model list for the newly selected provider refreshes asynchronously, but
+  neither the send handlers nor the message input were gated on that
+  fetch still being in flight, so a fast switch-and-send could reach the
+  server as e.g. `{"provider": "openai", "model": "gemini-flash-latest"}`.
+  The chat input and Send button are now disabled while the new
+  provider's model list is loading.
+
 - Gemini tool calls now work through the web client. `sseChat.js`'s
   `tool_use_start` handler only ever populated a tool call's arguments from
   later `tool_use_delta` chunks, but Gemini delivers the complete arguments

--- a/web/src/components/ChatInterface.jsx
+++ b/web/src/components/ChatInterface.jsx
@@ -1855,6 +1855,7 @@ const ChatInterface = ({ conversations }) => {
                 prompts={prompts}
                 onExecute={handlePromptExecute}
                 executing={executingPrompt}
+                disabled={llmProviders.loadingModels}
             />
 
             {/* Write Query Confirmation Dialog */}

--- a/web/src/components/ChatInterface.jsx
+++ b/web/src/components/ChatInterface.jsx
@@ -690,7 +690,11 @@ const ChatInterface = ({ conversations }) => {
 
     // Handle message sending
     const handleSend = useCallback(async () => {
-        if (!input.trim() || loading || !mcpClient) return;
+        // Switching providers refetches that provider's model list
+        // asynchronously; selectedModel still holds the previous
+        // provider's model until it resolves. Sending in that window
+        // would pair the new provider with a model it never advertised.
+        if (!input.trim() || loading || !mcpClient || llmProviders.loadingModels) return;
 
         const userMessage = {
             role: 'user',
@@ -1204,7 +1208,7 @@ const ChatInterface = ({ conversations }) => {
             setLoading(false);
             abortControllerRef.current = null;
         }
-    }, [input, loading, mcpClient, messages, sessionToken, tools, llmProviders.selectedProvider, llmProviders.selectedModel, queryHistory, forceLogout, refreshTools, fetchDatabases, isWriteAccessEnabled, requestWriteConfirmation]);
+    }, [input, loading, mcpClient, messages, sessionToken, tools, llmProviders.selectedProvider, llmProviders.selectedModel, llmProviders.loadingModels, queryHistory, forceLogout, refreshTools, fetchDatabases, isWriteAccessEnabled, requestWriteConfirmation]);
 
     // Handle request cancellation
     const handleCancel = useCallback(() => {
@@ -1304,7 +1308,7 @@ const ChatInterface = ({ conversations }) => {
 
     // Handle prompt execution
     const handlePromptExecute = useCallback(async (promptName, args) => {
-        if (!mcpClient || loading) return;
+        if (!mcpClient || loading || llmProviders.loadingModels) return;
 
         setExecutingPrompt(true);
 
@@ -1783,7 +1787,7 @@ const ChatInterface = ({ conversations }) => {
             setLoading(false);
             abortControllerRef.current = null;
         }
-    }, [mcpClient, loading, messages, sessionToken, tools, llmProviders.selectedProvider, llmProviders.selectedModel, forceLogout, refreshTools, fetchDatabases, isWriteAccessEnabled, requestWriteConfirmation]);
+    }, [mcpClient, loading, messages, sessionToken, tools, llmProviders.selectedProvider, llmProviders.selectedModel, llmProviders.loadingModels, forceLogout, refreshTools, fetchDatabases, isWriteAccessEnabled, requestWriteConfirmation]);
 
     return (
         <Box
@@ -1819,7 +1823,7 @@ const ChatInterface = ({ conversations }) => {
                     onSend={handleSend}
                     onCancel={handleCancel}
                     onKeyDown={handleKeyDown}
-                    disabled={loading}
+                    disabled={loading || llmProviders.loadingModels}
                     isLoading={loading}
                     onPromptClick={handlePromptClick}
                     hasPrompts={prompts && prompts.length > 0}

--- a/web/src/components/PromptPopover.jsx
+++ b/web/src/components/PromptPopover.jsx
@@ -41,6 +41,7 @@ const PromptPopover = ({
     prompts = [],
     onExecute,
     executing = false,
+    disabled = false,
 }) => {
     const [selectedPromptName, setSelectedPromptName] = useState('');
     const [argumentValues, setArgumentValues] = useState({});
@@ -391,7 +392,7 @@ const PromptPopover = ({
                             fullWidth
                             variant="contained"
                             onClick={handleExecute}
-                            disabled={executing}
+                            disabled={executing || disabled}
                             startIcon={executing ? <CircularProgress size={16} sx={{ color: '#FFFFFF' }} /> : <PlayArrowIcon />}
                             sx={{
                                 bgcolor: '#15AABF',
@@ -443,6 +444,7 @@ PromptPopover.propTypes = {
     })),
     onExecute: PropTypes.func.isRequired,
     executing: PropTypes.bool,
+    disabled: PropTypes.bool,
 };
 
 export default PromptPopover;

--- a/web/src/components/__tests__/ChatInterface.providerRace.test.jsx
+++ b/web/src/components/__tests__/ChatInterface.providerRace.test.jsx
@@ -71,7 +71,10 @@ vi.mock('../../hooks/useLLMProviders', () => ({
     useLLMProviders: () => ({
         providers: [{ name: 'openai', display: 'OpenAI', model: 'gpt-4', isDefault: false }],
         selectedProvider: 'openai',
-        selectedModel: 'gemini-flash-latest', // stale model left over from the previous provider
+        // Whilst the fetch is in flight the model is still the previous
+        // provider's; once it resolves the hook has replaced it with one
+        // the new provider actually advertises.
+        selectedModel: mockLoadingModels ? 'gemini-flash-latest' : 'gpt-4',
         setSelectedProvider: vi.fn(),
         models: mockLoadingModels ? [] : [{ name: 'gpt-4', description: '' }],
         setSelectedModel: vi.fn(),
@@ -164,7 +167,12 @@ describe('ChatInterface provider/model switch race', () => {
 
         // Whatever request went out was built with the provider/model
         // pairing the hook actually reports, never a mismatched leftover.
+        // Asserting the model matters as much as the provider: the bug
+        // being fixed sent the right provider with the wrong model, so a
+        // test that checks only the provider would pass on the very
+        // payload this PR exists to prevent.
         const [requestBody] = mockSseChat.mock.calls[0];
         expect(requestBody.provider).toBe('openai');
+        expect(requestBody.model).toBe('gpt-4');
     });
 });

--- a/web/src/components/__tests__/ChatInterface.providerRace.test.jsx
+++ b/web/src/components/__tests__/ChatInterface.providerRace.test.jsx
@@ -1,0 +1,170 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - ChatInterface Provider/Model Race Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockCallTool = vi.fn();
+const mockGetPrompt = vi.fn();
+const mockSseChat = vi.fn();
+
+vi.mock('../../contexts/AuthContext', () => ({
+    useAuth: () => ({ sessionToken: 'test-token', forceLogout: vi.fn() }),
+}));
+
+vi.mock('../../contexts/LLMProcessingContext', () => ({
+    useLLMProcessing: () => ({ setIsProcessing: vi.fn() }),
+}));
+
+vi.mock('../../contexts/DatabaseContext', () => ({
+    useDatabaseContext: () => ({
+        databases: [],
+        currentDatabase: null,
+        selectDatabase: vi.fn(),
+        fetchDatabases: vi.fn(),
+    }),
+}));
+
+vi.mock('../../contexts/ConversationActionsContext', () => ({
+    useConversationActions: () => ({ registerActions: vi.fn() }),
+}));
+
+vi.mock('../../hooks/useLocalStorage', () => ({
+    useLocalStorageBoolean: () => [false, vi.fn()],
+}));
+
+vi.mock('../../hooks/useQueryHistory', () => ({
+    useQueryHistory: () => ({
+        addToHistory: vi.fn(),
+        clearHistory: vi.fn(),
+        setHistory: vi.fn(),
+        navigateUp: (current) => current,
+        navigateDown: (current) => current,
+        isNavigating: false,
+        resetNavigation: vi.fn(),
+    }),
+}));
+
+vi.mock('../../hooks/useMCPClient', () => ({
+    useMCPClient: () => ({
+        mcpClient: { callTool: mockCallTool, getPrompt: mockGetPrompt },
+        tools: [{ name: 'query_database', inputSchema: {} }],
+        prompts: [{ name: 'test_prompt', arguments: [] }],
+        refreshTools: vi.fn(),
+    }),
+}));
+
+// The case under test: selectedProvider has already flipped to the newly
+// chosen provider, but its model list is still loading (loadingModels:
+// true) - the exact window in which a provider switch can be paired with
+// the *previous* provider's model.
+let mockLoadingModels = false;
+
+vi.mock('../../hooks/useLLMProviders', () => ({
+    useLLMProviders: () => ({
+        providers: [{ name: 'openai', display: 'OpenAI', model: 'gpt-4', isDefault: false }],
+        selectedProvider: 'openai',
+        selectedModel: 'gemini-flash-latest', // stale model left over from the previous provider
+        setSelectedProvider: vi.fn(),
+        models: mockLoadingModels ? [] : [{ name: 'gpt-4', description: '' }],
+        setSelectedModel: vi.fn(),
+        loadingProviders: false,
+        loadingModels: mockLoadingModels,
+        error: '',
+        restoreProviderAndModel: vi.fn(),
+    }),
+}));
+
+vi.mock('../../utils/sseChat', () => ({
+    sseChat: (...args) => mockSseChat(...args),
+}));
+
+vi.mock('../MessageList', () => ({
+    default: ({ messages }) => (
+        <div>
+            {messages.map((msg, index) => (
+                <div key={index} data-testid="message" data-role={msg.role}
+                    data-thinking={msg.isThinking ? 'true' : 'false'}>
+                    {typeof msg.content === 'string'
+                        ? msg.content
+                        : JSON.stringify(msg.content)}
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+vi.mock('../MessageInput', () => ({
+    default: ({ value, onChange, onSend, disabled }) => (
+        <div>
+            <textarea aria-label="prompt" value={value} onChange={onChange} disabled={disabled} />
+            <button type="button" onClick={onSend} disabled={disabled}>
+                Send
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock('../ProviderSelector', () => ({ default: () => null }));
+vi.mock('../PromptPopover', () => ({
+    default: ({ onExecute }) => (
+        <button type="button" onClick={() => onExecute('test_prompt', {})}>
+            Run prompt
+        </button>
+    ),
+}));
+vi.mock('../WriteQueryConfirmDialog', () => ({ default: () => null }));
+
+const ChatInterface = (await import('../ChatInterface')).default;
+
+describe('ChatInterface provider/model switch race', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLoadingModels = false;
+    });
+
+    it("blocks sending while the new provider's model list is still loading", async () => {
+        mockLoadingModels = true;
+        render(<ChatInterface />);
+
+        const textarea = screen.getByLabelText('prompt');
+        expect(textarea).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+
+        fireEvent.change(textarea, { target: { value: 'how many users are there?' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockSseChat).not.toHaveBeenCalled();
+    });
+
+    it('allows sending once the model list has finished loading', async () => {
+        mockLoadingModels = false;
+        mockSseChat.mockResolvedValue({
+            stop_reason: 'end_turn',
+            content: [{ type: 'text', text: 'done' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        });
+        render(<ChatInterface />);
+
+        const textarea = screen.getByLabelText('prompt');
+        expect(textarea).not.toBeDisabled();
+
+        fireEvent.change(textarea, { target: { value: 'how many users are there?' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+        await waitFor(() => expect(mockSseChat).toHaveBeenCalledTimes(1));
+
+        // Whatever request went out was built with the provider/model
+        // pairing the hook actually reports, never a mismatched leftover.
+        const [requestBody] = mockSseChat.mock.calls[0];
+        expect(requestBody.provider).toBe('openai');
+    });
+});

--- a/web/src/hooks/__tests__/useLLMProviders.test.js
+++ b/web/src/hooks/__tests__/useLLMProviders.test.js
@@ -8,8 +8,9 @@
  *-------------------------------------------------------------------------
  */
 
-import { describe, it, expect } from 'vitest';
-import { normaliseProviders } from '../useLLMProviders';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { normaliseProviders, useLLMProviders } from '../useLLMProviders';
 
 describe('normaliseProviders', () => {
     it('prefers the API display_name when present', () => {
@@ -27,5 +28,73 @@ describe('normaliseProviders', () => {
     it('capitalises unknown providers with no display_name', () => {
         const out = normaliseProviders([{ name: 'weird', model: 'x' }]);
         expect(out[0].display).toBe('Weird');
+    });
+});
+
+describe('useLLMProviders model list failures', () => {
+    // The providers fetch seeds selectedModel with the default
+    // provider's advertised model, so by the time the models fetch runs
+    // there is always a model in place that belongs to some provider.
+    // If that fetch then fails, sending is re-enabled regardless, and a
+    // model left over from the provider we switched away from would go
+    // out paired with the new one.
+    const providersPayload = {
+        providers: [{ name: 'openai', model: 'gpt-4', default: true }],
+        default_provider: 'openai',
+    };
+
+    const mockFetch = (modelsResponse) => {
+        globalThis.fetch = vi.fn((url) => {
+            if (String(url).includes('/v1/providers')) {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve(providersPayload),
+                });
+            }
+            return Promise.resolve(modelsResponse);
+        });
+    };
+
+    beforeEach(() => {
+        localStorage.clear();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        delete globalThis.fetch;
+        localStorage.clear();
+    });
+
+    it('clears the selected model when the model list fails to load', async () => {
+        mockFetch({
+            ok: false,
+            status: 500,
+            text: () => Promise.resolve('boom'),
+        });
+
+        const { result } = renderHook(() => useLLMProviders('test-token'));
+
+        await waitFor(() => expect(result.current.error).toContain('Failed to load models'));
+        await waitFor(() => expect(result.current.loadingModels).toBe(false));
+
+        // Without the clear, this holds the previous provider's 'gpt-4',
+        // seeded by the providers fetch, and sending is enabled again.
+        expect(result.current.selectedModel).toBe('');
+    });
+
+    it('clears the selected model when the provider advertises no models', async () => {
+        mockFetch({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ models: [] }),
+        });
+
+        const { result } = renderHook(() => useLLMProviders('test-token'));
+
+        await waitFor(() => expect(result.current.providers).toHaveLength(1));
+        await waitFor(() => expect(result.current.loadingModels).toBe(false));
+
+        expect(result.current.selectedModel).toBe('');
     });
 });

--- a/web/src/hooks/__tests__/useLLMProviders.test.js
+++ b/web/src/hooks/__tests__/useLLMProviders.test.js
@@ -56,13 +56,18 @@ describe('useLLMProviders model list failures', () => {
         });
     };
 
+    // Node and jsdom both supply a global fetch, so put the original
+    // back rather than deleting the property; other suites sharing this
+    // worker would otherwise find it missing.
+    const originalFetch = globalThis.fetch;
+
     beforeEach(() => {
         localStorage.clear();
         vi.clearAllMocks();
     });
 
     afterEach(() => {
-        delete globalThis.fetch;
+        globalThis.fetch = originalFetch;
         localStorage.clear();
     });
 

--- a/web/src/hooks/useLLMProviders.js
+++ b/web/src/hooks/useLLMProviders.js
@@ -398,6 +398,11 @@ export const useLLMProviders = (sessionToken) => {
                     }
                 } else {
                     console.warn('No models returned from API');
+                    // Nothing to select for this provider, so the model
+                    // left over from the previous one must not survive;
+                    // see the note on the catch below.
+                    usingFallbackModelRef.current = false;
+                    setSelectedModel('');
                 }
             } catch (err) {
                 if (err.name === 'AbortError') {
@@ -407,6 +412,16 @@ export const useLLMProviders = (sessionToken) => {
                 console.error('Error fetching models:', err);
                 setModels([]);
                 setError('Failed to load models. Please check browser console.');
+                // selectedModel still holds the model belonging to the
+                // provider we have just switched away from, and the
+                // finally below re-enables sending. Leaving it in place
+                // would let a request go out pairing the new provider
+                // with a model it never advertised, which is the same
+                // mismatch the loadingModels gate prevents whilst the
+                // fetch is in flight. Clearing it makes the proxy fall
+                // back to the provider's configured default instead.
+                usingFallbackModelRef.current = false;
+                setSelectedModel('');
             } finally {
                 // Only clear loading state if this effect run is still
                 // current. The newer run will manage its own loading


### PR DESCRIPTION
## Summary

Issue #245: switching LLM providers and sending a message immediately
afterwards can pair the new provider with the previous provider's model
name.

`useLLMProviders`'s model-list fetch is asynchronous — switching
`selectedProvider` triggers a re-fetch of that provider's model list, but
`selectedModel` is not cleared until the fetch resolves. Neither
`handleSend` nor `handlePromptExecute` in `ChatInterface.jsx` checked
`llmProviders.loadingModels`, and the message input/Send button were only
disabled via `loading` (mid-response), not during this window. A fast
switch followed immediately by a send goes out with the *new*
`selectedProvider` but the *old* provider's still-cached `selectedModel`.

Fix: gate both send handlers on `llmProviders.loadingModels`, and disable
the message input/Send button during that window, so the input can't be
used until the new provider's model list has actually resolved.

## Verification

- Live, twice: an automated scripted browser session switching providers
  and sending immediately (captured request payload:
  `{"provider": "openai", "model": "gemini-flash-latest"}`), and in normal
  manual use (OpenAI's `GPT-3.5-16K` selected, switched to Gemini, sent
  immediately — Gemini 404'd on `models/gpt-3.5-turbo-16k`, the OpenAI
  model name it received).
- With the fix applied, the same fast switch-and-send is blocked (input
  disabled) until the model list resolves, rather than sending a
  mismatched pair — verified live via the same scripted reproduction.
- New tests, mutation-tested: reverted the fix, confirmed the "blocks
  sending" test fails with the exact expected symptom (`not disabled`
  where it should be), restored, confirmed both new tests pass.
- Full web test suite: 213/213 passing.

## Test plan

- [x] New tests: blocks sending while `loadingModels` is true, allows
      sending (with the correct provider/model pairing) once resolved
- [x] Mutation-tested the fix
- [x] Live reproduction of both the bug and the fix
- [x] Full web suite: 213/213

Fixes #245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled chat input, Send, and prompt execution while models load after switching providers.
  * Prevented requests from using a newly selected provider with a previously selected model.
  * Re-enabled chat automatically once model loading completes.
  * Cleared unavailable model selections when loading fails or returns no models, allowing provider defaults to apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->