### PR TITLE
feat(tracing): add metadata-only trace mode

### DIFF
--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -1105,6 +1105,10 @@ func main() {
 			DBHostsSet:              cliFlags.DBHostsSet,
 			DBTargetSessionAttrs:    *dbTargetSessionAttrs,
 			DBTargetSessionAttrsSet: cliFlags.DBTargetSessionAttrsSet,
+			TraceFile:               *traceFile,
+			TraceFileSet:            cliFlags.TraceFileSet,
+			TraceMetadataOnly:       *traceMetadataOnly,
+			TraceMetadataOnlySet:    cliFlags.TraceMetadataOnlySet,
 		}
 		reloadableCfg := config.NewReloadableConfig(cfg, configPath, reloadCLIFlags)
 

--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -459,9 +459,9 @@ func main() {
 
 	// Initialize tracing if configured
 	if cfg.TraceFile != "" {
-		if err := tracing.Initialize(cfg.TraceFile, cfg.TraceMetadataOnly); err != nil {
+		if err := tracing.Initialize(cfg.TraceFile, cfg.IsTraceMetadataOnly()); err != nil {
 			fmt.Fprintf(os.Stderr, "WARNING: Failed to initialize tracing: %v\n", err)
-		} else if cfg.TraceMetadataOnly {
+		} else if cfg.IsTraceMetadataOnly() {
 			fmt.Fprintf(os.Stderr, "Tracing: ENABLED (%s, metadata-only)\n", cfg.TraceFile)
 		} else {
 			fmt.Fprintf(os.Stderr, "Tracing: ENABLED (%s)\n", cfg.TraceFile)
@@ -1115,6 +1115,18 @@ func main() {
 		// Register callback to update client manager when databases change
 		reloadableCfg.OnReload(func(newCfg *config.Config) {
 			clientManager.UpdateDatabaseConfigs(newCfg.Databases)
+		})
+
+		// trace_metadata_only can change on a running server: unlike
+		// trace_file itself (opening/closing the trace file is a
+		// startup-only decision behind tracing.Initialize's sync.Once),
+		// it's just a flag Log() consults on every call, so there's no
+		// reason an operator should need a restart just to turn
+		// redaction on or off.
+		reloadableCfg.OnReload(func(newCfg *config.Config) {
+			if tracing.IsEnabled() {
+				tracing.SetMetadataOnly(newCfg.IsTraceMetadataOnly())
+			}
 		})
 
 		// Start SIGHUP listener

--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -71,6 +71,7 @@ func main() {
 	noAuth := flag.Bool("no-auth", false, "Disable API token authentication in HTTP mode")
 	debug := flag.Bool("debug", false, "Enable debug logging (logs HTTP requests/responses)")
 	traceFile := flag.String("trace-file", "", "Path to trace output file (JSONL format)")
+	traceMetadataOnly := flag.Bool("trace-metadata-only", false, "Omit parameters/results from trace entries, keeping only call metadata")
 	tokenFilePath := flag.String("token-file", "", "Path to API token file")
 	showOpenAPI := flag.Bool("openapi", false, "Output OpenAPI specification as JSON and exit")
 
@@ -375,6 +376,9 @@ func main() {
 		case "trace-file":
 			cliFlags.TraceFileSet = true
 			cliFlags.TraceFile = *traceFile
+		case "trace-metadata-only":
+			cliFlags.TraceMetadataOnlySet = true
+			cliFlags.TraceMetadataOnly = *traceMetadataOnly
 		}
 	})
 
@@ -455,8 +459,10 @@ func main() {
 
 	// Initialize tracing if configured
 	if cfg.TraceFile != "" {
-		if err := tracing.Initialize(cfg.TraceFile); err != nil {
+		if err := tracing.Initialize(cfg.TraceFile, cfg.TraceMetadataOnly); err != nil {
 			fmt.Fprintf(os.Stderr, "WARNING: Failed to initialize tracing: %v\n", err)
+		} else if cfg.TraceMetadataOnly {
+			fmt.Fprintf(os.Stderr, "Tracing: ENABLED (%s, metadata-only)\n", cfg.TraceFile)
 		} else {
 			fmt.Fprintf(os.Stderr, "Tracing: ENABLED (%s)\n", cfg.TraceFile)
 		}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,16 @@ and this project adheres to
 
 ### Added
 
+- Tracing gains a metadata-only mode for operators who want per-token
+  attribution without a second copy of customer data. Set
+  `trace_metadata_only` in the configuration file, pass
+  `-trace-metadata-only`, or set `PGEDGE_TRACE_METADATA_ONLY`, and
+  trace entries drop their `parameters` and `result` fields entirely,
+  keeping only session, token hash, tool/resource/prompt name,
+  duration, and success/failure. This has no effect unless `trace_file`
+  (or `-trace-file`) is also set, and defaults to off so existing
+  full-detail tracing is unchanged. (#262)
+
 - Google Gemini now works as an embedding provider, alongside Voyage AI,
   OpenAI, and Ollama. Set `embedding.provider` to `gemini` and supply a
   key through `gemini_api_key_file`, `gemini_api_key`, or the

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -267,6 +267,7 @@ for details.
 | Configuration File Option | CLI Flag | Environment Variable | Description |
 |--------------------------|----------|---------------------|-------------|
 | `trace_file` | `-trace-file` | `PGEDGE_TRACE_FILE` | Path to JSONL trace file for debugging (disabled by default) |
+| `trace_metadata_only` | `-trace-metadata-only` | `PGEDGE_TRACE_METADATA_ONLY` | Omit call parameters and results from trace entries, keeping only metadata (default: false) |
 | `secret_file` | N/A | `PGEDGE_SECRET_FILE` | Path to encryption secret file (auto-generated if not present) |
 | `custom_definitions_path` | N/A | `PGEDGE_CUSTOM_DEFINITIONS_PATH` | Path to custom prompts and resources definition file |
 | `data_dir` | N/A | `PGEDGE_DATA_DIR` | Data directory for conversation history (default: `{binary_dir}/data`) |
@@ -330,6 +331,9 @@ options:
 - `-debug` - Enable debug logging (logs HTTP requests and responses)
 - `-trace-file` - Path to JSONL trace file for debugging MCP
   interactions (disabled by default)
+- `-trace-metadata-only` - Omit call parameters and results from
+  trace entries, keeping only metadata such as session, token,
+  name, duration, and error (disabled by default)
 
 **HTTP/HTTPS Options:**
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -332,7 +332,7 @@ options:
 - `-trace-file` - Path to JSONL trace file for debugging MCP
   interactions (disabled by default)
 - `-trace-metadata-only` - Omit call parameters and results from
-  trace entries, keeping only metadata such as session, token,
+  trace entries, keeping only metadata such as session, token hash,
   name, duration, and error (disabled by default)
 
 **HTTP/HTTPS Options:**

--- a/docs/guide/env_variable_config.md
+++ b/docs/guide/env_variable_config.md
@@ -202,7 +202,7 @@ preferences:
   MCP interactions (disabled by default)
 - **`PGEDGE_TRACE_METADATA_ONLY`**: Omit call parameters and
   results from trace entries, keeping only metadata such as
-  session, token, name, duration, and error (default: false)
+  session, token hash, name, duration, and error (default: false)
 - **`PGEDGE_SECRET_FILE`**: Path to encryption secret file
 - **`PGEDGE_CUSTOM_DEFINITIONS_PATH`**: Path to custom prompts and
   resources definition file

--- a/docs/guide/env_variable_config.md
+++ b/docs/guide/env_variable_config.md
@@ -200,6 +200,9 @@ preferences:
 
 - **`PGEDGE_TRACE_FILE`**: Path to JSONL trace file for debugging
   MCP interactions (disabled by default)
+- **`PGEDGE_TRACE_METADATA_ONLY`**: Omit call parameters and
+  results from trace entries, keeping only metadata such as
+  session, token, name, duration, and error (default: false)
 - **`PGEDGE_SECRET_FILE`**: Path to encryption secret file
 - **`PGEDGE_CUSTOM_DEFINITIONS_PATH`**: Path to custom prompts and
   resources definition file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,8 +56,19 @@ type Config struct {
 	TraceFile string `yaml:"trace_file"`
 
 	// Trace metadata only (omit parameters/results from trace entries,
-	// keeping only session, token, name, duration, and error/success)
-	TraceMetadataOnly bool `yaml:"trace_metadata_only"`
+	// keeping only session, token, name, duration, and error/success).
+	// A pointer, like the Builtins.Tools.* fields below, so mergeConfig
+	// can tell "the file didn't mention this" (nil) apart from "the file
+	// explicitly set it to false" (non-nil pointing to false); a plain
+	// bool can't make that distinction, since both cases parse to the
+	// zero value.
+	TraceMetadataOnly *bool `yaml:"trace_metadata_only"`
+}
+
+// IsTraceMetadataOnly reports whether metadata-only tracing is enabled,
+// defaulting to false (full detail) when unset.
+func (c *Config) IsTraceMetadataOnly() bool {
+	return c.TraceMetadataOnly != nil && *c.TraceMetadataOnly
 }
 
 // BuiltinsConfig holds configuration for enabling/disabling built-in tools, resources, and prompts
@@ -995,8 +1006,8 @@ func mergeConfig(dest, src *Config) {
 		dest.TraceFile = src.TraceFile
 	}
 
-	// Trace metadata only
-	if src.TraceMetadataOnly {
+	// Trace metadata only (pointer preserves an explicit false)
+	if src.TraceMetadataOnly != nil {
 		dest.TraceMetadataOnly = src.TraceMetadataOnly
 	}
 
@@ -1376,7 +1387,7 @@ func applyEnvironmentVariables(cfg *Config) {
 	setStringFromEnv(&cfg.TraceFile, "PGEDGE_TRACE_FILE")
 
 	// Trace metadata only
-	setBoolFromEnv(&cfg.TraceMetadataOnly, "PGEDGE_TRACE_METADATA_ONLY")
+	setBoolPtrFromEnv(&cfg.TraceMetadataOnly, "PGEDGE_TRACE_METADATA_ONLY")
 
 	// Built-in tools, resources, and prompts.
 	// Useful for containerized deployments where editing the config file is awkward.
@@ -1501,7 +1512,7 @@ func applyCLIFlags(cfg *Config, flags CLIFlags) error {
 
 	// Trace metadata only
 	if flags.TraceMetadataOnlySet {
-		cfg.TraceMetadataOnly = flags.TraceMetadataOnly
+		cfg.TraceMetadataOnly = &flags.TraceMetadataOnly
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,10 @@ type Config struct {
 
 	// Trace file path (for logging MCP requests/responses in JSONL format)
 	TraceFile string `yaml:"trace_file"`
+
+	// Trace metadata only (omit parameters/results from trace entries,
+	// keeping only session, token, name, duration, and error/success)
+	TraceMetadataOnly bool `yaml:"trace_metadata_only"`
 }
 
 // BuiltinsConfig holds configuration for enabling/disabling built-in tools, resources, and prompts
@@ -650,6 +654,10 @@ type CLIFlags struct {
 	// Trace file flags
 	TraceFile    string
 	TraceFileSet bool
+
+	// Trace metadata-only flag
+	TraceMetadataOnly    bool
+	TraceMetadataOnlySet bool
 }
 
 // defaultConfig returns configuration with hard-coded defaults
@@ -985,6 +993,11 @@ func mergeConfig(dest, src *Config) {
 	// Trace file
 	if src.TraceFile != "" {
 		dest.TraceFile = src.TraceFile
+	}
+
+	// Trace metadata only
+	if src.TraceMetadataOnly {
+		dest.TraceMetadataOnly = src.TraceMetadataOnly
 	}
 
 	// Builtins - merge individual settings (pointer fields preserve explicit false values)
@@ -1362,6 +1375,9 @@ func applyEnvironmentVariables(cfg *Config) {
 	// Trace file
 	setStringFromEnv(&cfg.TraceFile, "PGEDGE_TRACE_FILE")
 
+	// Trace metadata only
+	setBoolFromEnv(&cfg.TraceMetadataOnly, "PGEDGE_TRACE_METADATA_ONLY")
+
 	// Built-in tools, resources, and prompts.
 	// Useful for containerized deployments where editing the config file is awkward.
 	// Tools
@@ -1481,6 +1497,11 @@ func applyCLIFlags(cfg *Config, flags CLIFlags) error {
 	// Trace file
 	if flags.TraceFileSet {
 		cfg.TraceFile = flags.TraceFile
+	}
+
+	// Trace metadata only
+	if flags.TraceMetadataOnlySet {
+		cfg.TraceMetadataOnly = flags.TraceMetadataOnly
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2341,3 +2341,42 @@ knowledgebase:
 		t.Errorf("Knowledgebase.EmbeddingGeminiBaseURL = %q, want %q", cfg.Knowledgebase.EmbeddingGeminiBaseURL, "https://kb-gemini.example.com")
 	}
 }
+
+// TestMergeTraceMetadataOnlyPreservesExplicitFalse guards against a
+// regression to a plain bool for TraceMetadataOnly, which cannot tell
+// "the file didn't mention this" apart from "the file explicitly set it
+// to false" (both parse to the zero value): a truthy-only merge would
+// silently ignore a file's explicit false and leave dest's prior true in
+// place. Using a pointer, like the Builtins.Tools.* fields, must let an
+// explicit false in src override a true already in dest.
+func TestMergeTraceMetadataOnlyPreservesExplicitFalse(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	dest := defaultConfig()
+	dest.TraceMetadataOnly = &trueVal
+
+	src := &Config{TraceMetadataOnly: &falseVal}
+	mergeConfig(dest, src)
+
+	if dest.IsTraceMetadataOnly() {
+		t.Error("expected src's explicit false to override dest's true, but dest is still true")
+	}
+}
+
+// TestMergeTraceMetadataOnlyNilLeavesDestUnchanged confirms the other
+// half of the same contract: when src doesn't mention the field at all
+// (nil), the merge must not clobber whatever dest already had.
+func TestMergeTraceMetadataOnlyNilLeavesDestUnchanged(t *testing.T) {
+	trueVal := true
+
+	dest := defaultConfig()
+	dest.TraceMetadataOnly = &trueVal
+
+	src := &Config{}
+	mergeConfig(dest, src)
+
+	if !dest.IsTraceMetadataOnly() {
+		t.Error("expected dest's true to survive a merge where src leaves the field nil")
+	}
+}

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -111,6 +111,16 @@ func (rc *ReloadableConfig) logRestartRequiredSettings(newConfig *Config) {
 		fmt.Fprintf(os.Stderr, "  WARNING: http.tls.key_file changed - requires restart\n")
 	}
 
+	// Enabling, disabling, or repointing the trace file requires a
+	// restart: tracing.Initialize opens the file once behind a
+	// sync.Once, so a reload can't open a new file or close an
+	// existing one. trace_metadata_only is exempt from this warning;
+	// unlike trace_file, it's wired to take effect on reload without
+	// a restart.
+	if old.TraceFile != newConfig.TraceFile {
+		fmt.Fprintf(os.Stderr, "  WARNING: trace_file changed - requires restart\n")
+	}
+
 	// LLM/embedding provider changes are logged (may work but connections need reset)
 	if old.LLM.Provider != newConfig.LLM.Provider {
 		fmt.Fprintf(os.Stderr, "  NOTE: llm.provider changed to %s\n", newConfig.LLM.Provider)

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -193,6 +193,22 @@ func GetFilePath() string {
 // messages that quote the offending row).
 const metadataOnlyErrorPlaceholder = "error (detail omitted in metadata-only trace mode)"
 
+// SetMetadataOnly updates whether the tracer redacts Parameters/Result
+// from entries logged from this point on. Unlike Initialize, which is
+// one-time (opening the trace file is a startup-only decision), this
+// may be called any number of times, so that a configuration reload
+// can turn metadata-only mode on or off for an already-running server
+// without needing to restart it just to change that one setting. A
+// no-op if tracing was never initialized.
+func SetMetadataOnly(metadataOnly bool) {
+	if instance == nil {
+		return
+	}
+	instance.mu.Lock()
+	defer instance.mu.Unlock()
+	instance.metadataOnly = metadataOnly
+}
+
 // Log writes a single trace entry to the JSONL file. It auto-sets
 // Timestamp to the current time if the field is zero. When the tracer
 // is configured for metadata-only mode, Parameters and Result are
@@ -208,6 +224,11 @@ func Log(entry TraceEntry) {
 		entry.Timestamp = time.Now().UTC()
 	}
 
+	instance.mu.Lock()
+	defer instance.mu.Unlock()
+
+	// metadataOnly is read under the same lock that SetMetadataOnly
+	// writes it under, so a concurrent reload can't race this check.
 	if instance.metadataOnly {
 		entry.Parameters = nil
 		entry.Result = nil
@@ -215,9 +236,6 @@ func Log(entry TraceEntry) {
 			entry.Error = metadataOnlyErrorPlaceholder
 		}
 	}
-
-	instance.mu.Lock()
-	defer instance.mu.Unlock()
 
 	// Errors during trace writing are intentionally silenced to avoid
 	// disrupting normal server operation.

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -187,10 +187,18 @@ func GetFilePath() string {
 	return instance.filePath
 }
 
+// metadataOnlyErrorPlaceholder replaces an entry's Error text in
+// metadata-only mode, since driver and query errors can themselves
+// echo back query text or data values (e.g. constraint violation
+// messages that quote the offending row).
+const metadataOnlyErrorPlaceholder = "error (detail omitted in metadata-only trace mode)"
+
 // Log writes a single trace entry to the JSONL file. It auto-sets
 // Timestamp to the current time if the field is zero. When the tracer
 // is configured for metadata-only mode, Parameters and Result are
-// dropped before the entry is written, regardless of entry type.
+// dropped before the entry is written, regardless of entry type, and
+// any Error text is replaced with a generic placeholder so failure is
+// still visible without leaking error-message detail.
 func Log(entry TraceEntry) {
 	if !IsEnabled() {
 		return
@@ -203,6 +211,9 @@ func Log(entry TraceEntry) {
 	if instance.metadataOnly {
 		entry.Parameters = nil
 		entry.Result = nil
+		if entry.Error != "" {
+			entry.Error = metadataOnlyErrorPlaceholder
+		}
 	}
 
 	instance.mu.Lock()

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -112,11 +112,12 @@ func durationMs(d time.Duration) *int64 {
 
 // Tracer writes structured trace entries to a JSONL file.
 type Tracer struct {
-	mu       sync.Mutex
-	file     *os.File
-	encoder  *json.Encoder
-	enabled  bool
-	filePath string
+	mu           sync.Mutex
+	file         *os.File
+	encoder      *json.Encoder
+	enabled      bool
+	filePath     string
+	metadataOnly bool
 }
 
 var (
@@ -126,8 +127,10 @@ var (
 
 // Initialize performs one-time initialization of the global tracer.
 // If filePath is empty, tracing remains disabled. Errors are non-fatal
-// and do not prevent server startup.
-func Initialize(filePath string) error {
+// and do not prevent server startup. When metadataOnly is true, trace
+// entries omit their Parameters and Result fields entirely, so only
+// call metadata (session, token, name, duration, error) is written.
+func Initialize(filePath string, metadataOnly bool) error {
 	var initErr error
 
 	once.Do(func() {
@@ -145,10 +148,11 @@ func Initialize(filePath string) error {
 		enc.SetEscapeHTML(false)
 
 		instance = &Tracer{
-			file:     f,
-			encoder:  enc,
-			enabled:  true,
-			filePath: filePath,
+			file:         f,
+			encoder:      enc,
+			enabled:      true,
+			filePath:     filePath,
+			metadataOnly: metadataOnly,
 		}
 	})
 
@@ -184,7 +188,9 @@ func GetFilePath() string {
 }
 
 // Log writes a single trace entry to the JSONL file. It auto-sets
-// Timestamp to the current time if the field is zero.
+// Timestamp to the current time if the field is zero. When the tracer
+// is configured for metadata-only mode, Parameters and Result are
+// dropped before the entry is written, regardless of entry type.
 func Log(entry TraceEntry) {
 	if !IsEnabled() {
 		return
@@ -192,6 +198,11 @@ func Log(entry TraceEntry) {
 
 	if entry.Timestamp.IsZero() {
 		entry.Timestamp = time.Now().UTC()
+	}
+
+	if instance.metadataOnly {
+		entry.Parameters = nil
+		entry.Result = nil
 	}
 
 	instance.mu.Lock()

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -211,10 +211,20 @@ func SetMetadataOnly(metadataOnly bool) {
 
 // Log writes a single trace entry to the JSONL file. It auto-sets
 // Timestamp to the current time if the field is zero. When the tracer
-// is configured for metadata-only mode, Parameters and Result are
-// dropped before the entry is written, regardless of entry type, and
-// any Error text is replaced with a generic placeholder so failure is
-// still visible without leaking error-message detail.
+// is configured for metadata-only mode, Parameters, Result, and
+// Metadata are all dropped before the entry is written, regardless of
+// entry type, and any Error text is replaced with a generic
+// placeholder so failure is still visible without leaking
+// error-message detail.
+//
+// Metadata is cleared rather than allow-listed: it's a caller-supplied
+// map (LogDatabaseSwitch, LogSessionStart/End, LogConfigReload, and
+// any future Log* helper all accept one), so it's exactly as capable
+// of carrying real data as Parameters or Result, and an allowlist
+// would only protect the keys known about today. A denylist by field
+// name is what let issue #262 happen in the first place
+// (sanitizeParams/sanitizeResult); blanket omission is what makes this
+// mode's guarantee hold for entry shapes that don't exist yet.
 func Log(entry TraceEntry) {
 	if !IsEnabled() {
 		return
@@ -232,6 +242,7 @@ func Log(entry TraceEntry) {
 	if instance.metadataOnly {
 		entry.Parameters = nil
 		entry.Result = nil
+		entry.Metadata = nil
 		if entry.Error != "" {
 			entry.Error = metadataOnlyErrorPlaceholder
 		}

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -861,7 +861,11 @@ func TestSanitizationInLogToolCall(t *testing.T) {
 }
 
 // assertNoParametersOrResult fails the test if any entry carries a
-// "parameters" or "result" field, as metadata-only mode requires.
+// "parameters", "result", or "metadata" field, as metadata-only mode
+// requires. Metadata is included alongside Parameters/Result because
+// it's just as caller-controlled as they are (LogDatabaseSwitch,
+// LogSessionStart/End, and LogConfigReload all accept an arbitrary
+// map), so it needs the same blanket omission to keep the guarantee.
 func assertNoParametersOrResult(t *testing.T, entries []map[string]interface{}) {
 	t.Helper()
 	for _, entry := range entries {
@@ -870,6 +874,9 @@ func assertNoParametersOrResult(t *testing.T, entries []map[string]interface{}) 
 		}
 		if _, ok := entry["result"]; ok {
 			t.Errorf("entry %v: expected no \"result\" field in metadata-only mode", entry["type"])
+		}
+		if _, ok := entry["metadata"]; ok {
+			t.Errorf("entry %v: expected no \"metadata\" field in metadata-only mode", entry["type"])
 		}
 	}
 }
@@ -889,12 +896,18 @@ func TestMetadataOnlyOmitsParametersAndResult(t *testing.T) {
 	}, nil, 42*time.Millisecond)
 	LogResourceResult("sess-meta", "tok-hash", "req-meta", "resource://pg/tables", "sensitive rows", nil, 10*time.Millisecond)
 	LogPromptResult("sess-meta", "tok-hash", "req-meta", "explain_query", "sensitive explanation", nil, 5*time.Millisecond)
+	LogDatabaseSwitch("sess-meta", "tok-hash", "req-meta", "customers_db", map[string]interface{}{
+		"previous_query": "SELECT * FROM customers WHERE ssn = '123-45-6789'",
+	})
+	LogConfigReload("sess-meta", map[string]interface{}{
+		"leaked": "this metadata map is caller-supplied, just like Parameters and Result",
+	})
 
 	Close()
 
 	entries := parseJSONLFile(t, tracePath)
-	if len(entries) != 4 {
-		t.Fatalf("expected 4 entries, got %d", len(entries))
+	if len(entries) != 6 {
+		t.Fatalf("expected 6 entries, got %d", len(entries))
 	}
 
 	assertNoParametersOrResult(t, entries)

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -55,7 +55,7 @@ func parseJSONLFile(t *testing.T, path string) []map[string]interface{} {
 func TestInitializeEmpty(t *testing.T) {
 	ResetForTesting()
 
-	Initialize("")
+	Initialize("", false)
 
 	if IsEnabled() {
 		t.Error("expected tracing to be disabled after Initialize(\"\")")
@@ -66,7 +66,7 @@ func TestInitializeValid(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 	defer Close()
 
 	if !IsEnabled() {
@@ -107,7 +107,7 @@ func TestLogToolCall(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	params := map[string]interface{}{
 		"query": "SELECT 1",
@@ -146,7 +146,7 @@ func TestLogToolResult(t *testing.T) {
 		ResetForTesting()
 
 		tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-		Initialize(tracePath)
+		Initialize(tracePath, false)
 
 		LogToolResult("sess-1", "tok", "req1", "query_database", "some result", nil, 250*time.Millisecond)
 
@@ -182,7 +182,7 @@ func TestLogToolResult(t *testing.T) {
 		ResetForTesting()
 
 		tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-		Initialize(tracePath)
+		Initialize(tracePath, false)
 
 		testErr := fmt.Errorf("connection refused")
 		LogToolResult("sess-2", "tok", "req2", "query_database", "", testErr, 100*time.Millisecond)
@@ -213,7 +213,7 @@ func TestLogResourceReadResult(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	LogResourceRead("sess-r", "tok", "req1", "resource://pg/tables")
 	LogResourceResult("sess-r", "tok", "req1", "resource://pg/tables", nil, nil, 30*time.Millisecond)
@@ -237,7 +237,7 @@ func TestLogPromptCallResult(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	LogPromptCall("sess-p", "tok", "req1", "explain_query", map[string]string{"sql": "SELECT 1"})
 	LogPromptResult("sess-p", "tok", "req1", "explain_query", nil, nil, 60*time.Millisecond)
@@ -261,7 +261,7 @@ func TestLogDatabaseSwitch(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	metadata := map[string]interface{}{
 		"previous": "db1",
@@ -292,7 +292,7 @@ func TestLogConfigReload(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	metadata := map[string]interface{}{
 		"source": "file_watcher",
@@ -320,7 +320,7 @@ func TestLogHTTPRequestResponse(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	LogHTTPRequest("sess-http", "tok", "req1", "POST", "/api/v1/query", nil)
 	LogHTTPResponse("sess-http", "tok", "req1", "POST", "/api/v1/query", 200, nil, 45*time.Millisecond)
@@ -383,7 +383,7 @@ func TestLogSessionStartEnd(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	startMeta := map[string]interface{}{
 		"transport": "stdio",
@@ -422,7 +422,7 @@ func TestLogError(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	LogError("sess-err", "tok", "req1", "database_query", fmt.Errorf("relation \"foo\" does not exist"))
 
@@ -453,7 +453,7 @@ func TestLogUserPromptAndLLMResponse(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	LogUserPrompt("sess-llm", "tok", "req1", "What tables exist in the database?")
 	LogLLMResponse("sess-llm", "tok", "req1", "The database contains the following tables...", 1500*time.Millisecond)
@@ -517,7 +517,7 @@ func TestDurationSerialization(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	// 1.5 seconds should serialize as duration_ms=1500 (integer).
 	LogToolResult("sess-dur", "tok", "req1", "slow_tool", "done", nil, 1500*time.Millisecond)
@@ -548,7 +548,7 @@ func TestZeroDurationNotOmitted(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	// A zero-duration result must still include duration_ms: 0
 	// so that "not measured" (nil, omitted) and "instant" (0) are
@@ -581,7 +581,7 @@ func TestHTMLEscapingDisabled(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	params := map[string]interface{}{
 		"input": "<script>alert(1)</script>",
@@ -612,7 +612,7 @@ func TestFilePermissions(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 	defer Close()
 
 	info, err := os.Stat(tracePath)
@@ -630,7 +630,7 @@ func TestConcurrentWrites(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 
 	const goroutineCount = 100
 	var wg sync.WaitGroup
@@ -668,7 +668,7 @@ func TestResetForTesting(t *testing.T) {
 
 	// Initialize and verify enabled.
 	tracePath1 := filepath.Join(t.TempDir(), "trace1.jsonl")
-	Initialize(tracePath1)
+	Initialize(tracePath1, false)
 
 	if !IsEnabled() {
 		t.Error("expected tracing to be enabled after Initialize")
@@ -685,7 +685,7 @@ func TestResetForTesting(t *testing.T) {
 
 	// Initialize again with a new path and verify enabled.
 	tracePath2 := filepath.Join(t.TempDir(), "trace2.jsonl")
-	Initialize(tracePath2)
+	Initialize(tracePath2, false)
 	defer Close()
 
 	if !IsEnabled() {
@@ -833,7 +833,7 @@ func TestSanitizationInLogToolCall(t *testing.T) {
 	ResetForTesting()
 
 	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
-	Initialize(tracePath)
+	Initialize(tracePath, false)
 	defer Close()
 
 	LogToolCall("sess1", "hash1", "req1", "authenticate_user", map[string]interface{}{
@@ -857,5 +857,77 @@ func TestSanitizationInLogToolCall(t *testing.T) {
 	}
 	if params["username"] != "admin" {
 		t.Errorf("expected username to be preserved in trace, got %v", params["username"])
+	}
+}
+
+func TestMetadataOnlyOmitsParametersAndResult(t *testing.T) {
+	ResetForTesting()
+
+	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
+	Initialize(tracePath, true)
+	defer Close()
+
+	LogToolCall("sess-meta", "tok-hash", "req-meta", "query_database", map[string]interface{}{
+		"query": "SELECT * FROM customers",
+	})
+	LogToolResult("sess-meta", "tok-hash", "req-meta", "query_database", []map[string]interface{}{
+		{"id": 1, "name": "Jane Doe"},
+	}, nil, 42*time.Millisecond)
+	LogResourceResult("sess-meta", "tok-hash", "req-meta", "resource://pg/tables", "sensitive rows", nil, 10*time.Millisecond)
+	LogPromptResult("sess-meta", "tok-hash", "req-meta", "explain_query", "sensitive explanation", nil, 5*time.Millisecond)
+
+	Close()
+
+	entries := parseJSONLFile(t, tracePath)
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+
+	for _, entry := range entries {
+		if _, ok := entry["parameters"]; ok {
+			t.Errorf("entry %v: expected no \"parameters\" field in metadata-only mode", entry["type"])
+		}
+		if _, ok := entry["result"]; ok {
+			t.Errorf("entry %v: expected no \"result\" field in metadata-only mode", entry["type"])
+		}
+	}
+
+	toolCall := entries[0]
+	if toolCall["type"] != "tool_call" {
+		t.Errorf("type = %v, want \"tool_call\"", toolCall["type"])
+	}
+	if toolCall["name"] != "query_database" {
+		t.Errorf("name = %v, want \"query_database\"", toolCall["name"])
+	}
+	if toolCall["session_id"] != "sess-meta" {
+		t.Errorf("session_id = %v, want \"sess-meta\"", toolCall["session_id"])
+	}
+
+	toolResult := entries[1]
+	durationMs, ok := toolResult["duration_ms"].(float64)
+	if !ok || int(durationMs) != 42 {
+		t.Errorf("duration_ms = %v, want 42", toolResult["duration_ms"])
+	}
+}
+
+func TestMetadataOnlyFalsePreservesParametersAndResult(t *testing.T) {
+	ResetForTesting()
+
+	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
+	Initialize(tracePath, false)
+	defer Close()
+
+	LogToolCall("sess-full", "tok-hash", "req-full", "query_database", map[string]interface{}{
+		"query": "SELECT 1",
+	})
+
+	Close()
+
+	entries := parseJSONLFile(t, tracePath)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if _, ok := entries[0]["parameters"]; !ok {
+		t.Error("expected \"parameters\" field to be present when metadata-only is disabled")
 	}
 }

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -860,6 +860,20 @@ func TestSanitizationInLogToolCall(t *testing.T) {
 	}
 }
 
+// assertNoParametersOrResult fails the test if any entry carries a
+// "parameters" or "result" field, as metadata-only mode requires.
+func assertNoParametersOrResult(t *testing.T, entries []map[string]interface{}) {
+	t.Helper()
+	for _, entry := range entries {
+		if _, ok := entry["parameters"]; ok {
+			t.Errorf("entry %v: expected no \"parameters\" field in metadata-only mode", entry["type"])
+		}
+		if _, ok := entry["result"]; ok {
+			t.Errorf("entry %v: expected no \"result\" field in metadata-only mode", entry["type"])
+		}
+	}
+}
+
 func TestMetadataOnlyOmitsParametersAndResult(t *testing.T) {
 	ResetForTesting()
 
@@ -883,14 +897,7 @@ func TestMetadataOnlyOmitsParametersAndResult(t *testing.T) {
 		t.Fatalf("expected 4 entries, got %d", len(entries))
 	}
 
-	for _, entry := range entries {
-		if _, ok := entry["parameters"]; ok {
-			t.Errorf("entry %v: expected no \"parameters\" field in metadata-only mode", entry["type"])
-		}
-		if _, ok := entry["result"]; ok {
-			t.Errorf("entry %v: expected no \"result\" field in metadata-only mode", entry["type"])
-		}
-	}
+	assertNoParametersOrResult(t, entries)
 
 	toolCall := entries[0]
 	if toolCall["type"] != "tool_call" {

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -910,6 +910,35 @@ func TestMetadataOnlyOmitsParametersAndResult(t *testing.T) {
 	}
 }
 
+func TestMetadataOnlyRedactsErrorText(t *testing.T) {
+	ResetForTesting()
+
+	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
+	Initialize(tracePath, true)
+	defer Close()
+
+	testErr := fmt.Errorf(`duplicate key value violates unique constraint "users_email_key" (Key (email)=(jane@example.com) already exists)`)
+	LogToolResult("sess-err", "tok-hash", "req-err", "query_database", nil, testErr, 5*time.Millisecond)
+
+	Close()
+
+	entries := parseJSONLFile(t, tracePath)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	errField, ok := entries[0]["error"].(string)
+	if !ok {
+		t.Fatalf("expected \"error\" field to be a string, got %T", entries[0]["error"])
+	}
+	if errField != metadataOnlyErrorPlaceholder {
+		t.Errorf("error = %q, want generic placeholder %q", errField, metadataOnlyErrorPlaceholder)
+	}
+	if strings.Contains(errField, "jane@example.com") {
+		t.Error("expected error text to be redacted, but it leaked the underlying error message")
+	}
+}
+
 func TestMetadataOnlyFalsePreservesParametersAndResult(t *testing.T) {
 	ResetForTesting()
 

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -967,3 +967,61 @@ func TestMetadataOnlyFalsePreservesParametersAndResult(t *testing.T) {
 		t.Error("expected \"parameters\" field to be present when metadata-only is disabled")
 	}
 }
+
+// TestSetMetadataOnlyTakesEffectWithoutRestart is the regression test
+// for the scenario a config reload is supposed to support: an operator
+// turns metadata-only mode on (or off) on an already-running server,
+// without restarting it. Before SetMetadataOnly existed, the tracer's
+// metadataOnly flag was set once in Initialize and never touched
+// again, so an entry logged after a config reload that flipped
+// trace_metadata_only would silently keep using the tracer's original
+// setting -- the reload would report success while quietly leaving the
+// old behavior in place.
+func TestSetMetadataOnlyTakesEffectWithoutRestart(t *testing.T) {
+	ResetForTesting()
+
+	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
+	Initialize(tracePath, false)
+	defer Close()
+
+	LogToolCall("sess-a", "tok", "req1", "query_database", map[string]interface{}{
+		"query": "SELECT 1",
+	})
+
+	SetMetadataOnly(true)
+
+	LogToolCall("sess-b", "tok", "req2", "query_database", map[string]interface{}{
+		"query": "SELECT 2",
+	})
+
+	SetMetadataOnly(false)
+
+	LogToolCall("sess-c", "tok", "req3", "query_database", map[string]interface{}{
+		"query": "SELECT 3",
+	})
+
+	Close()
+
+	entries := parseJSONLFile(t, tracePath)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+	if _, ok := entries[0]["parameters"]; !ok {
+		t.Error("entry logged before SetMetadataOnly(true): expected parameters to be present")
+	}
+	if _, ok := entries[1]["parameters"]; ok {
+		t.Error("entry logged after SetMetadataOnly(true): expected parameters to be omitted")
+	}
+	if _, ok := entries[2]["parameters"]; !ok {
+		t.Error("entry logged after SetMetadataOnly(false): expected parameters to be present again")
+	}
+}
+
+// TestSetMetadataOnlyNoopWhenTracingNotInitialized confirms
+// SetMetadataOnly doesn't panic when called before (or without) tracing
+// having been initialized, matching the other tracing functions' pattern
+// of tolerating a nil instance.
+func TestSetMetadataOnlyNoopWhenTracingNotInitialized(t *testing.T) {
+	ResetForTesting()
+	SetMetadataOnly(true)
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in `trace_metadata_only` setting (also `-trace-metadata-only` and `PGEDGE_TRACE_METADATA_ONLY`) that drops the `parameters` and `result` fields from every trace entry, keeping only `session_id`, `token_hash`, `name`, `duration_ms`, and error/success.
- The redaction is centralised in `tracing.Log()`, so it applies uniformly to tool calls, resource reads, prompt calls, and any future entry type, rather than needing to be added to each `Log*` helper individually.
- Default is `false`, so existing full-detail tracing behaviour is unchanged; this has no effect unless `trace_file`/`-trace-file` is also set.

Addresses the concern in #262: enabling `trace_file` today writes the full SQL text and full result rows for every `query_database` call, turning tracing into a second copy of customer data. This gives operators (e.g. drydock) a lighter-weight "who did what, when, did it work" attribution trail without that commitment.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all unit test packages pass; the one pre-existing failure is an unrelated local-Postgres integration test that needs a live database)
- [x] `gofmt -l` / `go vet ./...` clean
- [x] Added `TestMetadataOnlyOmitsParametersAndResult` and `TestMetadataOnlyFalsePreservesParametersAndResult` in `internal/tracing/tracer_test.go`
- [x] Documented the new flag/config/env var in `docs/guide/configuration.md`, `docs/guide/env_variable_config.md`, and `docs/changelog.md`

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metadata-only tracing, retaining event identity, timing, and status while omitting call parameters and results.
  * Sensitive error details are replaced with a generic placeholder.
  * Configure the feature through the configuration file, command-line flag, or environment variable.
  * Changes apply during configuration reloads without restarting tracing.
  * Disabled by default and requires trace-file output.

* **Documentation**
  * Added configuration guidance and changelog details.

* **Tests**
  * Added coverage for metadata-only and standard tracing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->