### PR TITLE
style: repair the copyright headers and test that they stay repaired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test: test-server test-client test-web
 # covered by test-client, so they are deliberately absent rather than missing.
 test-server:
 	@echo "Running server tests..."
-	$(GO) test -v ./internal/api/... ./internal/auth/... ./internal/compactor/... ./internal/config/... ./internal/conversations/... ./internal/crypto/... ./internal/database/... ./internal/definitions/... ./internal/httperror/... ./internal/llmtracing/... ./internal/logging/... ./internal/mcp/... ./internal/openapi/... ./internal/prompts/... ./internal/redact/... ./internal/resources/... ./internal/search/... ./internal/sqltext/... ./internal/tools/... ./internal/tracing/... ./internal/tsv/... ./$(SERVER_CMD_DIR)/...
+	$(GO) test -v ./internal/api/... ./internal/auth/... ./internal/compactor/... ./internal/config/... ./internal/conversations/... ./internal/crypto/... ./internal/database/... ./internal/definitions/... ./internal/httperror/... ./internal/llmtracing/... ./internal/logging/... ./internal/mcp/... ./internal/openapi/... ./internal/prompts/... ./internal/redact/... ./internal/resources/... ./internal/search/... ./internal/sourceheader/... ./internal/sqltext/... ./internal/tools/... ./internal/tracing/... ./internal/tsv/... ./$(SERVER_CMD_DIR)/...
 
 # Run client tests
 test-client:

--- a/common/build.sh
+++ b/common/build.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Build Bridge Wrapper
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 # Bridge wrapper: pgedge-builder-action hardcodes
 # `cd /build && bash ./common/build.sh $COMPONENT_NAME`. Our packaging lives
 # under pkg/, so delegate to the real entrypoint there. The shared

--- a/docker/init-server.sh
+++ b/docker/init-server.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Docker Initialization Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -e
 
 # Redirect init script output to stderr. In stdio mode, stdout is the MCP

--- a/examples/claude-try-it/install.ps1
+++ b/examples/claude-try-it/install.ps1
@@ -1,3 +1,12 @@
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Server — One-Command Installer for Windows
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 # pgEdge MCP Server — one-command installer for Windows
 #
 # Usage (interactive, in PowerShell):

--- a/examples/claude-try-it/install.sh
+++ b/examples/claude-try-it/install.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Server — One-Command Installer
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 # pgEdge MCP Server — one-command installer
 #
 # Usage (interactive, in a terminal):

--- a/examples/codespaces-demo/start.sh
+++ b/examples/codespaces-demo/start.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Server Codespaces Demo Startup Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 # Starts the pgEdge MCP Server Codespaces demo.
 #
 # Usage (from repo root):

--- a/examples/http-ollama-chatbot/chatbot.py
+++ b/examples/http-ollama-chatbot/chatbot.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Chatbot Client (HTTP + Ollama)
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 """
 pgEdge Postgres MCP Chatbot Client (HTTP + Ollama)
 

--- a/examples/quickstart-demo/pgedge-ait-demo.sh
+++ b/examples/quickstart-demo/pgedge-ait-demo.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Quickstart Demo Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -eu
 
 # ----------------------------

--- a/examples/stdio-anthropic-chatbot/chatbot.py
+++ b/examples/stdio-anthropic-chatbot/chatbot.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Chatbot Client (Stdio + Anthropic Claude)
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 """
 pgEdge Postgres MCP Chatbot Client (Stdio + Anthropic Claude)
 

--- a/internal/chat/commands.go
+++ b/internal/chat/commands.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/commands_test.go
+++ b/internal/chat/commands_test.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/config.go
+++ b/internal/chat/config.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/config_test.go
+++ b/internal/chat/config_test.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/conversations.go
+++ b/internal/chat/conversations.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/mcp_client.go
+++ b/internal/chat/mcp_client.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/mcp_client_test.go
+++ b/internal/chat/mcp_client_test.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/preferences.go
+++ b/internal/chat/preferences.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/ui_darwin.go
+++ b/internal/chat/ui_darwin.go
@@ -1,5 +1,15 @@
 //go:build darwin
 
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
 package chat
 
 import (

--- a/internal/chat/ui_linux.go
+++ b/internal/chat/ui_linux.go
@@ -1,5 +1,15 @@
 //go:build linux
 
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
 package chat
 
 import (

--- a/internal/chat/ui_test.go
+++ b/internal/chat/ui_test.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package chat
 

--- a/internal/chat/ui_unix.go
+++ b/internal/chat/ui_unix.go
@@ -1,5 +1,15 @@
 //go:build !windows
 
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
 package chat
 
 import (

--- a/internal/chat/ui_windows.go
+++ b/internal/chat/ui_windows.go
@@ -1,5 +1,15 @@
 //go:build windows
 
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
 package chat
 
 import (

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package logging
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package logging
 

--- a/internal/prompts/registry_test.go
+++ b/internal/prompts/registry_test.go
@@ -1,12 +1,12 @@
 /*-------------------------------------------------------------------------
-*
+ *
  * pgEdge Natural Language Agent
-*
-* Copyright (c) 2025 - 2026, pgEdge, Inc.
-* This software is released under The PostgreSQL License
-*
-*-------------------------------------------------------------------------
-*/
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
 
 package prompts
 

--- a/internal/sourceheader/sourceheader_test.go
+++ b/internal/sourceheader/sourceheader_test.go
@@ -14,6 +14,14 @@
 // misaligned header is caught here rather than noticed by eye some releases
 // later. Twelve files had drifted to an unaligned banner and four had no
 // notice at all before this test was written.
+//
+// The original pass covered only Go and JavaScript. A follow-up review found
+// the same gap in eighteen more files the extension list did not reach at
+// all: shell scripts, the two example chatbots' Python, the Windows
+// installer's PowerShell, and four Debian maintainer scripts named by
+// suffix rather than a conventional extension. All eighteen got the notice
+// and their languages joined checkedExtensions below, on the same reasoning
+// as the original fix: a gap nothing enforces is a gap that reopens.
 package sourceheader
 
 import (
@@ -36,9 +44,14 @@ const (
 	licenceLine   = "This software is released under The PostgreSQL License"
 )
 
-// checkedExtensions are the source languages the rule covers.
+// checkedExtensions are the source languages the rule covers. The Debian
+// maintainer scripts are named "<package>.preinst" and so on rather than
+// carrying a language extension, but filepath.Ext still isolates the
+// suffix correctly, so they need no special-casing beyond being listed here.
 var checkedExtensions = map[string]bool{
 	".go": true, ".js": true, ".jsx": true, ".mjs": true,
+	".sh": true, ".py": true, ".ps1": true,
+	".preinst": true, ".postinst": true, ".prerm": true, ".postrm": true,
 }
 
 // skippedDirs are not ours to head: dependencies, build output, and anything

--- a/internal/sourceheader/sourceheader_test.go
+++ b/internal/sourceheader/sourceheader_test.go
@@ -1,0 +1,191 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+// Package sourceheader carries no code. It exists for the test below, which
+// checks that every source file in the repository carries the copyright
+// notice the project requires, in the shape it requires, so that a missing or
+// misaligned header is caught here rather than noticed by eye some releases
+// later. Twelve files had drifted to an unaligned banner and four had no
+// notice at all before this test was written.
+package sourceheader
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// headerLines is how far into a file the notice must appear. It is generous
+// because a banner may legitimately carry other content first, such as the
+// usage text in web/scripts/take-screenshots.js.
+const headerLines = 30
+
+// copyrightLine and licenceLine are the two statements every source file must
+// make. The year range is deliberately not matched, so that a file's own range
+// need not be edited here.
+const (
+	copyrightLine = "Copyright (c)"
+	licenceLine   = "This software is released under The PostgreSQL License"
+)
+
+// checkedExtensions are the source languages the rule covers.
+var checkedExtensions = map[string]bool{
+	".go": true, ".js": true, ".jsx": true, ".mjs": true,
+}
+
+// skippedDirs are not ours to head: dependencies, build output, and anything
+// in a dot-directory, which covers the git metadata and any worktrees kept
+// inside the repository.
+var skippedDirs = map[string]bool{
+	"node_modules": true, "vendor": true, "bin": true, "dist": true,
+	"third_party": true, "coverage": true,
+}
+
+// exemptFiles are configuration rather than source, which the rule excludes.
+// Keep this list short, and prefer heading a file to exempting it.
+var exemptFiles = map[string]bool{
+	"web/vite.config.js":     true,
+	"web/vitest.config.js":   true,
+	"web/eslint.config.js":   true,
+	"web/postcss.config.js":  true,
+	"web/tailwind.config.js": true,
+}
+
+// repoRoot walks up from the test's working directory to the directory holding
+// go.mod, so the test does not care where it is run from.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to determine the working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("Failed to find go.mod above the working directory")
+		}
+		dir = parent
+	}
+}
+
+// sourceFiles returns every file the header rule applies to, as paths relative
+// to the repository root and using forward slashes.
+func sourceFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var found []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		name := info.Name()
+		if info.IsDir() {
+			if skippedDirs[name] || (strings.HasPrefix(name, ".") && path != root) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !checkedExtensions[filepath.Ext(name)] || strings.HasSuffix(name, ".pb.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if exemptFiles[rel] {
+			return nil
+		}
+		found = append(found, rel)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to walk %s: %v", root, err)
+	}
+	return found
+}
+
+// TestEverySourceFileCarriesTheNotice checks the notice is present. A file may
+// use either the /* */ banner or // line comments, since the required style
+// follows the language, but it must say both things.
+func TestEverySourceFileCarriesTheNotice(t *testing.T) {
+	root := repoRoot(t)
+	files := sourceFiles(t, root)
+	if len(files) == 0 {
+		t.Fatal("Found no source files to check, so the walk is wrong")
+	}
+
+	for _, rel := range files {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Errorf("%s: failed to read: %v", rel, err)
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		if len(lines) > headerLines {
+			lines = lines[:headerLines]
+		}
+		head := strings.Join(lines, "\n")
+		if !strings.Contains(head, copyrightLine) {
+			t.Errorf("%s: no %q in the first %d lines; add the project header",
+				rel, copyrightLine, headerLines)
+		}
+		if !strings.Contains(head, licenceLine) {
+			t.Errorf("%s: no licence line in the first %d lines; add the project header",
+				rel, headerLines)
+		}
+	}
+}
+
+// TestBannerHeadersAreAligned checks the shape of the /* */ form. Every line
+// inside the banner has to start with " *", which is what drifted: a header
+// whose continuation lines begin at column one still compiles, and gofmt has
+// no opinion on it, so nothing else catches it.
+func TestBannerHeadersAreAligned(t *testing.T) {
+	root := repoRoot(t)
+
+	for _, rel := range sourceFiles(t, root) {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Errorf("%s: failed to read: %v", rel, err)
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+
+		// Find the banner, which may sit below a build constraint.
+		start := -1
+		for i, line := range lines {
+			if i >= headerLines {
+				break
+			}
+			if strings.HasPrefix(line, "/*---") {
+				start = i
+				break
+			}
+		}
+		if start == -1 {
+			continue // Not the banner form; the notice test still applies.
+		}
+
+		for i := start + 1; i < len(lines); i++ {
+			line := lines[i]
+			if !strings.HasPrefix(line, " *") {
+				t.Errorf("%s:%d: banner line must start with \" *\", got %q",
+					rel, i+1, line)
+			}
+			if strings.HasSuffix(strings.TrimSpace(line), "*/") {
+				break
+			}
+		}
+	}
+}

--- a/pkg/build-deb.sh
+++ b/pkg/build-deb.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Debian Packaging Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -euo pipefail
 
 # Environment variables

--- a/pkg/build-rpm.sh
+++ b/pkg/build-rpm.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP RPM Packaging Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -euo pipefail
 
 RHEL="$(rpm --eval %rhel)"

--- a/pkg/common.sh
+++ b/pkg/common.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Packaging Environment
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 # common.sh - packaging environment for pgedge-postgres-mcp.
 #
 # Sourced by pkg/scripts/build.sh (via the common/build.sh bridge wrapper)

--- a/pkg/deb/debian/pgedge-nla-web.postinst
+++ b/pkg/deb/debian/pgedge-nla-web.postinst
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Web Package Post-Install Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -e
 
 case "$1" in

--- a/pkg/deb/debian/pgedge-nla-web.preinst
+++ b/pkg/deb/debian/pgedge-nla-web.preinst
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Web Package Pre-Install Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -e
 
 case "$1" in

--- a/pkg/deb/debian/pgedge-nla-web.prerm
+++ b/pkg/deb/debian/pgedge-nla-web.prerm
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Web Package Pre-Remove Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -e
 
 case "$1" in

--- a/pkg/deb/debian/pgedge-postgres-mcp.preinst
+++ b/pkg/deb/debian/pgedge-postgres-mcp.preinst
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Server Package Pre-Install Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -e
 
 case "$1" in

--- a/pkg/scripts/build.sh
+++ b/pkg/scripts/build.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Packaging Build Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 set -euo pipefail
 
 COMPONENT_NAME=$1

--- a/pkg/scripts/common-functions.sh
+++ b/pkg/scripts/common-functions.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP Packaging Common Functions
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 install_syft(){
 
   echo "Installing syft ..."

--- a/test-goreleaser.sh
+++ b/test-goreleaser.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+#--------------------------------------------------------------------------
+#
+# pgEdge MCP GoReleaser Test Script
+#
+# Copyright (c) 2025 - 2026, pgEdge, Inc.
+# This software is released under The PostgreSQL License
+#
+#--------------------------------------------------------------------------
+
 # Test script for GoReleaser configuration
 # This script tests the GoReleaser build locally without creating a release
 


### PR DESCRIPTION
## Summary

Repairs the copyright headers that had drifted out of shape, and adds a test
so they cannot drift again.

**Sixteen files were wrong.** Twelve carried the banner with its continuation
lines starting at column one instead of `" *"`:

```
/*-------------------------------------------------------------------------
*
 * pgEdge Natural Language Agent
*
* Copyright (c) 2025 - 2026, pgEdge, Inc.
```

All twelve share the identical pattern, including a correctly aligned title
line, which points at a single copy-pasted original rather than gradual decay.
The other four, the platform-specific `internal/chat/ui_*.go` files, had no
notice at all.

**Nothing was ever going to catch it.** A misaligned banner compiles, the
linter has no rule for it, and `gofmt` has no opinion on the interior of a
top-level block comment. I had guessed `gofmt` was the culprit; it is not, and
it accepts the corrected form unchanged, so this will not revert on the next
format run.

So the second commit adds two tests that walk the repository:

- every Go and JavaScript source file must carry the copyright and licence
  lines within its first thirty lines, accepting either the `/* */` banner or
  `//` line comments, since the required style follows the language; and
- every line inside a banner must start with `" *"`, which is the specific
  drift that happened.

Both report the file and line. Dependencies, build output, dot-directories and
generated `.pb.go` files are skipped, and the few genuine configuration files
are exempt by name, which the standing instructions already carve out. The walk
fails if it matches nothing, so a broken skip rule cannot turn the check into a
silent no-op.

## Notes on scope

Three files in `internal/chat` state the notice with `//` line comments rather
than the banner. They are left alone: the substance is present and the standing
instructions ask for the comment style to follow the language, so changing them
would be churn with no defect behind it. The test accepts both forms.

`web/scripts/take-screenshots.js` looked non-compliant on a first pass but is
not; its notice sits below the usage text, at lines 17-18, which is why the
presence check allows thirty lines rather than ten.

`web/vite.config.js` and its siblings are configuration, which the standing
instructions exclude, so they are exempt by name.

No changelog entry: nothing here is user-visible.

## Verification

- Cross-compiled for `linux`, `darwin` and `windows`, since the four newly
  headed files are build-constrained and the header had to go on the correct
  side of `//go:build`. All three build.
- The header commit changes comment lines only: 84 insertions, 84 deletions,
  and the diff contains no non-comment line.
- Mutation-tested the new tests both ways: re-mangling one header fails the
  alignment test with the file and line named, and stripping a notice fails the
  presence test.
- `make test-server`, `make test-client` and `make lint` all clean, `gofmt`
  reports nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized copyright and PostgreSQL License headers across source files, scripts, examples, and platform-specific components.
  * Improved consistency and clarity of project ownership and licensing information.

* **Tests**
  * Added automated checks to verify required notices across supported source files.
  * Added validation for consistent formatting and alignment of banner-style headers.
  * Included source-header verification in server test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->