### PR TITLE
fix: connect immediately when switching database connections

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -131,6 +131,16 @@ and this project adheres to
   looks conversational. A model named on the command line, or held as a
   saved preference the provider still serves, is used as before. (#255)
 
+- `select_database_connection` now connects to the target database as
+  part of the switch, instead of only updating which database is
+  current and leaving the connection for whatever tool call happened to
+  use it next. Previously, `list_database_connections` kept reporting a
+  freshly switched-to database as `unavailable` until an unrelated query
+  connected it, contradicting the success response from the switch
+  itself; a switch to an unreachable database also reported success and
+  only surfaced the failure on first use. Switching now fails immediately
+  with the connection error if the database cannot be reached. (#256)
+
 - A configuration file that sets an LLM or embedding option without also
   naming the provider, or enabling the section, is no longer discarded.
   The merge tested only those two fields, so a file that configured just a

--- a/internal/tools/database_switching.go
+++ b/internal/tools/database_switching.go
@@ -257,19 +257,21 @@ permissions. Consider re-examining the schema after switching.`,
 				return mcp.NewToolError(fmt.Sprintf("Access denied to database '%s'", name))
 			}
 
-			// Perform the switch
-			if err := clientManager.SetCurrentDatabase(tokenHash, name); err != nil {
-				return mcp.NewToolError(fmt.Sprintf("Failed to switch database: %v", err))
+			// Connect before committing the switch, as documented, rather
+			// than leaving the database "unavailable" in
+			// list_database_connections until some other tool happens to
+			// use it: a switch that reports success should leave the
+			// target database actually connected. Connecting first, before
+			// changing the current database, also means a switch to an
+			// unreachable database fails outright and leaves the previous
+			// selection in place instead of committing to a database that
+			// isn't there.
+			if _, err := clientManager.GetClientForDatabase(tokenHash, name); err != nil {
+				return mcp.NewToolError(fmt.Sprintf("Failed to connect to database '%s': %v", name, err))
 			}
 
-			// Connect now, as documented, rather than leaving the database
-			// "unavailable" in list_database_connections until some other
-			// tool happens to use it: a switch that reports success should
-			// leave the target database actually connected, and a switch to
-			// an unreachable database should fail here rather than silently
-			// succeed and only surface an error on first query.
-			if _, err := clientManager.GetClientForDatabase(tokenHash, name); err != nil {
-				return mcp.NewToolError(fmt.Sprintf("Switched to database '%s' but failed to connect: %v", name, err))
+			if err := clientManager.SetCurrentDatabase(tokenHash, name); err != nil {
+				return mcp.NewToolError(fmt.Sprintf("Failed to switch database: %v", err))
 			}
 
 			// Build success response

--- a/internal/tools/database_switching.go
+++ b/internal/tools/database_switching.go
@@ -262,6 +262,16 @@ permissions. Consider re-examining the schema after switching.`,
 				return mcp.NewToolError(fmt.Sprintf("Failed to switch database: %v", err))
 			}
 
+			// Connect now, as documented, rather than leaving the database
+			// "unavailable" in list_database_connections until some other
+			// tool happens to use it: a switch that reports success should
+			// leave the target database actually connected, and a switch to
+			// an unreachable database should fail here rather than silently
+			// succeed and only surface an error on first query.
+			if _, err := clientManager.GetClientForDatabase(tokenHash, name); err != nil {
+				return mcp.NewToolError(fmt.Sprintf("Switched to database '%s' but failed to connect: %v", name, err))
+			}
+
 			// Build success response
 			result := map[string]interface{}{
 				"success":      true,

--- a/internal/tools/database_switching_test.go
+++ b/internal/tools/database_switching_test.go
@@ -343,12 +343,18 @@ func TestSelectDatabaseConnectionTool_Success(t *testing.T) {
 // TestSelectDatabaseConnectionTool_ConnectFailure tests that switching to a
 // configured but unreachable database surfaces a connection error
 // immediately, rather than reporting success and leaving the failure for
-// whatever tool call happens to use the connection next.
+// whatever tool call happens to use the connection next, and that the
+// previously selected database remains current rather than being
+// committed to an unreachable one.
 func TestSelectDatabaseConnectionTool_ConnectFailure(t *testing.T) {
 	databases := createTestDatabaseConfigs()
 	cfg := &config.Config{Databases: databases}
 	clientManager := database.NewClientManager(databases)
 	defer clientManager.CloseAll()
+
+	if err := clientManager.SetCurrentDatabase("default", "db1"); err != nil {
+		t.Fatalf("Failed to set initial current database: %v", err)
+	}
 
 	tool := SelectDatabaseConnectionTool(clientManager, nil, cfg)
 
@@ -366,6 +372,10 @@ func TestSelectDatabaseConnectionTool_ConnectFailure(t *testing.T) {
 	}
 	if !strings.Contains(response.Content[0].Text, "failed to connect") {
 		t.Errorf("Expected a connect-failure message, got: %s", response.Content[0].Text)
+	}
+
+	if current := clientManager.GetCurrentDatabase("default"); current != "db1" {
+		t.Errorf("Expected current database to remain 'db1' after a failed switch, got %q", current)
 	}
 }
 

--- a/internal/tools/database_switching_test.go
+++ b/internal/tools/database_switching_test.go
@@ -13,12 +13,69 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 
 	"pgedge-postgres-mcp/internal/config"
 	"pgedge-postgres-mcp/internal/database"
 )
+
+// testDBConfig parses TEST_PGEDGE_POSTGRES_CONNECTION_STRING into a
+// NamedDatabaseConfig for tests that need a genuinely reachable database,
+// skipping the test if the env var isn't set. Mirrors the helper of the
+// same name in internal/database/client_manager_test.go.
+func testDBConfig(t *testing.T) *config.NamedDatabaseConfig {
+	t.Helper()
+	connStr := os.Getenv("TEST_PGEDGE_POSTGRES_CONNECTION_STRING")
+	if connStr == "" {
+		t.Skip("TEST_PGEDGE_POSTGRES_CONNECTION_STRING not set, skipping live database test")
+	}
+
+	u, err := url.Parse(connStr)
+	if err != nil {
+		t.Fatalf("Failed to parse TEST_PGEDGE_POSTGRES_CONNECTION_STRING: %v", err)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	port := 5432
+	if u.Port() != "" {
+		p, err := strconv.Atoi(u.Port())
+		if err != nil {
+			t.Fatalf("invalid port %q in TEST_PGEDGE_POSTGRES_CONNECTION_STRING: %v", u.Port(), err)
+		}
+		port = p
+	}
+	dbName := "postgres"
+	if len(u.Path) > 1 {
+		dbName = u.Path[1:]
+	}
+	user := ""
+	password := ""
+	if u.User != nil {
+		user = u.User.Username()
+		password, _ = u.User.Password()
+	}
+	sslMode := u.Query().Get("sslmode")
+
+	trueVal := true
+	return &config.NamedDatabaseConfig{
+		Name:              "testdb",
+		Host:              host,
+		Port:              port,
+		Database:          dbName,
+		User:              user,
+		Password:          password,
+		SSLMode:           sslMode,
+		AllowWrites:       true,
+		AllowLLMSwitching: &trueVal,
+	}
+}
 
 // Helper to create a test config with databases
 func createTestDatabaseConfigs() []config.NamedDatabaseConfig {
@@ -196,9 +253,18 @@ func TestListDatabaseConnectionsTool_EmptyConfig(t *testing.T) {
 	}
 }
 
-// TestSelectDatabaseConnectionTool_Success tests successful database switching
+// TestSelectDatabaseConnectionTool_Success tests successful database
+// switching against a live database, verifying both the response fields
+// and that the connection is actually established: after a successful
+// switch, list_database_connections must report the database as
+// "connected" without any other tool having run first. Regression test
+// for issue #256, where the switch only updated the current-database
+// pointer and left the target "unavailable" until an unrelated query
+// happened to connect it.
 func TestSelectDatabaseConnectionTool_Success(t *testing.T) {
-	databases := createTestDatabaseConfigs()
+	dbConfig := testDBConfig(t)
+
+	databases := []config.NamedDatabaseConfig{*dbConfig}
 	cfg := &config.Config{Databases: databases}
 	clientManager := database.NewClientManager(databases)
 	defer clientManager.CloseAll()
@@ -212,7 +278,7 @@ func TestSelectDatabaseConnectionTool_Success(t *testing.T) {
 
 	args := map[string]interface{}{
 		"__context": context.Background(),
-		"name":      "db2",
+		"name":      dbConfig.Name,
 	}
 	response, err := tool.Handler(args)
 	if err != nil {
@@ -238,17 +304,68 @@ func TestSelectDatabaseConnectionTool_Success(t *testing.T) {
 	if !result.Success {
 		t.Error("Expected success=true")
 	}
-	if result.Current != "db2" {
-		t.Errorf("Expected current='db2', got %q", result.Current)
+	if result.Current != dbConfig.Name {
+		t.Errorf("Expected current=%q, got %q", dbConfig.Name, result.Current)
 	}
-	if result.Database != "testdb2" {
-		t.Errorf("Expected database='testdb2', got %q", result.Database)
+	if result.Database != dbConfig.Database {
+		t.Errorf("Expected database=%q, got %q", dbConfig.Database, result.Database)
 	}
-	if result.Host != "remotehost" {
-		t.Errorf("Expected host='remotehost', got %q", result.Host)
+	if result.Host != dbConfig.Host {
+		t.Errorf("Expected host=%q, got %q", dbConfig.Host, result.Host)
 	}
 	if result.AllowWrites != true {
 		t.Error("Expected allow_writes=true")
+	}
+
+	if !clientManager.IsConnected("default", dbConfig.Name) {
+		t.Error("Expected the switched-to database to be connected immediately after a successful switch")
+	}
+
+	listTool := ListDatabaseConnectionsTool(clientManager, nil, cfg)
+	listResponse, err := listTool.Handler(map[string]interface{}{"__context": context.Background()})
+	if err != nil {
+		t.Fatalf("list_database_connections returned error: %v", err)
+	}
+	var listResult struct {
+		Databases []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"databases"`
+	}
+	if err := json.Unmarshal([]byte(listResponse.Content[0].Text), &listResult); err != nil {
+		t.Fatalf("Failed to parse list response: %v", err)
+	}
+	if len(listResult.Databases) != 1 || listResult.Databases[0].Status != "connected" {
+		t.Errorf("Expected %q to show status 'connected' after switching, got %+v", dbConfig.Name, listResult.Databases)
+	}
+}
+
+// TestSelectDatabaseConnectionTool_ConnectFailure tests that switching to a
+// configured but unreachable database surfaces a connection error
+// immediately, rather than reporting success and leaving the failure for
+// whatever tool call happens to use the connection next.
+func TestSelectDatabaseConnectionTool_ConnectFailure(t *testing.T) {
+	databases := createTestDatabaseConfigs()
+	cfg := &config.Config{Databases: databases}
+	clientManager := database.NewClientManager(databases)
+	defer clientManager.CloseAll()
+
+	tool := SelectDatabaseConnectionTool(clientManager, nil, cfg)
+
+	args := map[string]interface{}{
+		"__context": context.Background(),
+		"name":      "db2",
+	}
+	response, err := tool.Handler(args)
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	if !response.IsError {
+		t.Fatal("Expected error response for a switch to an unreachable database")
+	}
+	if !strings.Contains(response.Content[0].Text, "failed to connect") {
+		t.Errorf("Expected a connect-failure message, got: %s", response.Content[0].Text)
 	}
 }
 
@@ -724,17 +841,22 @@ func TestPopulateHostFields(t *testing.T) {
 	})
 }
 
-// TestSelectDatabaseConnectionTool_MultiHost tests multi-host fields in select response
+// TestSelectDatabaseConnectionTool_MultiHost tests multi-host fields in the
+// select response, against a live database so the eager connect performed
+// by select_database_connection succeeds.
 func TestSelectDatabaseConnectionTool_MultiHost(t *testing.T) {
+	dbConfig := testDBConfig(t)
 	trueVal := true
 	databases := []config.NamedDatabaseConfig{
 		{
 			Name:     "cluster",
-			Database: "mydb",
-			User:     "user1",
+			Database: dbConfig.Database,
+			User:     dbConfig.User,
+			Password: dbConfig.Password,
+			SSLMode:  dbConfig.SSLMode,
 			Hosts: []config.HostEntry{
-				{Host: "primary.example.com", Port: 5432},
-				{Host: "replica.example.com", Port: 5433},
+				{Host: dbConfig.Host, Port: dbConfig.Port},
+				{Host: dbConfig.Host, Port: dbConfig.Port},
 			},
 			TargetSessionAttrs: "read-write",
 			AllowLLMSwitching:  &trueVal,
@@ -763,8 +885,8 @@ func TestSelectDatabaseConnectionTool_MultiHost(t *testing.T) {
 		t.Fatalf("failed to parse response: %v", jsonErr)
 	}
 
-	if result["host"] != "primary.example.com" {
-		t.Errorf("expected host primary.example.com, got %v", result["host"])
+	if result["host"] != dbConfig.Host {
+		t.Errorf("expected host %v, got %v", dbConfig.Host, result["host"])
 	}
 	hosts, ok := result["hosts"]
 	if !ok {


### PR DESCRIPTION
## Summary

- `select_database_connection` only updated the current-database pointer via `SetCurrentDatabase`, leaving the actual connection for whatever tool call happened to run next.
- `list_database_connections` therefore kept reporting a freshly switched-to database as `unavailable`, directly contradicting the switch's own success response, until an unrelated query established the connection.
- A switch to an unreachable database also silently reported success, with the failure only surfacing on first use.
- The tool now calls `GetClientForDatabase` as part of the switch, matching what's already documented in `docs/reference/tools.md`, so a successful switch is immediately reflected as `connected` and an unreachable database fails the switch itself.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./internal/tools/...`
- [x] `go test ./internal/... ./cmd/...`
- [x] Manually verified the new live-DB gated tests (`TestSelectDatabaseConnectionTool_Success`, `TestSelectDatabaseConnectionTool_MultiHost`) against a real local Postgres via `TEST_PGEDGE_POSTGRES_CONNECTION_STRING`
- [x] Added `TestSelectDatabaseConnectionTool_ConnectFailure` regression test for the unreachable-database case

Closes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database switching now verifies the connection immediately.
  * Switching to an unreachable database reports the connection error instead of indicating success.
  * Connection listings now accurately reflect the selected database’s availability.

* **Documentation**
  * Added an unreleased changelog entry describing the improved database-switching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->