### PR TITLE
fix(embed): default the OpenAI embedding model to text-embedding-3-small

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -118,6 +118,11 @@ and this project adheres to
 
 ### Fixed
 
+- The OpenAI embedding provider no longer fails with "model parameter is
+  required" when `embedding.model` is left unset. It now defaults to
+  `text-embedding-3-small`, matching the built-in fallbacks Voyage,
+  Gemini, and Ollama already had.
+
 - The CLI client no longer falls back to a model that cannot hold a
   conversation. When a saved model preference named something the provider
   no longer serves, and the provider's default was absent too, the client

--- a/internal/tools/embed_client.go
+++ b/internal/tools/embed_client.go
@@ -42,11 +42,12 @@ type embedClientConfig struct {
 // provider, applying the same defaults the previous embedding.Provider
 // wrapper applied (voyage-3-lite model default, nomic-embed-text for
 // ollama, localhost:11434 for the ollama URL), along with a
-// gemini-embedding-001 default for gemini and a text-embedding-3-small
-// default for openai, whose request URLs embed the model name and so
-// cannot be left empty. It returns the client and the resolved model
-// name (after defaults are applied) so callers can display it without
-// re-deriving the default logic.
+// gemini-embedding-001 default for gemini, whose request URL embeds the
+// model name and so cannot be left empty, and a text-embedding-3-small
+// default for openai, whose embeddings API requires a non-empty model
+// field in the JSON request body. It returns the client and the
+// resolved model name (after defaults are applied) so callers can
+// display it without re-deriving the default logic.
 func newEmbedClient(cfg embedClientConfig) (llm.Client, string, error) {
 	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
 	var opts llm.Options

--- a/internal/tools/embed_client.go
+++ b/internal/tools/embed_client.go
@@ -42,10 +42,11 @@ type embedClientConfig struct {
 // provider, applying the same defaults the previous embedding.Provider
 // wrapper applied (voyage-3-lite model default, nomic-embed-text for
 // ollama, localhost:11434 for the ollama URL), along with a
-// gemini-embedding-001 default for gemini, whose request URL embeds the
-// model name and so cannot be left empty. It returns the client
-// and the resolved model name (after defaults are applied) so callers
-// can display it without re-deriving the default logic.
+// gemini-embedding-001 default for gemini and a text-embedding-3-small
+// default for openai, whose request URLs embed the model name and so
+// cannot be left empty. It returns the client and the resolved model
+// name (after defaults are applied) so callers can display it without
+// re-deriving the default logic.
 func newEmbedClient(cfg embedClientConfig) (llm.Client, string, error) {
 	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
 	var opts llm.Options
@@ -67,9 +68,13 @@ func newEmbedClient(cfg embedClientConfig) (llm.Client, string, error) {
 		if cfg.OpenAIAPIKey == "" {
 			return nil, "", fmt.Errorf("missing OpenAI API key for embedding provider 'openai'")
 		}
+		model := cfg.Model
+		if model == "" {
+			model = "text-embedding-3-small"
+		}
 		opts = llm.Options{
 			APIKey:  cfg.OpenAIAPIKey,
-			Model:   cfg.Model,
+			Model:   model,
 			BaseURL: cfg.OpenAIBaseURL,
 		}
 	case "gemini":

--- a/internal/tools/embed_client_test.go
+++ b/internal/tools/embed_client_test.go
@@ -72,13 +72,28 @@ func TestNewEmbedClient(t *testing.T) {
 			wantModel: "voyage-3-lite",
 		},
 		{
-			name: "openai leaves the model to the library",
+			name: "openai defaults the model",
 			cfg: embedClientConfig{
 				Provider:     "openai",
-				Model:        "text-embedding-3-small",
 				OpenAIAPIKey: "test-openai-key",
 			},
 			wantModel: "text-embedding-3-small",
+		},
+		{
+			name: "openai honours an explicit model",
+			cfg: embedClientConfig{
+				Provider:     "openai",
+				Model:        "text-embedding-3-large",
+				OpenAIAPIKey: "test-openai-key",
+			},
+			wantModel: "text-embedding-3-large",
+		},
+		{
+			name: "openai without an api key fails",
+			cfg: embedClientConfig{
+				Provider: "openai",
+			},
+			wantErr: "missing OpenAI API key for embedding provider 'openai'",
 		},
 		{
 			name: "ollama defaults the model",


### PR DESCRIPTION
## Summary

- `newEmbedClient`'s OpenAI branch passed `cfg.Model` through unchanged, so leaving `embedding.model` unset sent an empty model to the OpenAI API, which rejected the request with "model parameter is required".
- OpenAI now defaults to `text-embedding-3-small` when no model is configured, matching the existing fallbacks for Voyage (`voyage-3-lite`), Gemini (`gemini-embedding-001`), and Ollama (`nomic-embed-text`).

## Test plan

- [x] Added `openai defaults the model`, `openai honours an explicit model`, and `openai without an api key fails` cases to `TestNewEmbedClient` in `internal/tools/embed_client_test.go`.
- [x] `go test ./internal/tools/...` passes.
- [x] `go build ./...`, `go vet`, `gofmt -l`, and `golangci-lint run ./internal/tools/...` are clean.

Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI embeddings now automatically use `text-embedding-3-small` when no model is configured.
  * Prevents errors caused by missing embedding model settings.
  * Explicitly configured models continue to be honored.
* **Documentation**
  * Updated embedding provider documentation and changelog with the new default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->