### PR TITLE
Speak the MCP 2026-07-28 modern protocol in the web and CLI clients

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -73,6 +73,13 @@ and this project adheres to
   always been supported; showing only `sslmode` left client certificate
   authentication undiscoverable for anyone working from the examples.
 
+- The web client and the CLI's HTTP and stdio clients now speak the MCP
+  2026-07-28 protocol exclusively, replacing the legacy `initialize`
+  handshake with the stateless `server/discover` call and the
+  per-request `_meta` envelope on every subsequent request. There is no
+  legacy fallback, so a CLI or web client from this release requires a
+  server from this release or later.
+
 ### Changed
 
 - Dependencies across every ecosystem this project uses are now on their

--- a/internal/chat/client_integration_test.go
+++ b/internal/chat/client_integration_test.go
@@ -46,15 +46,16 @@ func mockMCPServer(t *testing.T) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch method {
-		case "initialize":
+		case "server/discover":
 			resp := map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      req["id"],
 				"result": map[string]interface{}{
-					"protocolVersion": "1.0.0",
-					"serverInfo": map[string]interface{}{
-						"name":    "test-server",
-						"version": "1.0.0",
+					"_meta": map[string]interface{}{
+						"io.modelcontextprotocol/serverInfo": map[string]interface{}{
+							"name":    "test-server",
+							"version": "1.0.0",
+						},
 					},
 				},
 			}
@@ -943,15 +944,16 @@ func TestClient_ProcessQuery_ToolListRefreshAfterManageConnections(t *testing.T)
 		w.Header().Set("Content-Type", "application/json")
 
 		switch method {
-		case "initialize":
+		case "server/discover":
 			resp := map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      req["id"],
 				"result": map[string]interface{}{
-					"protocolVersion": "1.0.0",
-					"serverInfo": map[string]interface{}{
-						"name":    "test-server",
-						"version": "1.0.0",
+					"_meta": map[string]interface{}{
+						"io.modelcontextprotocol/serverInfo": map[string]interface{}{
+							"name":    "test-server",
+							"version": "1.0.0",
+						},
 					},
 				},
 			}

--- a/internal/chat/mcp_client.go
+++ b/internal/chat/mcp_client.go
@@ -194,38 +194,12 @@ func NewStdioClient(serverPath, serverConfigPath string) (MCPClient, error) {
 }
 
 func (c *stdioClient) Initialize(ctx context.Context) error {
-	params := mcp.InitializeParams{
-		ProtocolVersion: mcp.ProtocolVersion,
-		Capabilities:    map[string]interface{}{},
-		ClientInfo: mcp.ClientInfo{
-			Name:    "pgedge-nla-cli",
-			Version: ClientVersion,
-		},
+	var result mcp.DiscoverResult
+	if err := c.sendRequest(ctx, "server/discover", nil, &result); err != nil {
+		return fmt.Errorf("discover failed: %w", err)
 	}
 
-	var result mcp.InitializeResult
-	if err := c.sendRequest(ctx, "initialize", params, &result); err != nil {
-		return fmt.Errorf("initialize failed: %w", err)
-	}
-
-	// Store server info
-	c.serverInfo = result.ServerInfo
-
-	// Send initialized notification
-	notification := mcp.JSONRPCRequest{
-		JSONRPC: "2.0",
-		Method:  "notifications/initialized",
-		Params:  map[string]interface{}{},
-	}
-
-	data, err := json.Marshal(notification)
-	if err != nil {
-		return fmt.Errorf("failed to marshal notification: %w", err)
-	}
-
-	if _, err := c.stdin.Write(append(data, '\n')); err != nil {
-		return fmt.Errorf("failed to send notification: %w", err)
-	}
+	c.serverInfo = result.Meta.ServerInfo
 
 	return nil
 }
@@ -337,7 +311,7 @@ func (c *stdioClient) sendRequest(ctx context.Context, method string, params int
 		JSONRPC: "2.0",
 		ID:      id,
 		Method:  method,
-		Params:  params,
+		Params:  withModernMeta(params),
 	}
 
 	reqData, err := json.Marshal(req)

--- a/internal/chat/mcp_client.go
+++ b/internal/chat/mcp_client.go
@@ -14,6 +14,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -63,6 +64,82 @@ type MCPClient interface {
 
 	// Close cleans up resources
 	Close() error
+}
+
+// methodsRequiringMcpName lists the methods for which the Streamable
+// HTTP transport spec requires an Mcp-Name header, mirroring
+// params.name (tools/call, prompts/get) or params.uri
+// (resources/read). Mirrors methodsRequiringMcpName in
+// internal/mcp/modern.go.
+var methodsRequiringMcpName = map[string]bool{
+	"tools/call":     true,
+	"resources/read": true,
+	"prompts/get":    true,
+}
+
+// modernMeta builds the _meta object every modern request this client
+// sends must carry. Deliberately a raw map literal, not the
+// mcp.RequestMeta struct: RequestMeta's ClientCapabilities field
+// carries json:",omitempty", and Go's encoding/json omits an *empty*
+// map under omitempty regardless of nilness, which would silently
+// drop this required key from the outgoing request.
+func modernMeta() map[string]interface{} {
+	return map[string]interface{}{
+		"io.modelcontextprotocol/protocolVersion":    mcp.ModernProtocolVersion,
+		"io.modelcontextprotocol/clientCapabilities": map[string]interface{}{},
+	}
+}
+
+// withModernMeta merges the modern _meta envelope into an arbitrary
+// request's params, via the same marshal-to-map idiom
+// internal/mcp/modern.go uses server-side (mergeModernFields).
+func withModernMeta(params interface{}) map[string]interface{} {
+	m := map[string]interface{}{}
+	if params != nil {
+		if data, err := json.Marshal(params); err == nil {
+			_ = json.Unmarshal(data, &m)
+		}
+	}
+	m["_meta"] = modernMeta()
+	return m
+}
+
+// nameOrURIFor extracts params.name or params.uri from an arbitrary
+// request's params, for the Mcp-Name header. Mirrors nameOrURI in
+// internal/mcp/modern.go.
+func nameOrURIFor(params interface{}) string {
+	if params == nil {
+		return ""
+	}
+	data, err := json.Marshal(params)
+	if err != nil {
+		return ""
+	}
+	var holder struct {
+		Name string `json:"name"`
+		URI  string `json:"uri"`
+	}
+	if err := json.Unmarshal(data, &holder); err != nil {
+		return ""
+	}
+	if holder.Name != "" {
+		return holder.Name
+	}
+	return holder.URI
+}
+
+// encodeHeaderValue is the encode-side mirror of decodeHeaderValue in
+// internal/mcp/modern.go: a value that round-trips safely as a raw
+// HTTP header value is returned as-is; anything else (non-ASCII or
+// control characters) is base64-encoded and wrapped in the spec's
+// "=?base64?<encoded>?=" sentinel.
+func encodeHeaderValue(v string) string {
+	for i := 0; i < len(v); i++ {
+		if v[i] < 0x20 || v[i] > 0x7E {
+			return "=?base64?" + base64.StdEncoding.EncodeToString([]byte(v)) + "?="
+		}
+	}
+	return v
 }
 
 // stdioClient implements MCPClient for stdio communication
@@ -327,22 +404,12 @@ func NewHTTPClient(url, token string) MCPClient {
 }
 
 func (c *httpClient) Initialize(ctx context.Context) error {
-	params := mcp.InitializeParams{
-		ProtocolVersion: mcp.ProtocolVersion,
-		Capabilities:    map[string]interface{}{},
-		ClientInfo: mcp.ClientInfo{
-			Name:    "pgedge-nla-cli",
-			Version: ClientVersion,
-		},
+	var result mcp.DiscoverResult
+	if err := c.sendRequest(ctx, "server/discover", nil, &result); err != nil {
+		return fmt.Errorf("discover failed: %w", err)
 	}
 
-	var result mcp.InitializeResult
-	if err := c.sendRequest(ctx, "initialize", params, &result); err != nil {
-		return fmt.Errorf("initialize failed: %w", err)
-	}
-
-	// Store server info
-	c.serverInfo = result.ServerInfo
+	c.serverInfo = result.Meta.ServerInfo
 
 	return nil
 }
@@ -447,7 +514,7 @@ func (c *httpClient) sendRequest(ctx context.Context, method string, params inte
 		JSONRPC: "2.0",
 		ID:      id,
 		Method:  method,
-		Params:  params,
+		Params:  withModernMeta(params),
 	}
 
 	reqData, err := json.Marshal(req)
@@ -461,6 +528,11 @@ func (c *httpClient) sendRequest(ctx context.Context, method string, params inte
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("MCP-Protocol-Version", mcp.ModernProtocolVersion)
+	httpReq.Header.Set("Mcp-Method", method)
+	if methodsRequiringMcpName[method] {
+		httpReq.Header.Set("Mcp-Name", encodeHeaderValue(nameOrURIFor(params)))
+	}
 	if c.token != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.token)
 	}

--- a/internal/chat/mcp_client.go
+++ b/internal/chat/mcp_client.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 
 	"pgedge-postgres-mcp/internal/mcp"
@@ -130,16 +131,35 @@ func nameOrURIFor(params interface{}) string {
 
 // encodeHeaderValue is the encode-side mirror of decodeHeaderValue in
 // internal/mcp/modern.go: a value that round-trips safely as a raw
-// HTTP header value is returned as-is; anything else (non-ASCII or
-// control characters) is base64-encoded and wrapped in the spec's
-// "=?base64?<encoded>?=" sentinel.
+// HTTP header value is returned as-is; anything else is base64-encoded
+// and wrapped in the spec's "=?base64?<encoded>?=" sentinel.
 func encodeHeaderValue(v string) string {
-	for i := 0; i < len(v); i++ {
-		if v[i] < 0x20 || v[i] > 0x7E {
-			return "=?base64?" + base64.StdEncoding.EncodeToString([]byte(v)) + "?="
-		}
+	if needsEscaping(v) {
+		return "=?base64?" + base64.StdEncoding.EncodeToString([]byte(v)) + "?="
 	}
 	return v
+}
+
+// needsEscaping reports whether v cannot round-trip safely as a raw HTTP
+// header value and must be base64-wrapped instead: any non-printable-ASCII
+// byte, leading/trailing whitespace (stripped by HTTP header parsing on
+// both ends), or a value that already looks like the base64 sentinel
+// (which decodeHeaderValue in internal/mcp/modern.go would otherwise
+// wrongly unwrap).
+func needsEscaping(v string) bool {
+	for i := 0; i < len(v); i++ {
+		if v[i] < 0x20 || v[i] > 0x7E {
+			return true
+		}
+	}
+	if strings.TrimSpace(v) != v {
+		return true
+	}
+	const prefix, suffix = "=?base64?", "?="
+	if len(v) >= len(prefix)+len(suffix) && strings.HasPrefix(v, prefix) && strings.HasSuffix(v, suffix) {
+		return true
+	}
+	return false
 }
 
 // stdioClient implements MCPClient for stdio communication
@@ -502,6 +522,7 @@ func (c *httpClient) sendRequest(ctx context.Context, method string, params inte
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json, text/event-stream")
 	httpReq.Header.Set("MCP-Protocol-Version", mcp.ModernProtocolVersion)
 	httpReq.Header.Set("Mcp-Method", method)
 	if methodsRequiringMcpName[method] {

--- a/internal/chat/mcp_client_test.go
+++ b/internal/chat/mcp_client_test.go
@@ -11,9 +11,12 @@
 package chat
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -331,5 +334,96 @@ func TestNameOrURIFor(t *testing.T) {
 				t.Errorf("nameOrURIFor(%v) = %q, want %q", tc.params, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestStdioClient_Initialize(t *testing.T) {
+	clientToServerR, clientToServerW := io.Pipe()
+	serverToClientR, serverToClientW := io.Pipe()
+
+	scanner := bufio.NewScanner(serverToClientR)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	c := &stdioClient{
+		stdin:   clientToServerW,
+		stdout:  serverToClientR,
+		scanner: scanner,
+	}
+
+	fakeServerErr := make(chan error, 1)
+	go func() {
+		reqScanner := bufio.NewScanner(clientToServerR)
+		reqScanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		if !reqScanner.Scan() {
+			fakeServerErr <- fmt.Errorf("no request received: %v", reqScanner.Err())
+			return
+		}
+
+		var req mcp.JSONRPCRequest
+		if err := json.Unmarshal(reqScanner.Bytes(), &req); err != nil {
+			fakeServerErr <- err
+			return
+		}
+		if req.Method != "server/discover" {
+			fakeServerErr <- fmt.Errorf("expected method 'server/discover', got %q", req.Method)
+			return
+		}
+
+		paramsMap, ok := req.Params.(map[string]interface{})
+		if !ok {
+			fakeServerErr <- fmt.Errorf("expected params to be a map, got %T", req.Params)
+			return
+		}
+		meta, ok := paramsMap["_meta"].(map[string]interface{})
+		if !ok {
+			fakeServerErr <- fmt.Errorf("expected _meta in params, got %v", paramsMap)
+			return
+		}
+		if meta["io.modelcontextprotocol/protocolVersion"] != mcp.ModernProtocolVersion {
+			fakeServerErr <- fmt.Errorf("unexpected protocolVersion: %v",
+				meta["io.modelcontextprotocol/protocolVersion"])
+			return
+		}
+		if _, ok := meta["io.modelcontextprotocol/clientCapabilities"]; !ok {
+			fakeServerErr <- fmt.Errorf("expected clientCapabilities in _meta, got %v", meta)
+			return
+		}
+
+		resp := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result": map[string]interface{}{
+				"_meta": map[string]interface{}{
+					"io.modelcontextprotocol/serverInfo": map[string]interface{}{
+						"name":    "test-server",
+						"version": "1.0.0",
+					},
+				},
+			},
+		}
+		respData, err := json.Marshal(resp)
+		if err != nil {
+			fakeServerErr <- err
+			return
+		}
+		if _, err := serverToClientW.Write(append(respData, '\n')); err != nil {
+			fakeServerErr <- err
+			return
+		}
+		fakeServerErr <- nil
+	}()
+
+	ctx := context.Background()
+	if err := c.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	if err := <-fakeServerErr; err != nil {
+		t.Fatalf("fake server error: %v", err)
+	}
+
+	name, version := c.GetServerInfo()
+	if name != "test-server" || version != "1.0.0" {
+		t.Errorf("Expected server info 'test-server'/'1.0.0', got '%s'/'%s'", name, version)
 	}
 }

--- a/internal/chat/mcp_client_test.go
+++ b/internal/chat/mcp_client_test.go
@@ -363,65 +363,7 @@ func TestStdioClient_Initialize(t *testing.T) {
 
 	fakeServerErr := make(chan error, 1)
 	go func() {
-		reqScanner := bufio.NewScanner(clientToServerR)
-		reqScanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-		if !reqScanner.Scan() {
-			fakeServerErr <- fmt.Errorf("no request received: %v", reqScanner.Err())
-			return
-		}
-
-		var req mcp.JSONRPCRequest
-		if err := json.Unmarshal(reqScanner.Bytes(), &req); err != nil {
-			fakeServerErr <- err
-			return
-		}
-		if req.Method != "server/discover" {
-			fakeServerErr <- fmt.Errorf("expected method 'server/discover', got %q", req.Method)
-			return
-		}
-
-		paramsMap, ok := req.Params.(map[string]interface{})
-		if !ok {
-			fakeServerErr <- fmt.Errorf("expected params to be a map, got %T", req.Params)
-			return
-		}
-		meta, ok := paramsMap["_meta"].(map[string]interface{})
-		if !ok {
-			fakeServerErr <- fmt.Errorf("expected _meta in params, got %v", paramsMap)
-			return
-		}
-		if meta["io.modelcontextprotocol/protocolVersion"] != mcp.ModernProtocolVersion {
-			fakeServerErr <- fmt.Errorf("unexpected protocolVersion: %v",
-				meta["io.modelcontextprotocol/protocolVersion"])
-			return
-		}
-		if _, ok := meta["io.modelcontextprotocol/clientCapabilities"]; !ok {
-			fakeServerErr <- fmt.Errorf("expected clientCapabilities in _meta, got %v", meta)
-			return
-		}
-
-		resp := map[string]interface{}{
-			"jsonrpc": "2.0",
-			"id":      req.ID,
-			"result": map[string]interface{}{
-				"_meta": map[string]interface{}{
-					"io.modelcontextprotocol/serverInfo": map[string]interface{}{
-						"name":    "test-server",
-						"version": "1.0.0",
-					},
-				},
-			},
-		}
-		respData, err := json.Marshal(resp)
-		if err != nil {
-			fakeServerErr <- err
-			return
-		}
-		if _, err := serverToClientW.Write(append(respData, '\n')); err != nil {
-			fakeServerErr <- err
-			return
-		}
-		fakeServerErr <- nil
+		fakeServerErr <- serveFakeStdioDiscover(clientToServerR, serverToClientW)
 	}()
 
 	ctx := context.Background()
@@ -437,4 +379,61 @@ func TestStdioClient_Initialize(t *testing.T) {
 	if name != "test-server" || version != "1.0.0" {
 		t.Errorf("Expected server info 'test-server'/'1.0.0', got '%s'/'%s'", name, version)
 	}
+}
+
+// serveFakeStdioDiscover reads one server/discover request from r, verifies
+// it carries the modern _meta envelope, and writes a matching DiscoverResult
+// response to w. Extracted from TestStdioClient_Initialize so that test's
+// setup stays a single, simple goroutine launch.
+func serveFakeStdioDiscover(r io.Reader, w io.Writer) error {
+	reqScanner := bufio.NewScanner(r)
+	reqScanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	if !reqScanner.Scan() {
+		return fmt.Errorf("no request received: %v", reqScanner.Err())
+	}
+
+	var req mcp.JSONRPCRequest
+	if err := json.Unmarshal(reqScanner.Bytes(), &req); err != nil {
+		return err
+	}
+	if req.Method != "server/discover" {
+		return fmt.Errorf("expected method 'server/discover', got %q", req.Method)
+	}
+
+	paramsMap, ok := req.Params.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("expected params to be a map, got %T", req.Params)
+	}
+	meta, ok := paramsMap["_meta"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("expected _meta in params, got %v", paramsMap)
+	}
+	if meta["io.modelcontextprotocol/protocolVersion"] != mcp.ModernProtocolVersion {
+		return fmt.Errorf("unexpected protocolVersion: %v",
+			meta["io.modelcontextprotocol/protocolVersion"])
+	}
+	if _, ok := meta["io.modelcontextprotocol/clientCapabilities"]; !ok {
+		return fmt.Errorf("expected clientCapabilities in _meta, got %v", meta)
+	}
+
+	resp := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      req.ID,
+		"result": map[string]interface{}{
+			"_meta": map[string]interface{}{
+				"io.modelcontextprotocol/serverInfo": map[string]interface{}{
+					"name":    "test-server",
+					"version": "1.0.0",
+				},
+			},
+		},
+	}
+	respData, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(append(respData, '\n')); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/chat/mcp_client_test.go
+++ b/internal/chat/mcp_client_test.go
@@ -12,6 +12,7 @@ package chat
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -29,22 +30,43 @@ func TestHTTPClient_Initialize(t *testing.T) {
 			t.Fatalf("Failed to decode request: %v", err)
 		}
 
-		if req.Method != "initialize" {
-			t.Errorf("Expected method 'initialize', got '%s'", req.Method)
+		if req.Method != "server/discover" {
+			t.Errorf("Expected method 'server/discover', got '%s'", req.Method)
+		}
+
+		if got := r.Header.Get("MCP-Protocol-Version"); got != mcp.ModernProtocolVersion {
+			t.Errorf("Expected MCP-Protocol-Version '%s', got '%s'", mcp.ModernProtocolVersion, got)
+		}
+		if got := r.Header.Get("Mcp-Method"); got != "server/discover" {
+			t.Errorf("Expected Mcp-Method 'server/discover', got '%s'", got)
+		}
+
+		paramsMap, ok := req.Params.(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected params to be a map, got %T", req.Params)
+		}
+		meta, ok := paramsMap["_meta"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected _meta in params, got %v", paramsMap)
+		}
+		if meta["io.modelcontextprotocol/protocolVersion"] != mcp.ModernProtocolVersion {
+			t.Errorf("Expected protocolVersion '%s' in _meta, got %v",
+				mcp.ModernProtocolVersion, meta["io.modelcontextprotocol/protocolVersion"])
+		}
+		if _, ok := meta["io.modelcontextprotocol/clientCapabilities"]; !ok {
+			t.Errorf("Expected clientCapabilities in _meta, got %v", meta)
 		}
 
 		// Send response
 		resp := mcp.JSONRPCResponse{
 			JSONRPC: "2.0",
 			ID:      req.ID,
-			Result: mcp.InitializeResult{
-				ProtocolVersion: mcp.ProtocolVersion,
-				Capabilities: map[string]interface{}{
-					"tools": map[string]interface{}{},
-				},
-				ServerInfo: mcp.Implementation{
-					Name:    "test-server",
-					Version: "1.0.0",
+			Result: mcp.DiscoverResult{
+				Meta: mcp.ResponseMeta{
+					ServerInfo: mcp.Implementation{
+						Name:    "test-server",
+						Version: "1.0.0",
+					},
 				},
 			},
 		}
@@ -61,6 +83,11 @@ func TestHTTPClient_Initialize(t *testing.T) {
 	ctx := context.Background()
 	if err := client.Initialize(ctx); err != nil {
 		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	name, version := client.GetServerInfo()
+	if name != "test-server" || version != "1.0.0" {
+		t.Errorf("Expected server info 'test-server'/'1.0.0', got '%s'/'%s'", name, version)
 	}
 }
 
@@ -130,6 +157,9 @@ func TestHTTPClient_CallTool(t *testing.T) {
 
 		if req.Method != "tools/call" {
 			t.Errorf("Expected method 'tools/call', got '%s'", req.Method)
+		}
+		if got := r.Header.Get("Mcp-Name"); got != "test_tool" {
+			t.Errorf("Expected Mcp-Name 'test_tool', got '%s'", got)
 		}
 
 		// Send response
@@ -207,5 +237,99 @@ func TestHTTPClient_Authentication(t *testing.T) {
 	_, err := client.ListTools(ctx)
 	if err != nil {
 		t.Fatalf("Request failed: %v", err)
+	}
+}
+
+func TestModernMeta_HasRequiredFields(t *testing.T) {
+	meta := modernMeta()
+
+	if meta["io.modelcontextprotocol/protocolVersion"] != mcp.ModernProtocolVersion {
+		t.Errorf("Expected protocolVersion '%s', got %v",
+			mcp.ModernProtocolVersion, meta["io.modelcontextprotocol/protocolVersion"])
+	}
+
+	caps, ok := meta["io.modelcontextprotocol/clientCapabilities"]
+	if !ok {
+		t.Fatalf("Expected clientCapabilities key to be present, got %v", meta)
+	}
+
+	// The required field must survive a JSON round-trip even though it's
+	// an empty map -- this is the omitempty trap the RequestMeta struct
+	// would fall into if used for outgoing requests.
+	data, err := json.Marshal(map[string]interface{}{"_meta": meta})
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	var roundTripped struct {
+		Meta map[string]interface{} `json:"_meta"`
+	}
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if _, ok := roundTripped.Meta["io.modelcontextprotocol/clientCapabilities"]; !ok {
+		t.Errorf("clientCapabilities was dropped by JSON round-trip: %s", data)
+	}
+
+	_ = caps
+}
+
+func TestEncodeHeaderValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"plain ascii passes through", "test_tool", "test_tool"},
+		{"resource uri passes through", "pg://some/resource", "pg://some/resource"},
+		{"empty string passes through", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := encodeHeaderValue(tc.value); got != tc.want {
+				t.Errorf("encodeHeaderValue(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("non-ASCII value is base64-wrapped and round-trips", func(t *testing.T) {
+		const original = "tést_tool"
+		encoded := encodeHeaderValue(original)
+
+		const prefix, suffix = "=?base64?", "?="
+		if len(encoded) < len(prefix)+len(suffix) ||
+			encoded[:len(prefix)] != prefix || encoded[len(encoded)-len(suffix):] != suffix {
+			t.Fatalf("expected sentinel-wrapped value, got %q", encoded)
+		}
+
+		b64 := encoded[len(prefix) : len(encoded)-len(suffix)]
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			t.Fatalf("base64 decode failed: %v", err)
+		}
+		if string(decoded) != original {
+			t.Errorf("round-trip mismatch: got %q, want %q", string(decoded), original)
+		}
+	})
+}
+
+func TestNameOrURIFor(t *testing.T) {
+	cases := []struct {
+		name   string
+		params interface{}
+		want   string
+	}{
+		{"tool call params", mcp.ToolCallParams{Name: "test_tool"}, "test_tool"},
+		{"resource read params", mcp.ResourceReadParams{URI: "pg://x"}, "pg://x"},
+		{"prompt get params", mcp.PromptGetParams{Name: "my_prompt"}, "my_prompt"},
+		{"nil params", nil, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nameOrURIFor(tc.params); got != tc.want {
+				t.Errorf("nameOrURIFor(%v) = %q, want %q", tc.params, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/chat/mcp_client_test.go
+++ b/internal/chat/mcp_client_test.go
@@ -46,11 +46,13 @@ func TestHTTPClient_Initialize(t *testing.T) {
 
 		paramsMap, ok := req.Params.(map[string]interface{})
 		if !ok {
-			t.Fatalf("Expected params to be a map, got %T", req.Params)
+			t.Errorf("Expected params to be a map, got %T", req.Params)
+			return
 		}
 		meta, ok := paramsMap["_meta"].(map[string]interface{})
 		if !ok {
-			t.Fatalf("Expected _meta in params, got %v", paramsMap)
+			t.Errorf("Expected _meta in params, got %v", paramsMap)
+			return
 		}
 		if meta["io.modelcontextprotocol/protocolVersion"] != mcp.ModernProtocolVersion {
 			t.Errorf("Expected protocolVersion '%s' in _meta, got %v",

--- a/internal/chat/mcp_client_test.go
+++ b/internal/chat/mcp_client_test.go
@@ -295,25 +295,36 @@ func TestEncodeHeaderValue(t *testing.T) {
 		})
 	}
 
-	t.Run("non-ASCII value is base64-wrapped and round-trips", func(t *testing.T) {
-		const original = "tést_tool"
-		encoded := encodeHeaderValue(original)
+	escapedCases := []struct {
+		name     string
+		original string
+	}{
+		{"non-ASCII value is base64-wrapped and round-trips", "tést_tool"},
+		{"leading whitespace is base64-wrapped and round-trips", " leading_space"},
+		{"trailing whitespace is base64-wrapped and round-trips", "trailing_space "},
+		{"value already shaped like the base64 sentinel is re-wrapped and round-trips", "=?base64?aGk=?="},
+	}
 
-		const prefix, suffix = "=?base64?", "?="
-		if len(encoded) < len(prefix)+len(suffix) ||
-			encoded[:len(prefix)] != prefix || encoded[len(encoded)-len(suffix):] != suffix {
-			t.Fatalf("expected sentinel-wrapped value, got %q", encoded)
-		}
+	for _, tc := range escapedCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded := encodeHeaderValue(tc.original)
 
-		b64 := encoded[len(prefix) : len(encoded)-len(suffix)]
-		decoded, err := base64.StdEncoding.DecodeString(b64)
-		if err != nil {
-			t.Fatalf("base64 decode failed: %v", err)
-		}
-		if string(decoded) != original {
-			t.Errorf("round-trip mismatch: got %q, want %q", string(decoded), original)
-		}
-	})
+			const prefix, suffix = "=?base64?", "?="
+			if len(encoded) < len(prefix)+len(suffix) ||
+				encoded[:len(prefix)] != prefix || encoded[len(encoded)-len(suffix):] != suffix {
+				t.Fatalf("expected sentinel-wrapped value, got %q", encoded)
+			}
+
+			b64 := encoded[len(prefix) : len(encoded)-len(suffix)]
+			decoded, err := base64.StdEncoding.DecodeString(b64)
+			if err != nil {
+				t.Fatalf("base64 decode failed: %v", err)
+			}
+			if string(decoded) != tc.original {
+				t.Errorf("round-trip mismatch: got %q, want %q", string(decoded), tc.original)
+			}
+		})
+	}
 }
 
 func TestNameOrURIFor(t *testing.T) {

--- a/internal/chat/mcp_client_test.go
+++ b/internal/chat/mcp_client_test.go
@@ -384,25 +384,46 @@ func TestStdioClient_Initialize(t *testing.T) {
 // serveFakeStdioDiscover reads one server/discover request from r, verifies
 // it carries the modern _meta envelope, and writes a matching DiscoverResult
 // response to w. Extracted from TestStdioClient_Initialize so that test's
-// setup stays a single, simple goroutine launch.
+// setup stays a single, simple goroutine launch; split further into
+// readDiscoverRequest/validateModernEnvelope to keep each function's
+// cyclomatic complexity low.
 func serveFakeStdioDiscover(r io.Reader, w io.Writer) error {
+	req, err := readDiscoverRequest(r)
+	if err != nil {
+		return err
+	}
+	if err := validateModernEnvelope(req.Params); err != nil {
+		return err
+	}
+	return writeDiscoverResponse(w, req.ID)
+}
+
+// readDiscoverRequest scans one JSON-RPC request line from r and confirms
+// its method is server/discover.
+func readDiscoverRequest(r io.Reader) (mcp.JSONRPCRequest, error) {
 	reqScanner := bufio.NewScanner(r)
 	reqScanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	if !reqScanner.Scan() {
-		return fmt.Errorf("no request received: %v", reqScanner.Err())
+		return mcp.JSONRPCRequest{}, fmt.Errorf("no request received: %v", reqScanner.Err())
 	}
 
 	var req mcp.JSONRPCRequest
 	if err := json.Unmarshal(reqScanner.Bytes(), &req); err != nil {
-		return err
+		return mcp.JSONRPCRequest{}, err
 	}
 	if req.Method != "server/discover" {
-		return fmt.Errorf("expected method 'server/discover', got %q", req.Method)
+		return mcp.JSONRPCRequest{}, fmt.Errorf("expected method 'server/discover', got %q", req.Method)
 	}
+	return req, nil
+}
 
-	paramsMap, ok := req.Params.(map[string]interface{})
+// validateModernEnvelope checks that params carries the modern _meta
+// envelope (protocolVersion and clientCapabilities) this test expects
+// stdioClient.sendRequest to attach to every outgoing request.
+func validateModernEnvelope(params interface{}) error {
+	paramsMap, ok := params.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("expected params to be a map, got %T", req.Params)
+		return fmt.Errorf("expected params to be a map, got %T", params)
 	}
 	meta, ok := paramsMap["_meta"].(map[string]interface{})
 	if !ok {
@@ -415,10 +436,15 @@ func serveFakeStdioDiscover(r io.Reader, w io.Writer) error {
 	if _, ok := meta["io.modelcontextprotocol/clientCapabilities"]; !ok {
 		return fmt.Errorf("expected clientCapabilities in _meta, got %v", meta)
 	}
+	return nil
+}
 
+// writeDiscoverResponse writes a DiscoverResult-shaped JSON-RPC response
+// for the given request id to w.
+func writeDiscoverResponse(w io.Writer, id interface{}) error {
 	resp := map[string]interface{}{
 		"jsonrpc": "2.0",
-		"id":      req.ID,
+		"id":      id,
 		"result": map[string]interface{}{
 			"_meta": map[string]interface{}{
 				"io.modelcontextprotocol/serverInfo": map[string]interface{}{

--- a/test/client_modern_protocol_test.go
+++ b/test/client_modern_protocol_test.go
@@ -1,0 +1,89 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package test
+
+// End-to-end coverage of internal/chat's HTTP client against a real
+// server, rather than a hand-written mock. Every existing mcp-client
+// test (Go and JS) exercises a mock that never implements the server's
+// actual Streamable HTTP header/body validation, so none of them would
+// have caught a client-side header-encoding bug (see needsEscaping in
+// internal/chat/mcp_client.go and encodeMcpNameHeader in
+// web/src/lib/mcp-client.js): this test drives chat.NewHTTPClient
+// against the real binary started the same way http_integration_test.go
+// and mcp_modern_protocol_test.go do, so a header/body mismatch would
+// surface here as a real RPC error.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"pgedge-postgres-mcp/internal/chat"
+)
+
+func TestClientModernProtocol(t *testing.T) {
+	server, err := StartHTTPMCPServer(t, "", "test-key", "localhost:18730", false)
+	if err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+
+	client := chat.NewHTTPClient(server.baseURL+"/mcp/v1", "")
+	ctx := context.Background()
+
+	if err := client.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	name, version := client.GetServerInfo()
+	if name == "" || version == "" {
+		t.Errorf("GetServerInfo() = (%q, %q), want non-empty name and version", name, version)
+	}
+
+	tools, err := client.ListTools(ctx)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	if len(tools) == 0 {
+		t.Error("expected at least one tool")
+	}
+
+	resources, err := client.ListResources(ctx)
+	if err != nil {
+		t.Fatalf("ListResources failed: %v", err)
+	}
+	if len(resources) > 0 {
+		// Exercises the Mcp-Name header path for resources/read against
+		// the real server -- no existing test does this.
+		if _, err := client.ReadResource(ctx, resources[0].URI); err != nil {
+			t.Errorf("ReadResource(%q) failed: %v", resources[0].URI, err)
+		}
+	}
+
+	prompts, err := client.ListPrompts(ctx)
+	if err != nil {
+		t.Fatalf("ListPrompts failed: %v", err)
+	}
+	if len(prompts) > 0 {
+		// GetPrompt exercises the Mcp-Name header path for prompts/get.
+		// Real prompts may require arguments this test doesn't supply,
+		// so only fail on a header/protocol-mismatch error -- any other
+		// error (e.g. a missing required argument) is not this test's
+		// concern.
+		if _, err := client.GetPrompt(ctx, prompts[0].Name, map[string]string{}); err != nil {
+			msg := err.Error()
+			if strings.Contains(msg, "RPC error -32020") || strings.Contains(msg, "HeaderMismatch") ||
+				strings.Contains(msg, "RPC error -32022") || strings.Contains(msg, "UnsupportedProtocolVersion") {
+				t.Errorf("GetPrompt(%q) failed with a header/protocol-mismatch error: %v", prompts[0].Name, err)
+			}
+		}
+	}
+}

--- a/test/client_modern_protocol_test.go
+++ b/test/client_modern_protocol_test.go
@@ -39,6 +39,13 @@ func TestClientModernProtocol(t *testing.T) {
 	client := chat.NewHTTPClient(server.baseURL+"/mcp/v1", "")
 	ctx := context.Background()
 
+	checkModernInitialize(t, ctx, client)
+	checkModernListTools(t, ctx, client)
+	checkModernReadResource(t, ctx, client)
+	checkModernGetPrompt(t, ctx, client)
+}
+
+func checkModernInitialize(t *testing.T, ctx context.Context, client chat.MCPClient) {
 	if err := client.Initialize(ctx); err != nil {
 		t.Fatalf("Initialize failed: %v", err)
 	}
@@ -47,7 +54,9 @@ func TestClientModernProtocol(t *testing.T) {
 	if name == "" || version == "" {
 		t.Errorf("GetServerInfo() = (%q, %q), want non-empty name and version", name, version)
 	}
+}
 
+func checkModernListTools(t *testing.T, ctx context.Context, client chat.MCPClient) {
 	tools, err := client.ListTools(ctx)
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
@@ -55,35 +64,44 @@ func TestClientModernProtocol(t *testing.T) {
 	if len(tools) == 0 {
 		t.Error("expected at least one tool")
 	}
+}
 
+// checkModernReadResource exercises the Mcp-Name header path for
+// resources/read against the real server -- no existing mock-based test
+// does this.
+func checkModernReadResource(t *testing.T, ctx context.Context, client chat.MCPClient) {
 	resources, err := client.ListResources(ctx)
 	if err != nil {
 		t.Fatalf("ListResources failed: %v", err)
 	}
-	if len(resources) > 0 {
-		// Exercises the Mcp-Name header path for resources/read against
-		// the real server -- no existing test does this.
-		if _, err := client.ReadResource(ctx, resources[0].URI); err != nil {
-			t.Errorf("ReadResource(%q) failed: %v", resources[0].URI, err)
-		}
+	if len(resources) == 0 {
+		return
 	}
+	if _, err := client.ReadResource(ctx, resources[0].URI); err != nil {
+		t.Errorf("ReadResource(%q) failed: %v", resources[0].URI, err)
+	}
+}
 
+// checkModernGetPrompt exercises the Mcp-Name header path for prompts/get.
+// Real prompts may require arguments this test doesn't supply, so it only
+// fails on a header/protocol-mismatch error -- any other error (e.g. a
+// missing required argument) is not this test's concern.
+func checkModernGetPrompt(t *testing.T, ctx context.Context, client chat.MCPClient) {
 	prompts, err := client.ListPrompts(ctx)
 	if err != nil {
 		t.Fatalf("ListPrompts failed: %v", err)
 	}
-	if len(prompts) > 0 {
-		// GetPrompt exercises the Mcp-Name header path for prompts/get.
-		// Real prompts may require arguments this test doesn't supply,
-		// so only fail on a header/protocol-mismatch error -- any other
-		// error (e.g. a missing required argument) is not this test's
-		// concern.
-		if _, err := client.GetPrompt(ctx, prompts[0].Name, map[string]string{}); err != nil {
-			msg := err.Error()
-			if strings.Contains(msg, "RPC error -32020") || strings.Contains(msg, "HeaderMismatch") ||
-				strings.Contains(msg, "RPC error -32022") || strings.Contains(msg, "UnsupportedProtocolVersion") {
-				t.Errorf("GetPrompt(%q) failed with a header/protocol-mismatch error: %v", prompts[0].Name, err)
-			}
-		}
+	if len(prompts) == 0 {
+		return
+	}
+
+	_, err = client.GetPrompt(ctx, prompts[0].Name, map[string]string{})
+	if err == nil {
+		return
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "RPC error -32020") || strings.Contains(msg, "HeaderMismatch") ||
+		strings.Contains(msg, "RPC error -32022") || strings.Contains(msg, "UnsupportedProtocolVersion") {
+		t.Errorf("GetPrompt(%q) failed with a header/protocol-mismatch error: %v", prompts[0].Name, err)
 	}
 }

--- a/web/src/components/__tests__/Header.test.jsx
+++ b/web/src/components/__tests__/Header.test.jsx
@@ -13,7 +13,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Header from '../Header';
 import { AuthProvider } from '../../contexts/AuthContext';
-import { mockInitialize, mockListTools, mockUserInfo } from '../../test-utils/mcp-mocks';
+import { mockDiscover, mockListTools, mockUserInfo } from '../../test-utils/mcp-mocks';
 
 // Mock the logo imports
 vi.mock('../../assets/images/logo-light.png', () => ({
@@ -42,7 +42,7 @@ describe('Header Component', () => {
         localStorage.setItem('mcp-session-token', 'test-token');
 
         // Mock the sequence of calls that checkAuth makes:
-        global.fetch.mockResolvedValueOnce(mockInitialize(1));
+        global.fetch.mockResolvedValueOnce(mockDiscover(1));
         global.fetch.mockResolvedValueOnce(mockListTools(2));
         global.fetch.mockResolvedValueOnce(mockUserInfo(user.username));
 
@@ -71,7 +71,7 @@ describe('Header Component', () => {
         });
 
         // Re-render with dark mode (token still in localStorage, need to mock auth check again)
-        global.fetch.mockResolvedValueOnce(mockInitialize(3));
+        global.fetch.mockResolvedValueOnce(mockDiscover(3));
         global.fetch.mockResolvedValueOnce(mockListTools(4));
         global.fetch.mockResolvedValueOnce(mockUserInfo('testuser'));
 
@@ -111,7 +111,7 @@ describe('Header Component', () => {
         });
 
         // Re-render with dark mode (token still in localStorage, need to mock auth check again)
-        global.fetch.mockResolvedValueOnce(mockInitialize(3));
+        global.fetch.mockResolvedValueOnce(mockDiscover(3));
         global.fetch.mockResolvedValueOnce(mockListTools(4));
         global.fetch.mockResolvedValueOnce(mockUserInfo('testuser'));
 

--- a/web/src/contexts/__tests__/AuthContext.test.jsx
+++ b/web/src/contexts/__tests__/AuthContext.test.jsx
@@ -43,7 +43,7 @@ describe('AuthContext', () => {
     localStorage.setItem('mcp-session-token', 'test-token');
 
     // Mock the sequence of calls that checkAuth makes:
-    // 1. initialize
+    // 1. server/discover
     global.fetch.mockResolvedValueOnce(mockDiscover(1));
     // 2. listTools
     global.fetch.mockResolvedValueOnce(mockListTools(2));

--- a/web/src/contexts/__tests__/AuthContext.test.jsx
+++ b/web/src/contexts/__tests__/AuthContext.test.jsx
@@ -11,7 +11,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '../AuthContext';
-import { mockInitialize, mockListTools, mockUserInfo, mockAuthenticateSuccess, mockAuthenticateFailure } from '../../test-utils/mcp-mocks';
+import { mockDiscover, mockListTools, mockUserInfo, mockAuthenticateSuccess, mockAuthenticateFailure } from '../../test-utils/mcp-mocks';
 
 describe('AuthContext', () => {
   beforeEach(() => {
@@ -44,7 +44,7 @@ describe('AuthContext', () => {
 
     // Mock the sequence of calls that checkAuth makes:
     // 1. initialize
-    global.fetch.mockResolvedValueOnce(mockInitialize(1));
+    global.fetch.mockResolvedValueOnce(mockDiscover(1));
     // 2. listTools
     global.fetch.mockResolvedValueOnce(mockListTools(2));
     // 3. /api/user/info
@@ -114,7 +114,7 @@ describe('AuthContext', () => {
     localStorage.setItem('mcp-session-token', 'test-token');
 
     // Mock the sequence of calls that checkAuth makes:
-    global.fetch.mockResolvedValueOnce(mockInitialize(1));
+    global.fetch.mockResolvedValueOnce(mockDiscover(1));
     global.fetch.mockResolvedValueOnce(mockListTools(2));
     global.fetch.mockResolvedValueOnce(mockUserInfo('testuser'));
 

--- a/web/src/lib/__tests__/mcp-client.test.js
+++ b/web/src/lib/__tests__/mcp-client.test.js
@@ -113,4 +113,22 @@ describe('MCPClient modern protocol', () => {
         );
         expect(decoded).toBe('tést_tool');
     });
+
+    it.each([
+        ['leading whitespace', ' leading_space'],
+        ['trailing whitespace', 'trailing_space '],
+        ['a value already shaped like the base64 sentinel', '=?base64?aGk=?=']
+    ])('base64-wraps a name with %s and round-trips', async (_desc, original) => {
+        const client = new MCPClient('/mcp/v1');
+        await client.callTool(original, {});
+
+        const header = calls[0].options.headers['Mcp-Name'];
+        expect(header).toMatch(/^=\?base64\?.+\?=$/);
+
+        const encoded = header.slice('=?base64?'.length, -'?='.length);
+        const decoded = new TextDecoder().decode(
+            Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
+        );
+        expect(decoded).toBe(original);
+    });
 });

--- a/web/src/lib/__tests__/mcp-client.test.js
+++ b/web/src/lib/__tests__/mcp-client.test.js
@@ -1,0 +1,116 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge MCP Client - Modern Protocol Tests
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MCPClient, MODERN_PROTOCOL_VERSION } from '../mcp-client';
+
+// Node and jsdom both supply a global fetch, so put the original back
+// rather than deleting the property; other suites sharing this worker
+// would otherwise find it missing.
+const originalFetch = globalThis.fetch;
+
+describe('MCPClient modern protocol', () => {
+    let calls;
+
+    beforeEach(() => {
+        calls = [];
+        globalThis.fetch = vi.fn((url, options) => {
+            const body = JSON.parse(options.body);
+            calls.push({ url, options, body });
+
+            let result;
+            if (body.method === 'server/discover') {
+                result = {
+                    _meta: {
+                        'io.modelcontextprotocol/serverInfo': {
+                            name: 'test-server',
+                            version: '1.0.0'
+                        }
+                    }
+                };
+            } else if (body.method === 'tools/list') {
+                result = { tools: [] };
+            } else {
+                result = {};
+            }
+
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve({ jsonrpc: '2.0', id: body.id, result })
+            });
+        });
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    it('initializes via server/discover, not the legacy handshake', async () => {
+        const client = new MCPClient('/mcp/v1');
+        await client.initialize();
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].body.method).toBe('server/discover');
+        expect(client.getServerInfo()).toEqual({
+            name: 'test-server',
+            version: '1.0.0'
+        });
+    });
+
+    it('sends the modern _meta and headers on every request', async () => {
+        const client = new MCPClient('/mcp/v1');
+        await client.listTools();
+
+        const { body, options } = calls[0];
+        expect(body.params._meta).toEqual({
+            'io.modelcontextprotocol/protocolVersion': MODERN_PROTOCOL_VERSION,
+            'io.modelcontextprotocol/clientCapabilities': {}
+        });
+        expect(options.headers['MCP-Protocol-Version']).toBe(MODERN_PROTOCOL_VERSION);
+        expect(options.headers['Mcp-Method']).toBe('tools/list');
+        expect(options.headers['Mcp-Name']).toBeUndefined();
+    });
+
+    it('sets Mcp-Name from params.name for tools/call', async () => {
+        const client = new MCPClient('/mcp/v1');
+        await client.callTool('test_tool', { arg: 'value' });
+
+        expect(calls[0].options.headers['Mcp-Name']).toBe('test_tool');
+    });
+
+    it('sets Mcp-Name from params.uri for resources/read', async () => {
+        const client = new MCPClient('/mcp/v1');
+        await client.readResource('pg://some/resource');
+
+        expect(calls[0].options.headers['Mcp-Name']).toBe('pg://some/resource');
+    });
+
+    it('sets Mcp-Name from params.name for prompts/get', async () => {
+        const client = new MCPClient('/mcp/v1');
+        await client.getPrompt('my_prompt', {});
+
+        expect(calls[0].options.headers['Mcp-Name']).toBe('my_prompt');
+    });
+
+    it('base64-wraps a non-ASCII Mcp-Name using the =?base64?...?= sentinel', async () => {
+        const client = new MCPClient('/mcp/v1');
+        await client.callTool('tést_tool', {});
+
+        const header = calls[0].options.headers['Mcp-Name'];
+        expect(header).toMatch(/^=\?base64\?.+\?=$/);
+
+        const encoded = header.slice('=?base64?'.length, -'?='.length);
+        const decoded = new TextDecoder().decode(
+            Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
+        );
+        expect(decoded).toBe('tést_tool');
+    });
+});

--- a/web/src/lib/mcp-client.js
+++ b/web/src/lib/mcp-client.js
@@ -10,8 +10,7 @@
 
 // Web client version, injected from web/package.json by the define in
 // vite.config.js and vitest.config.js. It is deliberately not a literal
-// here: this constant is shown in the help panel and sent as
-// clientInfo.version in the MCP initialize handshake, and as a literal it
+// here: this constant is shown in the help panel, and as a literal it
 // sat at 1.0.0-alpha5 through five subsequent releases because nothing
 // tied it to anything that a release already had to touch.
 export const CLIENT_VERSION = __APP_VERSION__;
@@ -48,12 +47,35 @@ function nameOrURI(params) {
     return params.name || params.uri || '';
 }
 
+// needsEscaping mirrors needsEscaping in internal/chat/mcp_client.go: it
+// reports whether value cannot round-trip safely as a raw HTTP header
+// value and must be base64-wrapped instead: any non-printable-ASCII
+// character, leading/trailing whitespace (stripped by HTTP header
+// parsing on both ends), or a value that already looks like the base64
+// sentinel (which decodeHeaderValue in internal/mcp/modern.go would
+// otherwise wrongly unwrap).
+function needsEscaping(value) {
+    if (!/^[\x20-\x7E]*$/.test(value)) {
+        return true;
+    }
+    if (value !== value.trim()) {
+        return true;
+    }
+    const prefix = '=?base64?';
+    const suffix = '?=';
+    if (value.length >= prefix.length + suffix.length &&
+        value.startsWith(prefix) && value.endsWith(suffix)) {
+        return true;
+    }
+    return false;
+}
+
 // encodeMcpNameHeader mirrors decodeHeaderValue in internal/mcp/modern.go:
 // a value that round-trips safely as a raw HTTP header value is sent
-// as-is; anything else (non-ASCII characters, control characters) is
-// base64-encoded and wrapped in the spec's sentinel.
+// as-is; anything else is base64-encoded and wrapped in the spec's
+// sentinel.
 function encodeMcpNameHeader(value) {
-    if (/^[\x20-\x7E]*$/.test(value)) {
+    if (!needsEscaping(value)) {
         return value;
     }
     const bytes = new TextEncoder().encode(value);
@@ -98,6 +120,7 @@ export class MCPClient {
 
         const headers = {
             'Content-Type': 'application/json',
+            'Accept': 'application/json, text/event-stream',
             'MCP-Protocol-Version': MODERN_PROTOCOL_VERSION,
             'Mcp-Method': method
         };

--- a/web/src/lib/mcp-client.js
+++ b/web/src/lib/mcp-client.js
@@ -16,6 +16,51 @@
 // tied it to anything that a release already had to touch.
 export const CLIENT_VERSION = __APP_VERSION__;
 
+// Protocol revision every request this client sends declares itself
+// as speaking. 2026-07-28 removed the connection-scoped initialize
+// handshake in favor of a stateless, per-request model (see
+// internal/mcp/modern.go on the server side) -- there is no older
+// revision to fall back to, since this client only ever talks to this
+// project's own server.
+export const MODERN_PROTOCOL_VERSION = '2026-07-28';
+
+// The Streamable HTTP transport spec requires an Mcp-Name header,
+// mirroring params.name or params.uri, on exactly these methods.
+const METHODS_REQUIRING_MCP_NAME = new Set(['tools/call', 'resources/read', 'prompts/get']);
+
+// modernMeta returns the _meta object every modern request must carry.
+// clientCapabilities is a plain object literal, not built through any
+// helper that might apply JSON.stringify-time omission of an empty
+// value -- the server only checks for the key's presence.
+function modernMeta() {
+    return {
+        'io.modelcontextprotocol/protocolVersion': MODERN_PROTOCOL_VERSION,
+        'io.modelcontextprotocol/clientCapabilities': {}
+    };
+}
+
+// nameOrURI extracts the value an Mcp-Name header must mirror from an
+// arbitrary request's params.
+function nameOrURI(params) {
+    if (!params) {
+        return '';
+    }
+    return params.name || params.uri || '';
+}
+
+// encodeMcpNameHeader mirrors decodeHeaderValue in internal/mcp/modern.go:
+// a value that round-trips safely as a raw HTTP header value is sent
+// as-is; anything else (non-ASCII characters, control characters) is
+// base64-encoded and wrapped in the spec's sentinel.
+function encodeMcpNameHeader(value) {
+    if (/^[\x20-\x7E]*$/.test(value)) {
+        return value;
+    }
+    const bytes = new TextEncoder().encode(value);
+    const base64 = btoa(String.fromCharCode(...bytes));
+    return `=?base64?${base64}?=`;
+}
+
 /**
  * MCP Client for communicating with MCP server via JSON-RPC
  * Mirrors the HTTP client implementation in internal/chat/mcp_client.go
@@ -42,16 +87,24 @@ export class MCPClient {
     async sendRequest(method, params = null) {
         this.requestID++;
 
+        const requestParams = { ...(params || {}), _meta: modernMeta() };
+
         const request = {
             jsonrpc: '2.0',
             id: this.requestID,
             method: method,
-            params: params || {}
+            params: requestParams
         };
 
         const headers = {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'MCP-Protocol-Version': MODERN_PROTOCOL_VERSION,
+            'Mcp-Method': method
         };
+
+        if (METHODS_REQUIRING_MCP_NAME.has(method)) {
+            headers['Mcp-Name'] = encodeMcpNameHeader(nameOrURI(params));
+        }
 
         // Add Authorization header if token is present
         if (this.token) {
@@ -99,22 +152,20 @@ export class MCPClient {
     }
 
     /**
-     * Initialize MCP connection
-     * @returns {Promise<object>} - Initialize result
+     * Discover the server's identity and capabilities under the modern
+     * (2026-07-28) protocol. Replaces the legacy initialize handshake --
+     * 2026-07-28 removed the connection-scoped handshake in favor of a
+     * stateless, per-request model, and server/discover is how a client
+     * learns server identity/capabilities without one.
+     * @returns {Promise<object>} - Discover result
      */
     async initialize() {
-        const result = await this.sendRequest('initialize', {
-            protocolVersion: '2024-11-05',
-            capabilities: {},
-            clientInfo: {
-                name: 'pgedge-nla-web',
-                version: CLIENT_VERSION
-            }
-        });
+        const result = await this.sendRequest('server/discover');
 
-        // Store server info from response
-        if (result && result.serverInfo) {
-            this.serverInfo = result.serverInfo;
+        const serverInfo = result && result._meta &&
+            result._meta['io.modelcontextprotocol/serverInfo'];
+        if (serverInfo) {
+            this.serverInfo = serverInfo;
         }
 
         return result;
@@ -126,15 +177,6 @@ export class MCPClient {
      */
     getServerInfo() {
         return this.serverInfo;
-    }
-
-    /**
-     * Send initialized notification
-     * Note: This is a notification, not a request, so it doesn't expect a response
-     */
-    async sendInitializedNotification() {
-        // For HTTP mode, we still send this as a request (the server handles it)
-        await this.sendRequest('notifications/initialized', {});
     }
 
     /**

--- a/web/src/test-utils/mcp-mocks.js
+++ b/web/src/test-utils/mcp-mocks.js
@@ -64,20 +64,27 @@ export function createHTTPError(status, text) {
 
 /**
  * Create a mock for the server/discover method (the modern,
- * 2026-07-28 replacement for the legacy initialize handshake)
+ * 2026-07-28 replacement for the legacy initialize handshake). Mirrors
+ * the real DiscoverResult shape built by handleDiscoverHTTP in
+ * internal/mcp/http_server.go (resultType, ttlMs, cacheScope,
+ * supportedVersions, capabilities, and _meta.serverInfo).
  * @param {number} id - Request ID
  * @returns {object} - Mock fetch response
  */
-export function mockInitialize(id = 1) {
+export function mockDiscover(id = 1) {
     return createMCPResponse(id, {
+        resultType: 'complete',
+        ttlMs: 86400000,
+        cacheScope: 'public',
+        supportedVersions: ['2026-07-28'],
+        capabilities: {
+            tools: {}
+        },
         _meta: {
             'io.modelcontextprotocol/serverInfo': {
                 name: 'pgedge-postgres-mcp',
                 version: '1.0.0-alpha2'
             }
-        },
-        capabilities: {
-            tools: {}
         }
     });
 }

--- a/web/src/test-utils/mcp-mocks.js
+++ b/web/src/test-utils/mcp-mocks.js
@@ -63,19 +63,21 @@ export function createHTTPError(status, text) {
 }
 
 /**
- * Create a mock for initialize method
+ * Create a mock for the server/discover method (the modern,
+ * 2026-07-28 replacement for the legacy initialize handshake)
  * @param {number} id - Request ID
  * @returns {object} - Mock fetch response
  */
 export function mockInitialize(id = 1) {
     return createMCPResponse(id, {
-        protocolVersion: '2024-11-05',
+        _meta: {
+            'io.modelcontextprotocol/serverInfo': {
+                name: 'pgedge-postgres-mcp',
+                version: '1.0.0-alpha2'
+            }
+        },
         capabilities: {
             tools: {}
-        },
-        serverInfo: {
-            name: 'pgedge-postgres-mcp',
-            version: '1.0.0-alpha2'
         }
     });
 }


### PR DESCRIPTION
## Summary

- The server already implements both the legacy (2024-11-05) handshake and the modern, stateless 2026-07-28 protocol, but every client this project ships was hardcoded to the legacy handshake. This makes all three clients (web client, and both transports of the CLI client) speak the modern protocol exclusively — no fallback or negotiation, since both ends are this project's own server.
- `initialize` is replaced with `server/discover` in all three clients; every outgoing request carries the modern `_meta` envelope, and the HTTP transports (web, CLI httpClient) add the `MCP-Protocol-Version`/`Mcp-Method`/`Mcp-Name`/`Accept` headers the Streamable HTTP transport spec requires.
- Adds a real end-to-end test (`test/client_modern_protocol_test.go`) driving the CLI's HTTP client against a real running server, alongside per-client unit tests.
- One line added to `docs/changelog.md` under `[Unreleased]` noting the version-skew implication (a client from this release needs a same-or-later server).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all green except one pre-existing, environment-only failure (`TestMCPServerIntegration/CallGetSchemaInfo`, no local Postgres credentials in this sandbox) unrelated to this change (`test/integration_test.go` has zero diff on this branch)
- [x] `cd web && npm test -- --run` — 244/244 passing
- [x] `make lint` — 0 issues
- [x] `gofmt -l .` — clean

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated web and CLI clients to use MCP protocol version `2026-07-28`.
  * Added stateless server discovery and modern request metadata support.
  * Improved interoperability for tool, resource, and prompt requests, including names containing non-ASCII or whitespace characters.

* **Bug Fixes**
  * Improved protocol and request-header handling across HTTP and stdio connections.

* **Documentation**
  * Documented the protocol upgrade and compatibility requirement: clients require a server running this release or newer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->