### PR TITLE
fix(tools): stop query_database's LIMIT/OFFSET cap being defeated by plain text

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -123,6 +123,18 @@ and this project adheres to
   `text-embedding-3-small`, matching the built-in fallbacks Voyage,
   Gemini, and Ollama already had.
 
+- `query_database` now caps result sets correctly even when a query's
+  text merely mentions "limit" or "offset" without using them as a SQL
+  clause. It previously decided a query already capped its own results
+  by searching the raw statement text for those words, so a query
+  filtering on a phrase like "credit limit" was wrongly treated as
+  already limited and returned every matching row instead of the
+  requested number. Detection now runs against the statement with
+  comments and string, identifier and dollar-quoted literals removed,
+  and matches the keywords as whole words, so mentions inside data,
+  quoted identifiers or comments no longer suppress the safety cap.
+  (#260)
+
 - The CLI client no longer falls back to a model that cannot hold a
   conversation. When a saved model preference named something the provider
   no longer serves, and the provider's default was absent too, the client

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -13,6 +13,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -21,6 +22,7 @@ import (
 	"pgedge-postgres-mcp/internal/database"
 	"pgedge-postgres-mcp/internal/logging"
 	"pgedge-postgres-mcp/internal/mcp"
+	"pgedge-postgres-mcp/internal/sqltext"
 )
 
 // stripTrailingSemicolons removes trailing semicolons and whitespace from
@@ -29,6 +31,23 @@ func stripTrailingSemicolons(query string) string {
 	return strings.TrimRightFunc(query, func(r rune) bool {
 		return r == ';' || unicode.IsSpace(r)
 	})
+}
+
+// limitKeywordPattern and offsetKeywordPattern match a LIMIT/OFFSET clause
+// keyword as a whole word, so that "credit_limit" or a similarly-named
+// column doesn't count as a clause.
+var limitKeywordPattern = regexp.MustCompile(`(?i)\bLIMIT\b`)
+var offsetKeywordPattern = regexp.MustCompile(`(?i)\bOFFSET\b`)
+
+// queryHasClause reports whether a SQL statement already contains a
+// top-level LIMIT or OFFSET clause. It checks the statement's residue, with
+// comments removed and string literals, dollar-quoted blocks and quoted
+// identifiers replaced by placeholders, so a caller can't defeat the safety
+// cap by mentioning "limit" or "offset" in a string literal, a quoted
+// column alias, or a comment (issue #260).
+func queryHasClause(pattern *regexp.Regexp, sqlQuery string) bool {
+	residue, _ := sqltext.Strip(sqlQuery)
+	return pattern.MatchString(residue)
 }
 
 // QueryDatabaseTool creates the query_database tool
@@ -234,10 +253,13 @@ To avoid rate limits (30,000 input tokens/minute):
 				return mcp.NewToolError("Query is empty")
 			}
 
-			// Track if query already had LIMIT/OFFSET clauses
+			// Track if query already had LIMIT/OFFSET clauses. Checked
+			// against the statement's residue rather than raw text, so a
+			// literal or identifier that merely mentions "limit"/"offset"
+			// doesn't defeat the safety cap (issue #260).
 			upperQuery := strings.ToUpper(strings.TrimSpace(sqlQuery))
-			hasExistingLimit := strings.Contains(upperQuery, "LIMIT")
-			hasExistingOffset := strings.Contains(upperQuery, "OFFSET")
+			hasExistingLimit := queryHasClause(limitKeywordPattern, sqlQuery)
+			hasExistingOffset := queryHasClause(offsetKeywordPattern, sqlQuery)
 
 			// Check if this is a SELECT query - only SELECT queries support LIMIT/OFFSET
 			// DDL (CREATE, ALTER, DROP) and DML (INSERT, UPDATE, DELETE) don't support LIMIT

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -34,10 +34,13 @@ func stripTrailingSemicolons(query string) string {
 }
 
 // limitKeywordPattern and offsetKeywordPattern match a LIMIT/OFFSET clause
-// keyword as a whole word, so that "credit_limit" or a similarly-named
-// column doesn't count as a clause.
-var limitKeywordPattern = regexp.MustCompile(`(?i)\bLIMIT\b`)
-var offsetKeywordPattern = regexp.MustCompile(`(?i)\bOFFSET\b`)
+// keyword bounded by characters that can't appear in a PostgreSQL unquoted
+// identifier, so that "credit_limit" or "foo$limit" (the dollar sign is a
+// legal identifier character after the first position) doesn't count as a
+// clause. Go's regexp package has no lookaround, so the boundary characters
+// are captured alongside the keyword and excluded via the submatch index.
+var limitKeywordPattern = regexp.MustCompile(`(?i)(?:^|[^A-Z0-9_$])(LIMIT)(?:[^A-Z0-9_$]|$)`)
+var offsetKeywordPattern = regexp.MustCompile(`(?i)(?:^|[^A-Z0-9_$])(OFFSET)(?:[^A-Z0-9_$]|$)`)
 
 // queryHasClause reports whether a SQL statement already contains a
 // top-level LIMIT or OFFSET clause. It checks the statement's residue, with
@@ -52,8 +55,10 @@ var offsetKeywordPattern = regexp.MustCompile(`(?i)\bOFFSET\b`)
 // for a clause on the outer statement.
 func queryHasClause(pattern *regexp.Regexp, sqlQuery string) bool {
 	residue, _ := sqltext.Strip(sqlQuery)
-	for _, loc := range pattern.FindAllStringIndex(residue, -1) {
-		if parenDepthAt(residue, loc[0]) == 0 {
+	for _, loc := range pattern.FindAllStringSubmatchIndex(residue, -1) {
+		// loc[2] and loc[3] bound the captured keyword itself, excluding
+		// the boundary characters matched alongside it.
+		if parenDepthAt(residue, loc[2]) == 0 {
 			return true
 		}
 	}

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -45,9 +45,36 @@ var offsetKeywordPattern = regexp.MustCompile(`(?i)\bOFFSET\b`)
 // identifiers replaced by placeholders, so a caller can't defeat the safety
 // cap by mentioning "limit" or "offset" in a string literal, a quoted
 // column alias, or a comment (issue #260).
+//
+// A match only counts at parenthesis depth zero, so a LIMIT/OFFSET that
+// belongs to a subquery or CTE, such as
+// "SELECT * FROM t WHERE id IN (SELECT id FROM u LIMIT 1)", isn't mistaken
+// for a clause on the outer statement.
 func queryHasClause(pattern *regexp.Regexp, sqlQuery string) bool {
 	residue, _ := sqltext.Strip(sqlQuery)
-	return pattern.MatchString(residue)
+	for _, loc := range pattern.FindAllStringIndex(residue, -1) {
+		if parenDepthAt(residue, loc[0]) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// parenDepthAt returns the parenthesis nesting depth at byte offset pos in
+// s, counting unmatched '(' seen before it.
+func parenDepthAt(s string, pos int) int {
+	depth := 0
+	for i := 0; i < pos; i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return depth
 }
 
 // QueryDatabaseTool creates the query_database tool

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -424,6 +424,30 @@ func TestQueryHasClause(t *testing.T) {
 			pattern:        offsetKeywordPattern,
 			expectDetected: false,
 		},
+		{
+			name:           "LIMIT inside a subquery is not an outer clause",
+			query:          "SELECT * FROM parent WHERE id IN (SELECT parent_id FROM child LIMIT 1)",
+			pattern:        limitKeywordPattern,
+			expectDetected: false,
+		},
+		{
+			name:           "OFFSET inside a subquery is not an outer clause",
+			query:          "SELECT * FROM parent WHERE id IN (SELECT parent_id FROM child OFFSET 1)",
+			pattern:        offsetKeywordPattern,
+			expectDetected: false,
+		},
+		{
+			name:           "LIMIT inside a CTE is not an outer clause",
+			query:          "WITH recent AS (SELECT * FROM t LIMIT 5) SELECT * FROM recent",
+			pattern:        limitKeywordPattern,
+			expectDetected: false,
+		},
+		{
+			name:           "real LIMIT clause after a subquery with its own LIMIT",
+			query:          "SELECT * FROM (SELECT * FROM t LIMIT 5) sub LIMIT 10",
+			pattern:        limitKeywordPattern,
+			expectDetected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -370,87 +370,100 @@ func TestStripTrailingSemicolons(t *testing.T) {
 	}
 }
 
-// TestQueryHasClause verifies that LIMIT/OFFSET detection only fires on a
-// real clause, not on the word "limit"/"offset" appearing in a string
-// literal, a quoted identifier, or a comment. See GitHub issue #260, where a
-// query mentioning "credit limit" was wrongly treated as already capped and
+// queryHasClauseTests backs TestQueryHasClause. It verifies that LIMIT/OFFSET
+// detection only fires on a real clause, not on the word "limit"/"offset"
+// appearing in a string literal, a quoted identifier, a comment, or an
+// identifier that merely contains it. See GitHub issue #260, where a query
+// mentioning "credit limit" was wrongly treated as already capped and
 // returned every row instead of the requested number.
-func TestQueryHasClause(t *testing.T) {
-	tests := []struct {
-		name           string
-		query          string
-		pattern        *regexp.Regexp
-		expectDetected bool
-	}{
-		{
-			name:           "real LIMIT clause",
-			query:          "SELECT * FROM t LIMIT 10",
-			pattern:        limitKeywordPattern,
-			expectDetected: true,
-		},
-		{
-			name:           "real OFFSET clause",
-			query:          "SELECT * FROM t OFFSET 10",
-			pattern:        offsetKeywordPattern,
-			expectDetected: true,
-		},
-		{
-			name:           "word in string literal is not a clause",
-			query:          "SELECT * FROM t WHERE note = 'credit limit exceeded'",
-			pattern:        limitKeywordPattern,
-			expectDetected: false,
-		},
-		{
-			name:           "word in quoted identifier is not a clause",
-			query:          `SELECT "credit limit" FROM t`,
-			pattern:        limitKeywordPattern,
-			expectDetected: false,
-		},
-		{
-			name:           "word in a comment is not a clause",
-			query:          "SELECT * FROM t -- check the credit limit\n",
-			pattern:        limitKeywordPattern,
-			expectDetected: false,
-		},
-		{
-			name:           "column named credit_limit is not a clause",
-			query:          "SELECT credit_limit FROM t",
-			pattern:        limitKeywordPattern,
-			expectDetected: false,
-		},
-		{
-			name:           "word in string literal is not an offset clause",
-			query:          "SELECT * FROM t WHERE note = 'apply the offset'",
-			pattern:        offsetKeywordPattern,
-			expectDetected: false,
-		},
-		{
-			name:           "LIMIT inside a subquery is not an outer clause",
-			query:          "SELECT * FROM parent WHERE id IN (SELECT parent_id FROM child LIMIT 1)",
-			pattern:        limitKeywordPattern,
-			expectDetected: false,
-		},
-		{
-			name:           "OFFSET inside a subquery is not an outer clause",
-			query:          "SELECT * FROM parent WHERE id IN (SELECT parent_id FROM child OFFSET 1)",
-			pattern:        offsetKeywordPattern,
-			expectDetected: false,
-		},
-		{
-			name:           "LIMIT inside a CTE is not an outer clause",
-			query:          "WITH recent AS (SELECT * FROM t LIMIT 5) SELECT * FROM recent",
-			pattern:        limitKeywordPattern,
-			expectDetected: false,
-		},
-		{
-			name:           "real LIMIT clause after a subquery with its own LIMIT",
-			query:          "SELECT * FROM (SELECT * FROM t LIMIT 5) sub LIMIT 10",
-			pattern:        limitKeywordPattern,
-			expectDetected: true,
-		},
-	}
+var queryHasClauseTests = []struct {
+	name           string
+	query          string
+	pattern        *regexp.Regexp
+	expectDetected bool
+}{
+	{
+		name:           "real LIMIT clause",
+		query:          "SELECT * FROM t LIMIT 10",
+		pattern:        limitKeywordPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "real OFFSET clause",
+		query:          "SELECT * FROM t OFFSET 10",
+		pattern:        offsetKeywordPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "word in string literal is not a clause",
+		query:          "SELECT * FROM t WHERE note = 'credit limit exceeded'",
+		pattern:        limitKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "word in quoted identifier is not a clause",
+		query:          `SELECT "credit limit" FROM t`,
+		pattern:        limitKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "word in a comment is not a clause",
+		query:          "SELECT * FROM t -- check the credit limit\n",
+		pattern:        limitKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "column named credit_limit is not a clause",
+		query:          "SELECT credit_limit FROM t",
+		pattern:        limitKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "word in string literal is not an offset clause",
+		query:          "SELECT * FROM t WHERE note = 'apply the offset'",
+		pattern:        offsetKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "LIMIT inside a subquery is not an outer clause",
+		query:          "SELECT * FROM parent WHERE id IN (SELECT parent_id FROM child LIMIT 1)",
+		pattern:        limitKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "OFFSET inside a subquery is not an outer clause",
+		query:          "SELECT * FROM parent WHERE id IN (SELECT parent_id FROM child OFFSET 1)",
+		pattern:        offsetKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "LIMIT inside a CTE is not an outer clause",
+		query:          "WITH recent AS (SELECT * FROM t LIMIT 5) SELECT * FROM recent",
+		pattern:        limitKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "real LIMIT clause after a subquery with its own LIMIT",
+		query:          "SELECT * FROM (SELECT * FROM t LIMIT 5) sub LIMIT 10",
+		pattern:        limitKeywordPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "dollar-sign identifier ending in limit is not a clause",
+		query:          "SELECT foo$limit FROM t",
+		pattern:        limitKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "dollar-sign identifier ending in offset is not a clause",
+		query:          "SELECT foo$offset FROM t",
+		pattern:        offsetKeywordPattern,
+		expectDetected: false,
+	},
+}
 
-	for _, tt := range tests {
+func TestQueryHasClause(t *testing.T) {
+	for _, tt := range queryHasClauseTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := queryHasClause(tt.pattern, tt.query)
 			if got != tt.expectDetected {

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -11,6 +11,7 @@
 package tools
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -364,6 +365,72 @@ func TestStripTrailingSemicolons(t *testing.T) {
 			result := stripTrailingSemicolons(tt.input)
 			if result != tt.expected {
 				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestQueryHasClause verifies that LIMIT/OFFSET detection only fires on a
+// real clause, not on the word "limit"/"offset" appearing in a string
+// literal, a quoted identifier, or a comment. See GitHub issue #260, where a
+// query mentioning "credit limit" was wrongly treated as already capped and
+// returned every row instead of the requested number.
+func TestQueryHasClause(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		pattern        *regexp.Regexp
+		expectDetected bool
+	}{
+		{
+			name:           "real LIMIT clause",
+			query:          "SELECT * FROM t LIMIT 10",
+			pattern:        limitKeywordPattern,
+			expectDetected: true,
+		},
+		{
+			name:           "real OFFSET clause",
+			query:          "SELECT * FROM t OFFSET 10",
+			pattern:        offsetKeywordPattern,
+			expectDetected: true,
+		},
+		{
+			name:           "word in string literal is not a clause",
+			query:          "SELECT * FROM t WHERE note = 'credit limit exceeded'",
+			pattern:        limitKeywordPattern,
+			expectDetected: false,
+		},
+		{
+			name:           "word in quoted identifier is not a clause",
+			query:          `SELECT "credit limit" FROM t`,
+			pattern:        limitKeywordPattern,
+			expectDetected: false,
+		},
+		{
+			name:           "word in a comment is not a clause",
+			query:          "SELECT * FROM t -- check the credit limit\n",
+			pattern:        limitKeywordPattern,
+			expectDetected: false,
+		},
+		{
+			name:           "column named credit_limit is not a clause",
+			query:          "SELECT credit_limit FROM t",
+			pattern:        limitKeywordPattern,
+			expectDetected: false,
+		},
+		{
+			name:           "word in string literal is not an offset clause",
+			query:          "SELECT * FROM t WHERE note = 'apply the offset'",
+			pattern:        offsetKeywordPattern,
+			expectDetected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := queryHasClause(tt.pattern, tt.query)
+			if got != tt.expectDetected {
+				t.Errorf("queryHasClause(%q) = %v, want %v", tt.query, got, tt.expectDetected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `query_database` decided a query already had its own `LIMIT`/`OFFSET`
  clause by searching the raw statement text for those words. A query
  merely mentioning "limit" or "offset" in a string literal, a quoted
  identifier or a comment (e.g. filtering on `note = 'credit limit
  exceeded'`) was wrongly treated as already capped, so the tool
  appended nothing and returned every matching row instead of the
  requested number.
- Detection now runs against the statement with comments and string,
  identifier and dollar-quoted literals stripped (reusing the existing
  `internal/sqltext` scanner also used by the read-only guard), and
  matches `LIMIT`/`OFFSET` as whole words rather than substrings, so a
  column named `credit_limit` no longer counts either.
- Fixing the detection also fixes the related pagination-reporting
  issue: previously a false-positive match suppressed the "more rows
  available, use offset=N" message, which could leave a user believing
  they'd seen the full result set when they hadn't.

## Test plan

- [x] Added `TestQueryHasClause`, covering a real `LIMIT`/`OFFSET`
      clause, the word appearing in a string literal, a quoted
      identifier, a comment, and a column named `credit_limit`.
- [x] `go build ./...`
- [x] `go test ./internal/tools/...`
- [x] `gofmt -l` clean

Closes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved query handling to correctly recognize existing top-level `LIMIT` and `OFFSET` clauses.
  - Prevented comments, quoted text, identifiers, nested queries, and similar content from being mistaken for active clauses.
  - Ensured result caps are applied consistently without incorrectly altering already-limited queries.

- **Documentation**
  - Added a changelog entry describing the query result cap fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->