### PR TITLE
fix(web): explain that a chosen model cannot be used for chat

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -138,6 +138,21 @@ and this project adheres to
   configuration file, then the built-in defaults. An unset or empty
   variable still leaves a configured value alone. (#251)
 
+- Choosing a model that cannot hold a conversation now says so. A
+  provider's model list is not confined to chat models; Gemini advertises
+  text-to-speech, image, music and agent models alongside the
+  conversational ones, and they cannot be told apart from the metadata,
+  because all of them report `generateContent` and the API describes no
+  multi-turn capability. Picking one used to fail with the provider's own
+  words about response modalities or an unfamiliar API, which reads like a
+  misconfiguration rather than the wrong sort of model. The web client now
+  recognises those replies and explains that the selected model cannot be
+  used for chat, naming it and saying what it does produce where the
+  provider says so. An error it does not recognise still reaches the user
+  exactly as the provider phrased it. Filtering such models out of the
+  list belongs with the library that serves it, and is tracked
+  separately. (#246)
+
 - Switching LLM providers and sending a message immediately afterwards no
   longer pairs the new provider with the previous provider's model. The
   model list for the newly selected provider refreshes asynchronously, but

--- a/web/src/components/ChatInterface.jsx
+++ b/web/src/components/ChatInterface.jsx
@@ -1512,7 +1512,12 @@ const ChatInterface = ({ conversations }) => {
                         }
                     }
 
-                    throw new Error(`Server error: ${errorText || streamErr.message}`);
+                    // errorText prefers the raw body, which is right for the
+                    // rate-limit pattern matching above but wrong here: it
+                    // would show the still-JSON-encoded wrapper text sseChat
+                    // falls back to instead of its cleaned message. Prefer
+                    // the clean message, as the send-message path above does.
+                    throw new Error(`Server error: ${streamErr.message || errorText}`);
                 }
 
                 // Track token usage for rate limit awareness. Proxy now

--- a/web/src/components/ChatInterface.jsx
+++ b/web/src/components/ChatInterface.jsx
@@ -25,6 +25,7 @@ import PromptPopover from './PromptPopover';
 import WriteQueryConfirmDialog from './WriteQueryConfirmDialog';
 import { writeConfirmationSubject } from '../utils/queryClassify';
 import { sseChat } from '../utils/sseChat';
+import { formatChatError } from '../utils/modelErrors';
 import {
     createToolRepeatGuard,
     buildRepeatedToolFailureMessage,
@@ -1193,7 +1194,7 @@ const ChatInterface = ({ conversations }) => {
                     const thinkingMsg = newMessages[newMessages.length - 1];
                     newMessages[newMessages.length - 1] = {
                         role: 'assistant',
-                        content: `Error: ${err.message || 'Failed to send message'}`,
+                        content: `Error: ${formatChatError(err, thinkingMsg.model)}`,
                         timestamp: new Date().toISOString(),
                         provider: thinkingMsg.provider,
                         model: thinkingMsg.model,
@@ -1771,7 +1772,7 @@ const ChatInterface = ({ conversations }) => {
                     const thinkingMsg = newMessages[newMessages.length - 1];
                     newMessages[newMessages.length - 1] = {
                         role: 'assistant',
-                        content: `Error: ${err.message || 'Failed to execute prompt'}`,
+                        content: `Error: ${formatChatError(err, thinkingMsg.model, 'Failed to execute prompt')}`,
                         timestamp: new Date().toISOString(),
                         provider: thinkingMsg.provider,
                         model: thinkingMsg.model,

--- a/web/src/utils/modelErrors.js
+++ b/web/src/utils/modelErrors.js
@@ -33,6 +33,16 @@
  * Reads the response modalities a model will accept out of the error it
  * returns when asked for text, e.g. "AUDIO" for a text-to-speech model.
  *
+ * Capturing to the end of the string is wrong here: the streaming send
+ * path (sseChat.js) wraps a failed response as `HTTP <status>: <raw body
+ * text>` rather than handing back the provider's message alone, so the
+ * text this actually receives in production can carry trailing JSON
+ * syntax (a stray `"}` closing the body it was embedded in) after the
+ * modality list. Gemini's modality names are themselves a fixed,
+ * all-uppercase set (TEXT, IMAGE, AUDIO), so filtering each candidate
+ * line down to that shape discards whatever follows without needing to
+ * know what the wrapping looks like.
+ *
  * @param {string} text - The full error text.
  * @returns {string|null} The modalities, or null when absent.
  */
@@ -44,7 +54,7 @@ const acceptedModalities = (text) => {
     const names = match[1]
         .split('\n')
         .map(line => line.replace(/^[\s*-]+/, '').trim())
-        .filter(Boolean);
+        .filter(name => /^[A-Z]+$/.test(name));
     return names.length > 0 ? names.join(', ') : null;
 };
 

--- a/web/src/utils/modelErrors.js
+++ b/web/src/utils/modelErrors.js
@@ -1,0 +1,111 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - Unusable Model Error Descriptions
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/**
+ * Recognises the errors a provider returns when the selected model cannot
+ * hold a text conversation at all, and rewrites them as something that says
+ * so.
+ *
+ * The model list a provider advertises is not confined to chat models.
+ * Gemini's `models.list` reports text-to-speech, image, music and agent
+ * models alongside the conversational ones, and they are indistinguishable
+ * from the metadata, because they all advertise `generateContent` and the API
+ * exposes no field describing multi-turn support. Filtering them out belongs
+ * with whoever serves the list; until that happens a reader who picks one
+ * gets an error about response modalities or an unfamiliar API, which reads
+ * like a misconfiguration rather than the wrong kind of model.
+ *
+ * The patterns below were taken from the live API rather than guessed. Some
+ * of these models fail with nothing more specific than "Request contains an
+ * invalid argument", which no amount of matching can improve, so this
+ * deliberately recognises only the cases that identify themselves and leaves
+ * every other error exactly as the provider phrased it.
+ */
+
+/**
+ * Reads the response modalities a model will accept out of the error it
+ * returns when asked for text, e.g. "AUDIO" for a text-to-speech model.
+ *
+ * @param {string} text - The full error text.
+ * @returns {string|null} The modalities, or null when absent.
+ */
+const acceptedModalities = (text) => {
+    const match = text.match(
+        /accepts the following combination of response modalities:\s*([\s\S]*)$/i
+    );
+    if (!match) return null;
+    const names = match[1]
+        .split('\n')
+        .map(line => line.replace(/^[\s*-]+/, '').trim())
+        .filter(Boolean);
+    return names.length > 0 ? names.join(', ') : null;
+};
+
+/**
+ * Describes an error that means the chosen model cannot be used for chat.
+ *
+ * @param {string} errorText - The error as the provider and proxy phrased it.
+ * @param {string} [model] - The model that was selected, named in the result
+ *     when the error itself does not name it.
+ * @returns {string|null} A replacement message, or null when the error is
+ *     not one of the recognised cases and should be shown unaltered.
+ */
+export function describeUnusableModelError(errorText, model = '') {
+    if (!errorText || typeof errorText !== 'string') return null;
+
+    const named = model ? `The model ${model}` : 'The selected model';
+    const advice = 'Choose a different model from the model selector.';
+
+    // A model that only emits audio or images, such as Gemini's text-to-speech
+    // and image models, rejects a request for a text response outright.
+    if (/response modalities/i.test(errorText)) {
+        const modalities = acceptedModalities(errorText);
+        const produces = modalities
+            ? ` it produces ${modalities} output rather than text.`
+            : ' it does not produce text output.';
+        return `${named} cannot be used for chat, because${produces} ${advice}`;
+    }
+
+    // Agent and research models are reached through a different API and are
+    // not available for chat here at all.
+    if (/only supports\s+(?:the\s+)?([A-Za-z][\w\s-]*?)\s*API\b/i.test(errorText)) {
+        const [, api] = errorText.match(
+            /only supports\s+(?:the\s+)?([A-Za-z][\w\s-]*?)\s*API\b/i
+        );
+        return `${named} cannot be used for chat, because it is only available `
+            + `through the ${api.trim()} API. ${advice}`;
+    }
+
+    // Reported against some models historically, and kept because it states
+    // the problem plainly when it does appear.
+    if (/multi-?turn chat is not enabled/i.test(errorText)) {
+        return `${named} cannot be used for chat, because it does not support `
+            + `multi-turn conversations. ${advice}`;
+    }
+
+    return null;
+}
+
+/**
+ * Returns the text to show for a failed chat request: the description above
+ * when the error is a recognised unusable-model case, and otherwise the
+ * provider's own message untouched, so that nothing this does not understand
+ * is reworded or hidden.
+ *
+ * @param {Error|object} err - The error thrown by the chat call.
+ * @param {string} [model] - The model that was selected.
+ * @param {string} [fallback] - Text for an error that carries no message at
+ *     all, which differs between sending a message and running a prompt.
+ * @returns {string} Text to display to the user.
+ */
+export function formatChatError(err, model = '', fallback = 'Failed to send message') {
+    const raw = (err && err.message) || '';
+    return describeUnusableModelError(raw, model) || raw || fallback;
+}

--- a/web/src/utils/modelErrors.test.js
+++ b/web/src/utils/modelErrors.test.js
@@ -1,0 +1,92 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - Unusable Model Error Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect } from 'vitest';
+import { describeUnusableModelError, formatChatError } from './modelErrors';
+
+// Captured from the live Gemini API through the proxy, rather than written
+// from the documentation, so that the patterns match what actually arrives.
+const TTS_ERROR = 'gemini (400): The requested combination of response '
+    + 'modalities (TEXT) is not supported by the model. '
+    + 'models/gemini-2.5-flash-preview-tts accepts the following combination '
+    + 'of response modalities:\n* AUDIO\n';
+const INTERACTIONS_ERROR = 'gemini (400): This model only supports '
+    + 'Interactions API.';
+const GENERIC_ERROR = 'gemini (400): Request contains an invalid argument.';
+const RATE_LIMIT_ERROR = 'gemini (429): HTTP 429';
+
+describe('describeUnusableModelError', () => {
+    it('explains a text-to-speech model in terms of what it does produce', () => {
+        const out = describeUnusableModelError(TTS_ERROR, 'gemini-2.5-flash-preview-tts');
+        expect(out).toContain('gemini-2.5-flash-preview-tts');
+        expect(out).toContain('cannot be used for chat');
+        expect(out).toContain('AUDIO');
+        expect(out).toContain('Choose a different model');
+    });
+
+    it('explains a model that is only reachable through another API', () => {
+        const out = describeUnusableModelError(INTERACTIONS_ERROR, 'deep-research-preview-04-2026');
+        expect(out).toContain('deep-research-preview-04-2026');
+        expect(out).toContain('Interactions API');
+        expect(out).toContain('Choose a different model');
+    });
+
+    it('explains a model that does not support multi-turn chat', () => {
+        const out = describeUnusableModelError(
+            'gemini (400): Multiturn chat is not enabled for models/some-model',
+            'some-model'
+        );
+        expect(out).toContain('multi-turn');
+        expect(out).toContain('some-model');
+    });
+
+    it('falls back to a generic phrase when the model is not known', () => {
+        const out = describeUnusableModelError(TTS_ERROR);
+        expect(out).toContain('The selected model');
+    });
+
+    // The point of returning null is that everything unrecognised reaches the
+    // user in the provider's own words, rather than being flattened into a
+    // guess about the model.
+    it.each([
+        ['a generic invalid-argument error', GENERIC_ERROR],
+        ['a rate limit', RATE_LIMIT_ERROR],
+        ['an unrelated failure', 'gemini (500): internal error'],
+        ['an empty string', ''],
+        ['a non-string', null],
+    ])('leaves %s alone', (_name, input) => {
+        expect(describeUnusableModelError(input, 'gemini-2.5-flash')).toBeNull();
+    });
+});
+
+describe('formatChatError', () => {
+    it('describes a recognised unusable-model error', () => {
+        const out = formatChatError(new Error(TTS_ERROR), 'gemini-2.5-flash-preview-tts');
+        expect(out).toContain('cannot be used for chat');
+    });
+
+    it('passes an unrecognised error through unchanged', () => {
+        expect(formatChatError(new Error(GENERIC_ERROR), 'gemini-2.5-flash'))
+            .toBe(GENERIC_ERROR);
+    });
+
+    it('falls back when the error carries no message', () => {
+        expect(formatChatError(new Error(''), 'gemini-2.5-flash'))
+            .toBe('Failed to send message');
+        expect(formatChatError(undefined)).toBe('Failed to send message');
+    });
+
+    // Prompt execution and message sending word their fallback differently,
+    // so the caller supplies it rather than having one imposed.
+    it('uses a caller-supplied fallback', () => {
+        expect(formatChatError(new Error(''), '', 'Failed to execute prompt'))
+            .toBe('Failed to execute prompt');
+    });
+});

--- a/web/src/utils/modelErrors.test.js
+++ b/web/src/utils/modelErrors.test.js
@@ -28,6 +28,19 @@ describe('describeUnusableModelError', () => {
         expect(out).toContain('gemini-2.5-flash-preview-tts');
         expect(out).toContain('cannot be used for chat');
         expect(out).toContain('AUDIO');
+    });
+
+    // sseChat.js wraps a failed streaming response as "HTTP <status>: <raw
+    // body text>" when the body isn't the expected {"error": "..."} shape,
+    // and that raw text can carry a trailing JSON artifact after the
+    // modality list. The extraction must stop at the modality names
+    // themselves rather than swallowing whatever follows them.
+    it('ignores trailing garbage after the modality list rather than including it', () => {
+        const wrapped = 'HTTP 502: {"error":"gemini (400): accepts the following '
+            + 'combination of response modalities:\n* AUDIO\n"}';
+        const out = describeUnusableModelError(wrapped, 'gemini-2.5-flash-preview-tts');
+        expect(out).toContain('AUDIO');
+        expect(out).not.toContain('"}');
         expect(out).toContain('Choose a different model');
     });
 

--- a/web/src/utils/sseChat.js
+++ b/web/src/utils/sseChat.js
@@ -96,7 +96,26 @@ export async function sseChat(body, options = {}) {
 
     if (!response.ok) {
         const text = await response.text();
-        const err = new Error(`HTTP ${response.status}: ${text}`);
+        // The proxy's error responses are `{"error": "<provider message>"}`.
+        // Prefer that clean message over the raw body: the body is still
+        // JSON-encoded at this point, so any escape sequence the provider's
+        // own message contains (Gemini's response-modality errors carry a
+        // literal `\n` between each accepted modality) reaches consumers
+        // un-decoded otherwise, which breaks any caller that expects real
+        // newlines rather than the two-character escape sequence. err.body
+        // keeps the raw text unparsed, since callers matching on the wire
+        // shape (rate-limit detection) need it as-is.
+        let message = `HTTP ${response.status}: ${text}`;
+        try {
+            const parsed = JSON.parse(text);
+            if (parsed && typeof parsed.error === 'string' && parsed.error) {
+                message = parsed.error;
+            }
+        } catch (_err) {
+            // Not JSON, or no `error` field; keep the HTTP-status-prefixed
+            // raw text so the failure is still visible somewhere.
+        }
+        const err = new Error(message);
         err.status = response.status;
         err.body = text;
         throw err;

--- a/web/src/utils/sseChat.test.js
+++ b/web/src/utils/sseChat.test.js
@@ -193,6 +193,50 @@ describe('sseChat', () => {
         await expect(sseChat({ messages: [] })).rejects.toThrow(/HTTP 500/);
     });
 
+    it('throws the proxy\'s own error message, not the wrapped JSON body', async () => {
+        // The proxy's error responses are `{"error": "<message>"}`. A
+        // caller matching on the message text (e.g. modelErrors.js
+        // recognising a non-chat-model failure) needs the clean message,
+        // not "HTTP 502: {\"error\":\"...\"}" — the un-decoded JSON escape
+        // sequences a provider's own message can carry (Gemini's
+        // response-modality errors carry a literal `\n` between each
+        // accepted modality) would otherwise reach the caller as the
+        // literal two-character sequence rather than a real newline.
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 502,
+            statusText: 'Bad Gateway',
+            body: null,
+            text: async () => '{"error":"gemini (400): accepts the following combination of response modalities:\\n* AUDIO\\n"}',
+        });
+
+        let caught;
+        try {
+            await sseChat({ messages: [] });
+        } catch (err) {
+            caught = err;
+        }
+        expect(caught).toBeDefined();
+        expect(caught.message).toBe('gemini (400): accepts the following combination of response modalities:\n* AUDIO\n');
+        expect(caught.message).not.toContain('HTTP 502');
+        // err.body stays the raw, still-JSON-encoded text: rate-limit
+        // detection elsewhere matches on the wire shape, not the decoded
+        // message.
+        expect(caught.body).toContain('{"error"');
+    });
+
+    it('falls back to the HTTP-prefixed raw text when the body is not the expected JSON shape', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            body: null,
+            text: async () => 'not json at all',
+        });
+
+        await expect(sseChat({ messages: [] })).rejects.toThrow('HTTP 500: not json at all');
+    });
+
     it('forwards Authorization header when sessionToken is provided', async () => {
         const fetchMock = vi.fn().mockResolvedValue(buildStreamResponse([
             'event: done\ndata: {"stop_reason":"end_turn"}\n\n',


### PR DESCRIPTION
## Summary

Issue #246: a provider's model list is not confined to chat models, so the
model selector offers models that cannot hold a conversation, and choosing one
fails with an error that reads like a misconfiguration.

This is the half of #246 that belongs in this repository. Filtering the models
out of the list is the better fix and cannot happen here, because the server
mounts the library's proxy directly at `/api/llm/v1/models` and has no
interception point of its own; that half is pgEdge/pgedge-go-llm-lib#39.

## What the live API actually returns

I probed the real endpoint rather than working from the issue, and the picture
differs from what it records in two ways worth knowing.

**The quoted error no longer appears.** #246 reports `Multiturn chat is not
enabled for models/<name>`. No model returns that today. What they return is:

```
gemini-2.5-flash-preview-tts   gemini (400): The requested combination of response
                               modalities (TEXT) is not supported by the model.
                               models/... accepts the following combination of
                               response modalities: * AUDIO
antigravity-preview-05-2026    gemini (400): This model only supports Interactions API.
deep-research-preview-04-2026  gemini (400): This model only supports Interactions API.
gemini-3.1-flash-tts-preview   gemini (400): Request contains an invalid argument.
```

**Some models I had written off do work.** `gemini-robotics-er-2-preview` and
the Gemma models both hold a normal conversation, so my earlier count of 19
unusable models on the issue was too aggressive. I have corrected that on both
issues, since a blocklist built from it would have excluded working models.

## The change

`web/src/utils/modelErrors.js` recognises the three shapes that identify
themselves and rewrites them:

> The model gemini-2.5-flash-preview-tts cannot be used for chat, because it
> produces AUDIO output rather than text. Choose a different model from the
> model selector.

> The model deep-research-preview-04-2026 cannot be used for chat, because it
> is only available through the Interactions API. Choose a different model from
> the model selector.

The older multi-turn refusal is kept too, because it states the problem plainly
if it does reappear.

**Anything unrecognised passes through untouched.** That is the important
property rather than a caveat: `gemini-3.1-flash-tts-preview` fails with
nothing better than "Request contains an invalid argument", and rewording that
would swap a vague message for a confident guess about the cause. Rate limits,
server errors and everything else reach the user exactly as the provider
phrased them.

Both failure sites in `ChatInterface` use it, so a model that cannot chat is
explained the same way whether it was reached by sending a message or by
running a prompt, and each keeps its own wording for an error carrying no
message at all.

## Verification

- 13 unit tests using the strings captured from the live API as fixtures,
  including that each unrecognised class returns null and is left alone.
- End-to-end against the live Gemini API through a local server: each error
  becomes the intended sentence, and `gemini-2.5-flash` still streams a reply.
- `make test` green at 232 tests across 19 files, `make lint` 0 issues.

## Note

This touches the same `### Fixed` block as #252, so whichever merges second
will want a trivial changelog resolution.

Refs #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved chat error messages when a selected model cannot be used for conversations.
  * Messages identify the model, explain its limitation, and describe supported output formats when available.
  * Prompt execution errors now provide clearer, actionable guidance.

* **Bug Fixes**
  * Proxy error responses now display their decoded error messages when available.
  * Unrecognized or incomplete errors retain useful fallback messaging and original provider details.

* **Documentation**
  * Documented these improvements in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->