### PR TITLE
fix(chat): stop the model fallback choosing a non-chat model

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -118,6 +118,19 @@ and this project adheres to
 
 ### Fixed
 
+- The CLI client no longer falls back to a model that cannot hold a
+  conversation. When a saved model preference named something the provider
+  no longer serves, and the provider's default was absent too, the client
+  took the first entry in the model list without checking what kind of
+  model it was; an embedding model sorting first left every message failing
+  with the provider's complaint that the model does not support chat,
+  whilst a usable model sat further down the same list. The fallback now
+  skips the model kinds that identify themselves by name, covering
+  embedding, reranking, moderation, transcription, speech, image, video and
+  music models across all four providers, and takes the first entry that
+  looks conversational. A model named on the command line, or held as a
+  saved preference the provider still serves, is used as before. (#255)
+
 - A configuration file that sets an LLM or embedding option without also
   naming the provider, or enabling the section, is no longer discarded.
   The merge tested only those two fields, so a file that configured just a

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -1394,9 +1394,19 @@ func (c *Client) selectModel(provider string, availableModels, rawModels []strin
 	}
 
 	// The capability filter left nothing at all (e.g. only an embedding
-	// model is installed). Name a real model from the unfiltered list
-	// rather than reaching for the default below, which the provider may
-	// never have offered in the first place.
+	// model is installed) — but rawModels is unfiltered, so it can still
+	// hold a real conversational model the filter missed. Try the same
+	// name check as above before falling back to its head, for the same
+	// reason: the filter is real per-provider data, not a guess, but
+	// trusting it completely here would silently reintroduce issue #255
+	// if that data is ever wrong.
+	if candidate := firstChatCapableModel(rawModels); candidate != "" {
+		if debug {
+			fmt.Fprintf(os.Stderr, "[DEBUG] Falling back to first available chat-looking model (unfiltered): %s\n", candidate)
+		}
+		return modelSelectionResult{model: candidate, fromSavedPref: false, hadSavedPref: hadSaved}
+	}
+
 	if len(rawModels) > 0 {
 		if debug {
 			fmt.Fprintf(os.Stderr, "[DEBUG] Falling back to first available model (unfiltered): %s (no chat-capable model on the list)\n",

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -1343,11 +1343,25 @@ func (c *Client) selectModel(provider string, availableModels []string) modelSel
 		return modelSelectionResult{model: defaultModel, fromSavedPref: false, hadSavedPref: hadSaved}
 	}
 
-	// Fall back to first available model
+	// Fall back to the first available model that can hold a conversation.
+	// The provider's list is not confined to chat models, so taking the
+	// head of it unconditionally can land on something that rejects every
+	// message it is ever sent.
+	if candidate := firstChatCapableModel(availableModels); candidate != "" {
+		if debug {
+			fmt.Fprintf(os.Stderr, "[DEBUG] Falling back to first available chat model: %s (default %q also not available)\n",
+				candidate, defaultModel)
+		}
+		return modelSelectionResult{model: candidate, fromSavedPref: false, hadSavedPref: hadSaved}
+	}
+
+	// Nothing in the list looks usable for chat. Fall back to the head of it
+	// anyway rather than to a default the provider has not offered, so that
+	// whatever the provider says about it reaches the user.
 	if len(availableModels) > 0 {
 		if debug {
-			fmt.Fprintf(os.Stderr, "[DEBUG] Falling back to first available model: %s (default %q also not available)\n",
-				availableModels[0], defaultModel)
+			fmt.Fprintf(os.Stderr, "[DEBUG] Falling back to first available model: %s (no model in the list looks usable for chat)\n",
+				availableModels[0])
 		}
 		return modelSelectionResult{model: availableModels[0], fromSavedPref: false, hadSavedPref: hadSaved}
 	}
@@ -1422,6 +1436,63 @@ func extractModelFamily(model string) string {
 
 	// Return everything up to and including the hyphen before the date
 	return model[:len(model)-8]
+}
+
+// nonChatModelMarkers names the model kinds that cannot hold a text
+// conversation at all, as they appear in the model IDs the providers we
+// support advertise.
+//
+// A provider's model list is not confined to chat models, and none of the
+// four expose a capability flag that separates them: Ollama's /api/tags
+// reports embedding models next to conversational ones, and OpenAI and
+// Gemini list embedding, moderation, transcription, speech, image and video
+// models the same way. The names are the only signal available, so this
+// matches on the substrings those families put in their IDs:
+// nomic-embed-text, text-embedding-3-small, gemini-embedding-001,
+// omni-moderation-latest, whisper-1, gpt-4o-mini-tts, dall-e-3, imagen-4.0,
+// veo-3.0-generate-001 and their relatives.
+//
+// This is deliberately conservative, and covers only the kinds whose IDs say
+// what they are: a name that carries no marker is treated as a chat model,
+// because guessing the other way would rule out a usable model over a
+// coincidence in its name.
+var nonChatModelMarkers = []string{
+	"embed",
+	"rerank",
+	"moderation",
+	"whisper",
+	"transcribe",
+	"-tts",
+	"tts-",
+	"dall-e",
+	"imagen",
+	"stable-diffusion",
+	"veo-",
+	"lyria",
+}
+
+// isChatCapableModel reports whether a model ID looks like one that can be
+// used for chat, judged by the markers above. It says nothing about whether
+// the model exists or whether the caller is entitled to use it.
+func isChatCapableModel(model string) bool {
+	lower := strings.ToLower(model)
+	for _, marker := range nonChatModelMarkers {
+		if strings.Contains(lower, marker) {
+			return false
+		}
+	}
+	return true
+}
+
+// firstChatCapableModel returns the first model in availableModels that looks
+// usable for chat, or an empty string when the list holds none (or is empty).
+func firstChatCapableModel(availableModels []string) string {
+	for _, m := range availableModels {
+		if isChatCapableModel(m) {
+			return m
+		}
+	}
+	return ""
 }
 
 // isModelAvailable checks if model is in the available list

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -522,7 +522,13 @@ func (c *Client) initializeLLM() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	availableModels, err := tempClient.ListModels(ctx)
+	// Restrict the list to chat-capable models up front. The library
+	// backs this with real per-model data (e.g. Ollama's /api/show)
+	// rather than a name guess, and filtering here means every
+	// selection tier below — saved preference, family match, provider
+	// default, and the final fallback — only ever sees chat-capable
+	// models, not just the last of them.
+	availableModels, err := tempClient.ListModels(ctx, llmlib.WithCapabilities(llmlib.ModelCapabilityChat))
 	if err != nil {
 		if c.config.UI.Debug {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to list models from %s: %s\n", provider, redact.Error(err))
@@ -530,8 +536,24 @@ func (c *Client) initializeLLM() error {
 		availableModels = nil
 	}
 
+	// If the provider answered but nothing on the list looks chat-capable
+	// (e.g. an Ollama instance with only an embedding model pulled),
+	// fetch the same list again without the filter. selectModel's final
+	// fallback uses this to name a model the provider actually offers
+	// rather than reaching for an unvalidated hardcoded default — the
+	// same guarantee it gave before the list was filtered by capability.
+	// Skipped when the first call already failed outright: a second,
+	// unfiltered request to an unreachable provider would only add
+	// latency to an already-failing path.
+	var rawModels []string
+	if err == nil && len(availableModels) == 0 {
+		if raw, rawErr := tempClient.ListModels(ctx); rawErr == nil {
+			rawModels = raw
+		}
+	}
+
 	// Select the best model to use
-	selection := c.selectModel(provider, availableModels)
+	selection := c.selectModel(provider, availableModels, rawModels)
 	c.config.LLM.Model = selection.model
 
 	if selection.usedFamilyMatch && c.config.UI.Debug {
@@ -1273,7 +1295,12 @@ type modelSelectionResult struct {
 // 3. Saved preference - family match (e.g., claude-opus-4-5-20251101 → claude-opus-4-5-20251217)
 // 4. Default for provider (if available)
 // 5. First available model from provider's list
-func (c *Client) selectModel(provider string, availableModels []string) modelSelectionResult {
+// rawModels is the same provider's model list without the chat-capability
+// filter, used only once every validated tier below has found nothing —
+// so the final fallback can still name a model the provider actually
+// offers instead of an unvalidated hardcoded default. Empty whenever
+// availableModels itself already held something.
+func (c *Client) selectModel(provider string, availableModels, rawModels []string) modelSelectionResult {
 	debug := c.config.UI.Debug
 
 	// If model was already set (via flag), use it (trust the user)
@@ -1364,6 +1391,18 @@ func (c *Client) selectModel(provider string, availableModels []string) modelSel
 				availableModels[0])
 		}
 		return modelSelectionResult{model: availableModels[0], fromSavedPref: false, hadSavedPref: hadSaved}
+	}
+
+	// The capability filter left nothing at all (e.g. only an embedding
+	// model is installed). Name a real model from the unfiltered list
+	// rather than reaching for the default below, which the provider may
+	// never have offered in the first place.
+	if len(rawModels) > 0 {
+		if debug {
+			fmt.Fprintf(os.Stderr, "[DEBUG] Falling back to first available model (unfiltered): %s (no chat-capable model on the list)\n",
+				rawModels[0])
+		}
+		return modelSelectionResult{model: rawModels[0], fromSavedPref: false, hadSavedPref: hadSaved}
 	}
 
 	// Last resort: use default even if not validated

--- a/internal/chat/client_integration_test.go
+++ b/internal/chat/client_integration_test.go
@@ -13,6 +13,7 @@ package chat
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -253,6 +254,189 @@ func TestClient_InitializeLLM_Ollama(t *testing.T) {
 
 	if client.llm == nil {
 		t.Error("Expected LLM client to be initialized")
+	}
+}
+
+// TestClient_InitializeLLM_Ollama_SkipsEmbeddingModel reproduces issue
+// #255 against the real HTTP path: an Ollama /api/tags response listing
+// an embedding model before a chat model, and no saved preference or
+// flag-provided model to short-circuit selection. Before the fix at the
+// tempClient.ListModels call site, this landed on the embedding model
+// and every subsequent chat message would have failed.
+func TestClient_InitializeLLM_Ollama_SkipsEmbeddingModel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/tags":
+			fmt.Fprint(w, `{"models":[{"name":"nomic-embed-text:latest"},{"name":"llama3.2:latest"}]}`)
+		case "/api/show":
+			var req struct {
+				Name string `json:"name"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == "nomic-embed-text:latest" {
+				fmt.Fprint(w, `{"capabilities":["embedding"]}`)
+			} else {
+				fmt.Fprint(w, `{"capabilities":["completion","tools"]}`)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	cfg := &Config{
+		MCP: MCPConfig{
+			Mode:       "stdio",
+			ServerPath: "/fake/path",
+		},
+		LLM: LLMConfig{
+			Provider:  "ollama",
+			OllamaURL: ollama.URL,
+			MaxTokens: 4096,
+		},
+		UI: UIConfig{
+			NoColor: true,
+		},
+	}
+
+	client, err := NewClient(cfg, &ConfigOverrides{})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	if err := client.initializeLLM(); err != nil {
+		t.Fatalf("initializeLLM failed: %v", err)
+	}
+
+	if client.config.LLM.Model != "llama3.2:latest" {
+		t.Errorf("expected the chat-capable model llama3.2:latest to be selected, got %q", client.config.LLM.Model)
+	}
+}
+
+// TestClient_InitializeLLM_Ollama_SavedPreferenceIsEmbeddingModel covers
+// the tier that TestClient_InitializeLLM_Ollama_SkipsEmbeddingModel
+// cannot reach: a saved preference that itself names an embedding
+// model still present in the provider's list. selectModel's saved-
+// preference tier returns as soon as isModelAvailable matches, without
+// ever reaching the name-marker fallback added for issue #255 — that
+// fallback only runs once the saved preference and the provider
+// default have both missed. Filtering at the ListModels call protects
+// every tier, including this one.
+func TestClient_InitializeLLM_Ollama_SavedPreferenceIsEmbeddingModel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	prefs := &Preferences{
+		Version:        CurrentPreferencesVersion,
+		ProviderModels: map[string]string{"ollama": "nomic-embed-text:latest"},
+	}
+	if err := SavePreferences(prefs); err != nil {
+		t.Fatalf("failed to seed preferences: %v", err)
+	}
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/tags":
+			fmt.Fprint(w, `{"models":[{"name":"nomic-embed-text:latest"},{"name":"llama3.2:latest"}]}`)
+		case "/api/show":
+			var req struct {
+				Name string `json:"name"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == "nomic-embed-text:latest" {
+				fmt.Fprint(w, `{"capabilities":["embedding"]}`)
+			} else {
+				fmt.Fprint(w, `{"capabilities":["completion","tools"]}`)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	cfg := &Config{
+		MCP: MCPConfig{
+			Mode:       "stdio",
+			ServerPath: "/fake/path",
+		},
+		LLM: LLMConfig{
+			Provider:  "ollama",
+			OllamaURL: ollama.URL,
+			MaxTokens: 4096,
+		},
+		UI: UIConfig{
+			NoColor: true,
+		},
+	}
+
+	client, err := NewClient(cfg, &ConfigOverrides{})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	if err := client.initializeLLM(); err != nil {
+		t.Fatalf("initializeLLM failed: %v", err)
+	}
+
+	if client.config.LLM.Model != "llama3.2:latest" {
+		t.Errorf("expected the chat-capable model llama3.2:latest to be selected over the stale embedding preference, got %q", client.config.LLM.Model)
+	}
+}
+
+// TestClient_InitializeLLM_Ollama_NoChatModelInstalled covers the case
+// the capability filter itself creates: a provider reachable and
+// answering normally, but with nothing chat-capable at all (here, only
+// an embedding model). availableModels ends up empty after filtering,
+// so without a real, unfiltered fallback the selection would reach for
+// the hardcoded per-provider default without ever confirming the
+// provider actually offers it — trading an honest "this model can't
+// chat" error for a confusing "model not found" one. This asserts the
+// real, installed embedding model is named instead.
+func TestClient_InitializeLLM_Ollama_NoChatModelInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/tags":
+			fmt.Fprint(w, `{"models":[{"name":"nomic-embed-text:latest"}]}`)
+		case "/api/show":
+			fmt.Fprint(w, `{"capabilities":["embedding"]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	cfg := &Config{
+		MCP: MCPConfig{
+			Mode:       "stdio",
+			ServerPath: "/fake/path",
+		},
+		LLM: LLMConfig{
+			Provider:  "ollama",
+			OllamaURL: ollama.URL,
+			MaxTokens: 4096,
+		},
+		UI: UIConfig{
+			NoColor: true,
+		},
+	}
+
+	client, err := NewClient(cfg, &ConfigOverrides{})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	if err := client.initializeLLM(); err != nil {
+		t.Fatalf("initializeLLM failed: %v", err)
+	}
+
+	if client.config.LLM.Model != "nomic-embed-text:latest" {
+		t.Errorf("expected the real installed model nomic-embed-text:latest to be named, got %q (the hardcoded default, which this provider never offered)", client.config.LLM.Model)
 	}
 }
 

--- a/internal/chat/client_test.go
+++ b/internal/chat/client_test.go
@@ -401,7 +401,7 @@ func TestSelectModelFallbackSkipsNonChatModels(t *testing.T) {
 				},
 			}
 
-			got := c.selectModel("ollama", tt.availableModels)
+			got := c.selectModel("ollama", tt.availableModels, nil)
 			if got.model != tt.want {
 				t.Errorf("selectModel(ollama, %v) = %q, want %q",
 					tt.availableModels, got.model, tt.want)

--- a/internal/chat/client_test.go
+++ b/internal/chat/client_test.go
@@ -290,6 +290,132 @@ func TestFindModelFamilyMatch(t *testing.T) {
 	}
 }
 
+func TestIsChatCapableModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"anthropic chat model", "claude-sonnet-4-5-20250929", true},
+		{"openai chat model", "gpt-4o", true},
+		{"gemini chat model", "gemini-2.5-flash", true},
+		{"ollama chat model", "llama3.2:latest", true},
+		{"ollama embedding model", "nomic-embed-text:latest", false},
+		{"ollama embedding model, large", "mxbai-embed-large", false},
+		{"openai embedding model", "text-embedding-3-small", false},
+		{"gemini embedding model", "gemini-embedding-001", false},
+		{"reranking model", "rerank-2.5-lite", false},
+		{"moderation model", "omni-moderation-latest", false},
+		{"transcription model", "whisper-1", false},
+		{"newer transcription model", "gpt-4o-transcribe", false},
+		{"speech model", "gpt-4o-mini-tts", false},
+		{"image model", "dall-e-3", false},
+		{"gemini image model", "imagen-4.0-generate-001", false},
+		{"video model", "veo-3.0-generate-001", false},
+		{"music model", "lyria-002", false},
+		{"mixed case is matched", "TEXT-EMBEDDING-3-SMALL", false},
+		{"empty model", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isChatCapableModel(tt.model); got != tt.want {
+				t.Errorf("isChatCapableModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstChatCapableModel(t *testing.T) {
+	tests := []struct {
+		name            string
+		availableModels []string
+		want            string
+	}{
+		{
+			"skips a leading embedding model",
+			[]string{"nomic-embed-text:latest", "llama3.2:latest"},
+			"llama3.2:latest",
+		},
+		{
+			"takes the head when it is usable",
+			[]string{"llama3.2:latest", "nomic-embed-text:latest"},
+			"llama3.2:latest",
+		},
+		{
+			"no usable model",
+			[]string{"nomic-embed-text:latest", "mxbai-embed-large"},
+			"",
+		},
+		{"empty list", []string{}, ""},
+		{"nil list", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstChatCapableModel(tt.availableModels); got != tt.want {
+				t.Errorf("firstChatCapableModel(%v) = %q, want %q", tt.availableModels, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSelectModelFallbackSkipsNonChatModels covers the case reported in
+// issue #255: a saved preference naming a model the provider no longer
+// serves, with an embedding model at the head of the list that replaced it,
+// which left every chat message failing whilst a usable model sat further
+// down the same list.
+func TestSelectModelFallbackSkipsNonChatModels(t *testing.T) {
+	tests := []struct {
+		name            string
+		savedModel      string
+		availableModels []string
+		want            string
+	}{
+		{
+			"embedding model sorts first",
+			"llama3.1:latest",
+			[]string{"nomic-embed-text:latest", "llama3.2:latest"},
+			"llama3.2:latest",
+		},
+		{
+			"provider default wins when it is served",
+			"llama3.1:latest",
+			[]string{"nomic-embed-text:latest", "qwen3-coder:latest", "llama3.2:latest"},
+			"qwen3-coder:latest",
+		},
+		{
+			"list holds nothing usable for chat",
+			"llama3.1:latest",
+			[]string{"nomic-embed-text:latest", "mxbai-embed-large"},
+			"nomic-embed-text:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				config: &Config{},
+				preferences: &Preferences{
+					ProviderModels: map[string]string{"ollama": tt.savedModel},
+				},
+			}
+
+			got := c.selectModel("ollama", tt.availableModels)
+			if got.model != tt.want {
+				t.Errorf("selectModel(ollama, %v) = %q, want %q",
+					tt.availableModels, got.model, tt.want)
+			}
+			if !got.hadSavedPref {
+				t.Error("selectModel() reported no saved preference, want one recorded")
+			}
+			if got.fromSavedPref {
+				t.Error("selectModel() reported the saved preference was used, want a fallback")
+			}
+		})
+	}
+}
+
 func TestHasToolResults(t *testing.T) {
 	// Create a client for testing
 	cfg := &Config{

--- a/internal/chat/client_test.go
+++ b/internal/chat/client_test.go
@@ -416,6 +416,30 @@ func TestSelectModelFallbackSkipsNonChatModels(t *testing.T) {
 	}
 }
 
+// TestSelectModelRawFallbackSkipsNonChatModels covers the raw-list
+// fallback tier (reached when capability filtering leaves
+// availableModels empty): it must apply the same name check to
+// rawModels as the filtered tiers above it, not just take its head.
+// Flagged by CodeRabbit on PR #257 — an embedding model sorting first
+// in the unfiltered list would otherwise reintroduce issue #255 if the
+// capability filter ever excludes a real chat model.
+func TestSelectModelRawFallbackSkipsNonChatModels(t *testing.T) {
+	c := &Client{
+		config:      &Config{},
+		preferences: &Preferences{},
+	}
+
+	// availableModels must be an empty (non-nil) slice, matching what
+	// initializeLLM actually gets back from a capability-filtered
+	// ListModels call that excludes everything: isModelAvailable treats
+	// a nil slice as "couldn't fetch, trust it" and would short-circuit
+	// on the provider default before ever reaching the raw fallback.
+	got := c.selectModel("ollama", []string{}, []string{"nomic-embed-text:latest", "llama3.2:latest"})
+	if got.model != "llama3.2:latest" {
+		t.Errorf("selectModel raw fallback = %q, want %q", got.model, "llama3.2:latest")
+	}
+}
+
 func TestHasToolResults(t *testing.T) {
 	// Create a client for testing
 	cfg := &Config{

--- a/internal/chat/commands.go
+++ b/internal/chat/commands.go
@@ -458,6 +458,14 @@ func (c *Client) handleSetLLMModel(model string) bool {
 			"Model '%s' not available from %s", model, c.config.LLM.Provider))
 		c.ui.PrintSystemMessage("Use /list models to see available models")
 		return true
+	} else if !isChatCapableModel(model) {
+		// The model exists but its name marks it as embedding, rerank, or
+		// similar — the same mismatch issue #255 covers for automatic
+		// selection, just reached by naming a model directly. Warn rather
+		// than block: the marker is a name guess, and the model may hold a
+		// conversation despite it.
+		c.ui.PrintSystemMessage(fmt.Sprintf(
+			"Warning: '%s' looks like it may not support chat; the next message may fail", model))
 	}
 
 	// Update config

--- a/internal/chat/commands_test.go
+++ b/internal/chat/commands_test.go
@@ -11,11 +11,32 @@
 package chat
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"pgedge-postgres-mcp/internal/mcp"
+
+	llmlib "github.com/pgEdge/pgedge-go-llm-lib/llm"
 )
+
+// fixedModelListLLM is a minimal chatLLM whose ListModels always returns
+// the same fixed list, regardless of any capability options — enough to
+// drive handleSetLLMModel's validation without a real provider.
+type fixedModelListLLM struct {
+	models []string
+}
+
+func (m *fixedModelListLLM) Chat(_ context.Context, _ llmlib.ChatRequest) (*llmlib.ChatResponse, error) {
+	return &llmlib.ChatResponse{StopReason: llmlib.StopReasonEndTurn}, nil
+}
+
+func (m *fixedModelListLLM) ListModels(_ context.Context, _ ...llmlib.ListModelsOption) ([]string, error) {
+	return m.models, nil
+}
 
 func TestParseSlashCommand(t *testing.T) {
 	tests := []struct {
@@ -302,6 +323,51 @@ func TestHandleSetLLMProvider(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestHandleSetLLMModel_WarnsOnNonChatModel covers the manual-selection
+// counterpart to issue #255: /model lets a user name an existing but
+// non-chat model directly, bypassing the automatic fallback entirely.
+// isModelAvailable only checks existence, so this asserts the missing
+// half — a warning naming the risk before the model is actually set,
+// using the same isChatCapableModel marker check added for #255 rather
+// than a second network round-trip.
+func TestHandleSetLLMModel_WarnsOnNonChatModel(t *testing.T) {
+	cfg := &Config{
+		LLM: LLMConfig{
+			Provider:  "ollama",
+			Model:     "llama3.2:latest",
+			OllamaURL: "http://localhost:11434",
+		},
+		UI: UIConfig{NoColor: true},
+	}
+	client, err := NewClient(cfg, &ConfigOverrides{ProviderSet: true, ModelSet: true})
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	client.llm = &fixedModelListLLM{models: []string{"nomic-embed-text:latest", "llama3.2:latest"}}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	handled := client.handleSetLLMModel("nomic-embed-text:latest")
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	if !handled {
+		t.Error("expected handleSetLLMModel to return true")
+	}
+	if client.config.LLM.Model != "nomic-embed-text:latest" {
+		t.Errorf("expected the model to be set despite the warning, got %q", client.config.LLM.Model)
+	}
+	if !strings.Contains(output, "may not support chat") {
+		t.Errorf("expected a warning about chat support, got output: %s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `selectModel` fell back to the head of the provider's model list with no
  check on what kind of model it was, so an embedding model sorting first
  (Ollama's `nomic-embed-text` ahead of `llama3.2`) left every chat message
  failing whilst a usable model sat further down the same list.

- None of the four providers expose a capability flag separating chat models
  from the rest, so the fallback now skips the kinds that identify themselves
  by name: embedding, reranking, moderation, transcription, speech, image,
  video and music models. The matching is deliberately conservative, treating
  a name that carries no such marker as a chat model, because ruling out a
  usable model over a coincidence in its name would be the worse failure.

- When nothing in the list looks conversational the head is used as before,
  so the provider's own message still reaches the user rather than being
  replaced by a default it never offered. A model named on the command line,
  and a saved preference the provider still serves, are unaffected.

## Test plan

- [x] `TestIsChatCapableModel` and `TestFirstChatCapableModel` cover the name
      markers and the list walk across all four providers' naming styles.
- [x] `TestSelectModelFallbackSkipsNonChatModels` reproduces the reported
      case, and covers the provider default winning when it is served and the
      list holding nothing usable.
- [x] `make build`, `make lint` and `make test` all pass (Go suites plus 235
      web tests).

Closes #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved automatic model selection to prioritize conversational models.
  - Skips embedding, reranking, moderation, transcription, speech, image, video, and music models during fallback selection.
  - Warns when manually selecting a model that may not support chat.

- **Bug Fixes**
  - Saved preferences for unavailable or non-conversational models now fall back to a suitable conversational model.
  - Preserves fallback behavior when no conversational models are installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->