### PR TITLE
fix(http): guard nil userStore in /api/user/info handler

### DIFF
--- a/cmd/pgedge-pg-mcp-svr/main.go
+++ b/cmd/pgedge-pg-mcp-svr/main.go
@@ -918,6 +918,13 @@ func main() {
 				}
 
 				// Validate session token and get username
+				if userStore == nil {
+					//nolint:errcheck // Encoding a simple map should never fail
+					json.NewEncoder(w).Encode(map[string]any{
+						"authenticated": false,
+					})
+					return
+				}
 				username, err := userStore.ValidateSessionToken(token)
 				if err != nil {
 					//nolint:errcheck // Encoding a simple map should never fail

--- a/test/http_integration_test.go
+++ b/test/http_integration_test.go
@@ -370,6 +370,10 @@ func TestHTTPModeIntegration(t *testing.T) {
 	t.Run("GETRequestRejected", func(t *testing.T) {
 		testHTTPGETRejected(t, server)
 	})
+
+	t.Run("UserInfoNoAuth", func(t *testing.T) {
+		testHTTPUserInfoNoAuth(t, server)
+	})
 }
 
 // TestHTTPSModeIntegration tests the HTTPS transport mode with TLS
@@ -643,6 +647,49 @@ func testHTTPGETRejected(t *testing.T, server *HTTPMCPServer) {
 	}
 
 	t.Log("HTTP GET rejection test passed")
+}
+
+// testHTTPUserInfoNoAuth verifies that /api/user/info with a bearer token
+// does not panic when the server runs with HTTP auth disabled (-no-auth),
+// where userStore is nil. See issue #269.
+func testHTTPUserInfoNoAuth(t *testing.T, server *HTTPMCPServer) {
+	client := server.getHTTPClient()
+
+	req, err := http.NewRequest(http.MethodGet, server.baseURL+"/api/user/info", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer anything")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Logf("Warning: failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse response body: %v\nBody: %s", err, body)
+	}
+
+	if authenticated, ok := result["authenticated"].(bool); !ok || authenticated {
+		t.Errorf("Expected authenticated=false, got: %v", result)
+	}
+
+	t.Log("User info no-auth test passed")
 }
 
 func testHTTPSTLSConnection(t *testing.T, server *HTTPMCPServer) {


### PR DESCRIPTION
## Summary
- `/api/user/info` called `userStore.ValidateSessionToken` unconditionally, panicking when the server runs with HTTP auth disabled (`-no-auth`) and `userStore` stays nil.
- Added the same `userStore == nil` guard already used elsewhere in `main.go` (auth middleware, shutdown), returning `{"authenticated": false}` to match the endpoint's existing behaviour for a missing/malformed header.

## Test plan
- [x] Added `TestHTTPModeIntegration/UserInfoNoAuth`, which starts the server with `-no-auth` and sends a bearer token to `/api/user/info`; confirmed it reproduces the panic on the pre-fix code and passes after the fix.
- [x] `make fmt`, `go vet ./...`, `golangci-lint run ./cmd/... ./test/...` all clean.

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the user information endpoint behavior when authentication is disabled.
  * The endpoint now returns a successful response indicating that authentication is not enabled, even when a bearer token is provided.

* **Tests**
  * Added integration coverage to verify the unauthenticated response and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->