### PR TITLE
fix(config): resolve configuration the way the documentation describes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -118,6 +118,26 @@ and this project adheres to
 
 ### Fixed
 
+- A configuration file that sets an LLM or embedding option without also
+  naming the provider, or enabling the section, is no longer discarded.
+  The merge tested only those two fields, so a file that configured just a
+  base URL, a key, a key file, or a token limit was silently ignored and
+  the setting never took effect. Every field in both sections now merges
+  independently. The `enabled` flag is the one exception: a plain boolean
+  cannot distinguish an omitted setting from a false one, so, as elsewhere
+  in the merge, only a true is carried across, and a file that mentions
+  neither cannot switch off a section another source enabled. (#250)
+
+- The CLI client now lets environment variables override the
+  configuration file, which is what the documentation has always
+  described and what the server has always done. The client read the
+  environment into its defaults before parsing the file, so the file
+  quietly won instead, and the same variable resolved differently
+  depending on which of the two binaries read it. Settings resolve as
+  documented: command-line flags, then environment variables, then the
+  configuration file, then the built-in defaults. An unset or empty
+  variable still leaves a configured value alone. (#251)
+
 - Switching LLM providers and sending a message immediately afterwards no
   longer pairs the new provider with the previous provider's model. The
   model list for the newly selected provider refreshes asynchronously, but

--- a/internal/chat/config.go
+++ b/internal/chat/config.go
@@ -73,39 +73,78 @@ type UIConfig struct {
 	Debug                 bool `yaml:"debug"`                   // Display debug messages (e.g., LLM token usage)
 }
 
-// LoadConfig loads configuration from file, environment variables, and defaults
-func LoadConfig(configPath string) (*Config, error) {
-	cfg := &Config{
+// defaultConfig returns the configuration the client uses before anything
+// else is read. It holds literal defaults only: the configuration file is
+// merged over these, and the environment over that, so that the resolution
+// order is defaults, then file, then environment, then flags.
+func defaultConfig() *Config {
+	return &Config{
 		MCP: MCPConfig{
-			Mode:             getEnvOrDefault("PGEDGE_MCP_MODE", "stdio"),
-			URL:              os.Getenv("PGEDGE_MCP_URL"),
-			ServerPath:       getEnvOrDefault("PGEDGE_MCP_SERVER_PATH", "../../bin/pgedge-postgres-mcp"),
-			ServerConfigPath: getEnvOrDefault("PGEDGE_MCP_SERVER_CONFIG_PATH", ""),
-			AuthMode:         getEnvOrDefault("PGEDGE_MCP_AUTH_MODE", "user"),
-			Token:            "", // Will be loaded separately
-			Username:         os.Getenv("PGEDGE_MCP_USERNAME"),
-			Password:         os.Getenv("PGEDGE_MCP_PASSWORD"),
-			TLS:              false,
+			Mode:       "stdio",
+			ServerPath: "../../bin/pgedge-postgres-mcp",
+			AuthMode:   "user",
+			Token:      "", // Will be loaded separately
+			TLS:        false,
 		},
 		LLM: LLMConfig{
-			Provider:         getEnvOrDefault("PGEDGE_LLM_PROVIDER", "anthropic"),
-			Model:            getEnvOrDefault("PGEDGE_LLM_MODEL", "claude-sonnet-4-5-20250929"),
-			AnthropicAPIKey:  getEnvWithFallback("PGEDGE_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
-			AnthropicBaseURL: os.Getenv("PGEDGE_ANTHROPIC_BASE_URL"), // Empty string uses default
-			OpenAIAPIKey:     getEnvWithFallback("PGEDGE_OPENAI_API_KEY", "OPENAI_API_KEY"),
-			OpenAIBaseURL:    os.Getenv("PGEDGE_OPENAI_BASE_URL"), // Empty string uses default
-			GeminiAPIKey:     getEnvWithFallback("PGEDGE_GEMINI_API_KEY", "GEMINI_API_KEY"),
-			GeminiBaseURL:    os.Getenv("PGEDGE_GEMINI_BASE_URL"), // Empty string uses default
-			OllamaURL:        getEnvOrDefault("PGEDGE_OLLAMA_URL", "http://localhost:11434"),
-			MaxTokens:        4096,
+			Provider:  "anthropic",
+			Model:     "claude-sonnet-4-5-20250929",
+			OllamaURL: "http://localhost:11434",
+			MaxTokens: 4096,
 		},
 		UI: UIConfig{
-			NoColor:               os.Getenv("NO_COLOR") != "",
 			DisplayStatusMessages: true, // Default to showing status messages
 			RenderMarkdown:        true, // Default to rendering markdown
 		},
 		HistoryFile: filepath.Join(os.Getenv("HOME"), ".pgedge-nla-cli-history"),
 	}
+}
+
+// applyEnvironmentVariables overrides the configuration with any variables
+// that are set, and is called after the configuration file has been read so
+// that the environment wins, as it does on the server.
+//
+// An unset or empty variable changes nothing, which is what lets a value in
+// the file survive; there is deliberately no way to blank a configured
+// setting by exporting an empty variable.
+func applyEnvironmentVariables(cfg *Config) {
+	setStringFromEnv(&cfg.MCP.Mode, "PGEDGE_MCP_MODE")
+	setStringFromEnv(&cfg.MCP.URL, "PGEDGE_MCP_URL")
+	setStringFromEnv(&cfg.MCP.ServerPath, "PGEDGE_MCP_SERVER_PATH")
+	setStringFromEnv(&cfg.MCP.ServerConfigPath, "PGEDGE_MCP_SERVER_CONFIG_PATH")
+	setStringFromEnv(&cfg.MCP.AuthMode, "PGEDGE_MCP_AUTH_MODE")
+	setStringFromEnv(&cfg.MCP.Username, "PGEDGE_MCP_USERNAME")
+	setStringFromEnv(&cfg.MCP.Password, "PGEDGE_MCP_PASSWORD")
+
+	setStringFromEnv(&cfg.LLM.Provider, "PGEDGE_LLM_PROVIDER")
+	setStringFromEnv(&cfg.LLM.Model, "PGEDGE_LLM_MODEL")
+	setStringFromEnv(&cfg.LLM.AnthropicAPIKey, "PGEDGE_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY")
+	setStringFromEnv(&cfg.LLM.AnthropicBaseURL, "PGEDGE_ANTHROPIC_BASE_URL")
+	setStringFromEnv(&cfg.LLM.OpenAIAPIKey, "PGEDGE_OPENAI_API_KEY", "OPENAI_API_KEY")
+	setStringFromEnv(&cfg.LLM.OpenAIBaseURL, "PGEDGE_OPENAI_BASE_URL")
+	setStringFromEnv(&cfg.LLM.GeminiAPIKey, "PGEDGE_GEMINI_API_KEY", "GEMINI_API_KEY")
+	setStringFromEnv(&cfg.LLM.GeminiBaseURL, "PGEDGE_GEMINI_BASE_URL")
+	setStringFromEnv(&cfg.LLM.OllamaURL, "PGEDGE_OLLAMA_URL")
+
+	// NO_COLOR follows the convention that any non-empty value disables
+	// colour; it can turn colour off but never back on, so no_color in the
+	// configuration file still stands when the variable is absent.
+	if os.Getenv("NO_COLOR") != "" {
+		cfg.UI.NoColor = true
+	}
+}
+
+// setStringFromEnv assigns the first of the named environment variables that
+// is set and non-empty, and leaves the destination alone when none is.
+func setStringFromEnv(dest *string, keys ...string) {
+	if value := getEnvWithFallback(keys...); value != "" {
+		*dest = value
+	}
+}
+
+// LoadConfig loads configuration from file, environment variables, and defaults
+func LoadConfig(configPath string) (*Config, error) {
+	cfg := defaultConfig()
 
 	// Load from config file if provided
 	if configPath != "" {
@@ -127,6 +166,13 @@ func LoadConfig(configPath string) (*Config, error) {
 			}
 		}
 	}
+
+	// Environment variables override the configuration file, matching the
+	// server. They used to seed the defaults instead, before the file was
+	// read, which meant a value in the file quietly beat an exported
+	// variable, the opposite of what the server did with the same variable
+	// names and of what the key priority below has always documented.
+	applyEnvironmentVariables(cfg)
 
 	// API key loading priority: env vars > api_key_file > direct config value
 	// Environment variables were already loaded above, now check for API key files
@@ -299,14 +345,6 @@ func (c *Config) GetConfiguredProviders() []string {
 		providers = append(providers, "ollama")
 	}
 	return providers
-}
-
-// getEnvOrDefault returns the environment variable value or default
-func getEnvOrDefault(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
 }
 
 // getEnvWithFallback checks multiple environment variable names in priority order

--- a/internal/chat/config_test.go
+++ b/internal/chat/config_test.go
@@ -400,6 +400,99 @@ func TestLoadConfig_GeminiEmbeddingBaseURLIgnored(t *testing.T) {
 	}
 }
 
+// The environment must beat the configuration file, as it does on the
+// server. The client used to read the environment into its defaults before
+// the file was parsed, so the file quietly won instead, which meant the same
+// variable resolved differently depending on which binary read it.
+func TestLoadConfig_EnvironmentBeatsTheFile(t *testing.T) {
+	t.Setenv("PGEDGE_GEMINI_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test-config.yaml")
+	configContent := "" +
+		"mcp:\n" +
+		"  mode: http\n" +
+		"llm:\n" +
+		"  provider: openai\n" +
+		"  model: gpt-4o\n" +
+		"  gemini_base_url: https://file.example.com\n" +
+		"  ollama_url: http://file.example.com:11434\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	t.Setenv("PGEDGE_MCP_MODE", "stdio")
+	t.Setenv("PGEDGE_LLM_PROVIDER", "gemini")
+	t.Setenv("PGEDGE_LLM_MODEL", "gemini-2.5-flash")
+	t.Setenv("PGEDGE_GEMINI_BASE_URL", "https://env.example.com")
+	t.Setenv("PGEDGE_OLLAMA_URL", "http://env.example.com:11434")
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"MCP.Mode", cfg.MCP.Mode, "stdio"},
+		{"LLM.Provider", cfg.LLM.Provider, "gemini"},
+		{"LLM.Model", cfg.LLM.Model, "gemini-2.5-flash"},
+		{"LLM.GeminiBaseURL", cfg.LLM.GeminiBaseURL, "https://env.example.com"},
+		{"LLM.OllamaURL", cfg.LLM.OllamaURL, "http://env.example.com:11434"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want the environment value %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+// An absent variable must leave the file's value in place, which is what
+// stops the environment pass from flattening a configuration back to the
+// defaults.
+func TestLoadConfig_FileSurvivesAnAbsentEnvironment(t *testing.T) {
+	for _, key := range []string{
+		"PGEDGE_MCP_MODE", "PGEDGE_LLM_PROVIDER", "PGEDGE_LLM_MODEL",
+		"PGEDGE_GEMINI_BASE_URL", "PGEDGE_OLLAMA_URL",
+	} {
+		t.Setenv(key, "")
+	}
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test-config.yaml")
+	configContent := "" +
+		"llm:\n" +
+		"  provider: openai\n" +
+		"  model: gpt-4o\n" +
+		"  gemini_base_url: https://file.example.com\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if cfg.LLM.Provider != "openai" {
+		t.Errorf("LLM.Provider = %q, want the file value", cfg.LLM.Provider)
+	}
+	if cfg.LLM.Model != "gpt-4o" {
+		t.Errorf("LLM.Model = %q, want the file value", cfg.LLM.Model)
+	}
+	if cfg.LLM.GeminiBaseURL != "https://file.example.com" {
+		t.Errorf("LLM.GeminiBaseURL = %q, want the file value", cfg.LLM.GeminiBaseURL)
+	}
+	// Untouched by either source, so still the built-in default.
+	if cfg.LLM.OllamaURL != "http://localhost:11434" {
+		t.Errorf("LLM.OllamaURL = %q, want the default", cfg.LLM.OllamaURL)
+	}
+}
+
 func TestLoadConfig_GeminiAPIKeyFromFile(t *testing.T) {
 	t.Setenv("PGEDGE_GEMINI_API_KEY", "")
 	t.Setenv("GEMINI_API_KEY", "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -738,6 +738,21 @@ func loadConfigFile(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// llmSectionSet reports whether a configuration source says anything at all
+// about the LLM. Comparing against the zero value rather than naming
+// individual fields means a field added later is covered without anyone
+// having to remember to extend this, which is how the section came to drop
+// sources that set only a base URL or a key file.
+func llmSectionSet(c *LLMConfig) bool {
+	return *c != LLMConfig{}
+}
+
+// embeddingSectionSet reports whether a configuration source says anything at
+// all about embeddings, on the same terms as llmSectionSet.
+func embeddingSectionSet(c *EmbeddingConfig) bool {
+	return *c != EmbeddingConfig{}
+}
+
 // mergeConfig merges source config into dest, only overriding non-zero values
 func mergeConfig(dest, src *Config) {
 	// HTTP
@@ -801,9 +816,13 @@ func mergeConfig(dest, src *Config) {
 		dest.Databases = src.Databases
 	}
 
-	// Embedding - merge if any embedding fields are set
-	if src.Embedding.Provider != "" || src.Embedding.Enabled {
-		dest.Embedding.Enabled = src.Embedding.Enabled
+	// Embedding - merged on the same terms as the LLM section below, and
+	// for the same reason: a source setting only a key file or a base URL
+	// was being thrown away.
+	if embeddingSectionSet(&src.Embedding) {
+		if src.Embedding.Enabled {
+			dest.Embedding.Enabled = src.Embedding.Enabled
+		}
 		if src.Embedding.Provider != "" {
 			dest.Embedding.Provider = src.Embedding.Provider
 		}
@@ -845,9 +864,18 @@ func mergeConfig(dest, src *Config) {
 		}
 	}
 
-	// LLM - merge if any LLM fields are set
-	if src.LLM.Provider != "" || src.LLM.Enabled {
-		dest.LLM.Enabled = src.LLM.Enabled
+	// LLM - merge when the section carries anything at all. Testing only
+	// the provider and the enabled flag dropped a source that set just one
+	// subordinate field, so a configuration naming only, say, a base URL or
+	// a key file was silently discarded.
+	if llmSectionSet(&src.LLM) {
+		// A bool cannot distinguish "absent" from "false", so only a true
+		// propagates, as with every other bool in this function. Merging
+		// it unconditionally would let a source that sets nothing but a
+		// base URL switch off an LLM another source had enabled.
+		if src.LLM.Enabled {
+			dest.LLM.Enabled = src.LLM.Enabled
+		}
 		if src.LLM.Provider != "" {
 			dest.LLM.Provider = src.LLM.Provider
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -854,6 +854,110 @@ func TestMergePerAttemptTimeout(t *testing.T) {
 	}
 }
 
+// A configuration source is free to set a single subordinate field and say
+// nothing about the provider or the enabled flag. Gating the section on those
+// two alone discarded the whole source, so a file that named only a base URL
+// or a key file was silently ignored.
+func TestMergeLLMSectionWithoutProviderOrEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		src  LLMConfig
+		want func(*testing.T, *LLMConfig)
+	}{
+		{
+			name: "base URL alone",
+			src:  LLMConfig{GeminiBaseURL: "https://gemini.proxy.example.com"},
+			want: func(t *testing.T, got *LLMConfig) {
+				if got.GeminiBaseURL != "https://gemini.proxy.example.com" {
+					t.Errorf("LLM.GeminiBaseURL = %q, want the merged value", got.GeminiBaseURL)
+				}
+			},
+		},
+		{
+			name: "key file alone",
+			src:  LLMConfig{AnthropicAPIKeyFile: "/etc/pgedge/anthropic.key"},
+			want: func(t *testing.T, got *LLMConfig) {
+				if got.AnthropicAPIKeyFile != "/etc/pgedge/anthropic.key" {
+					t.Errorf("LLM.AnthropicAPIKeyFile = %q, want the merged value", got.AnthropicAPIKeyFile)
+				}
+			},
+		},
+		{
+			name: "max tokens alone",
+			src:  LLMConfig{MaxTokens: 8192},
+			want: func(t *testing.T, got *LLMConfig) {
+				if got.MaxTokens != 8192 {
+					t.Errorf("LLM.MaxTokens = %d, want the merged value", got.MaxTokens)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dest := defaultConfig()
+			mergeConfig(dest, &Config{LLM: tc.src})
+			tc.want(t, &dest.LLM)
+		})
+	}
+}
+
+// The enabled flag is a plain bool, so an omitted one is indistinguishable
+// from an explicit false. Now that a source setting only a subordinate field
+// merges at all, copying the flag unconditionally would let such a source
+// switch off an LLM that another source had turned on.
+func TestMergeLLMEnabledSurvivesASubordinateOnlySource(t *testing.T) {
+	dest := defaultConfig()
+	dest.LLM.Enabled = true
+	dest.LLM.Provider = "anthropic"
+
+	mergeConfig(dest, &Config{LLM: LLMConfig{GeminiBaseURL: "https://gemini.proxy.example.com"}})
+
+	if !dest.LLM.Enabled {
+		t.Error("LLM.Enabled = false, want it left enabled by a source that says nothing about it")
+	}
+	if dest.LLM.Provider != "anthropic" {
+		t.Errorf("LLM.Provider = %q, want it left alone", dest.LLM.Provider)
+	}
+	if dest.LLM.GeminiBaseURL != "https://gemini.proxy.example.com" {
+		t.Errorf("LLM.GeminiBaseURL = %q, want the merged value", dest.LLM.GeminiBaseURL)
+	}
+}
+
+// The embedding section carried the identical guard, so it merges on the same
+// terms and needs the same two guarantees.
+func TestMergeEmbeddingSectionWithoutProviderOrEnabled(t *testing.T) {
+	dest := defaultConfig()
+	dest.Embedding.Enabled = true
+
+	mergeConfig(dest, &Config{Embedding: EmbeddingConfig{
+		GeminiBaseURL: "https://embed.proxy.example.com",
+	}})
+
+	if dest.Embedding.GeminiBaseURL != "https://embed.proxy.example.com" {
+		t.Errorf("Embedding.GeminiBaseURL = %q, want the merged value", dest.Embedding.GeminiBaseURL)
+	}
+	if !dest.Embedding.Enabled {
+		t.Error("Embedding.Enabled = false, want it left enabled by a source that says nothing about it")
+	}
+}
+
+// An entirely empty source must still change nothing, which is what stops the
+// relaxed guard from turning every merge into a full overwrite.
+func TestMergeEmptySourceLeavesTheConfigurationAlone(t *testing.T) {
+	dest := defaultConfig()
+	dest.LLM.Enabled = true
+	dest.LLM.Provider = "openai"
+	dest.LLM.MaxTokens = 1234
+	before := dest.LLM
+
+	mergeConfig(dest, &Config{})
+
+	if dest.LLM != before {
+		t.Errorf("LLM = %+v after an empty merge, want it unchanged at %+v", dest.LLM, before)
+	}
+}
+
 func TestMergeLLMBaseURLs(t *testing.T) {
 	dest := defaultConfig()
 	src := &Config{


### PR DESCRIPTION
## Summary

Two configuration-resolution bugs found whilst reviewing #249, both raised
by CodeRabbit there and deliberately deferred because each needed a
behavioural change with its own tests rather than riding along in a
credential tidy. They are together in one PR because they are the same
subsystem and would otherwise conflict in the changelog; stacking two
dependent PRs is what produced the #243/#249 tangle.

**A configuration section that names no provider was discarded (#250).**
`mergeConfig` gated the LLM and embedding blocks on the provider or the
enabled flag being set, so a file carrying only a subordinate field was
parsed and then silently thrown away:

```yaml
llm:
    gemini_base_url: "https://gemini-proxy.internal.example.com"
```

with the provider coming from `PGEDGE_LLM_PROVIDER`, this reached the
public endpoint with no warning. Every field in both sections now merges
independently, decided by comparing the section against its zero value so
that a field added later is covered automatically, which is exactly how
the guard fell out of date.

The `enabled` flag needs the opposite treatment, as CodeRabbit noted: it
is a plain bool, so an omitted setting cannot be told from an explicit
false, and copying it unconditionally once the guard relaxed would let a
source setting only a base URL switch off an LLM another source enabled.
It now follows the same rule as every other bool in that function, where
only a true propagates. Both sections default to `false` and there is a
single merge, so the resolved behaviour is unchanged.

**The CLI and the server disagreed on precedence (#251).** The client read
the environment into its defaults *before* parsing the file, so the file
beat an exported variable; the server applies the environment after the
merge, so it wins. The same variable resolved differently depending on
which binary read it.

The documentation settles which one was wrong: `docs/guide/configuration.md`
has always listed flags, then environment variables, then the file, then
defaults, explicitly for the Natural Language Agent as well as the server,
and `docs/guide/cli-client.md` says the same. The loader's own comment,
"API key loading priority: env vars > api_key_file > direct config value",
described an intent the surrounding code honoured only for keys. So this
brings the code into line with its contract rather than changing policy,
and no documentation needed updating.

Literal defaults now live in `defaultConfig`, the file is read over them,
and `applyEnvironmentVariables` runs afterwards. An unset or empty variable
changes nothing, so a configured value still stands. `NO_COLOR` keeps its
convention of disabling colour when non-empty and never re-enabling it.
`getEnvOrDefault` had no callers left and has gone.

## Compatibility

The precedence change is user-visible: anyone currently relying on a file
value to override an exported variable in the CLI will see the variable win
after this. That is the documented behaviour and matches the server, but it
is worth calling out in the release notes.

## Verification

Both fixes mutation-tested, each against its own tests:

- Restoring the narrow merge guard fails the four new subordinate-field
  tests; making the `enabled` copy unconditional fails the test pinning the
  flag's survival, and nothing else.
- Moving the environment pass back before the file load fails the new
  precedence test on all five settings it covers, reproducing exactly the
  symptom in #251.

`make test-server` and `make test-client` green, `make lint` 0 issues,
`gofmt` clean.

Closes #250
Closes #251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration merging so LLM and embedding settings update independently, including API keys, key files, URLs, and token limits.
  * Preserved existing provider and enabled settings when omitted from updates.
  * Corrected configuration precedence: command-line flags, environment variables, configuration files, then defaults.
  * Ignored empty environment variables so they no longer override valid settings.
  * Ensured environment settings such as `NO_COLOR` are applied consistently.

* **Tests**
  * Added coverage for configuration precedence and partial configuration merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->