### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,9 @@
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities to **security@pgedge.com**, which
-reaches the pgEdge security team.
+Please report security vulnerabilities to
+[**security@pgedge.com**](mailto:security@pgedge.com), which reaches the
+pgEdge security team.
 
 Please do not open a public issue for a suspected vulnerability.
 
@@ -25,7 +26,7 @@ What is in scope, our safe harbour terms, and how we handle coordinated
 disclosure and CVE identifiers are all set out in the pgEdge Vulnerability
 Disclosure Statement:
 
-**https://docs.pgedge.com/security**
+[**https://docs.pgedge.com/security**](https://docs.pgedge.com/security)
 
 You may test this software freely in an environment you control. Testing
 pgEdge Cloud requires prior written authorisation — see the statement.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities to **security@pgedge.com**, which
+reaches the pgEdge security team.
+
+Please do not open a public issue for a suspected vulnerability.
+
+Tell us the product and version, what the impact is, and how to reproduce
+it. You do not need to sign anything or hold a pgEdge contract to report to
+us.
+
+We acknowledge reports within five business days, tell you the outcome of
+our assessment, and tell you before we publish anything.
+
+## Supported Versions
+
+Security fixes are provided for the latest release of each product. Where a
+product has its own published support lifecycle, that lifecycle governs.
+
+## Scope and Safe Harbour
+
+What is in scope, our safe harbour terms, and how we handle coordinated
+disclosure and CVE identifiers are all set out in the pgEdge Vulnerability
+Disclosure Statement:
+
+**https://docs.pgedge.com/security**
+
+You may test this software freely in an environment you control. Testing
+pgEdge Cloud requires prior written authorisation — see the statement.
+
+## Published Advisories
+
+Advisories are published under the Security tab of the repository for the
+affected product.


### PR DESCRIPTION
Adds `SECURITY.md` to the repository root. It names **security@pgedge.com** as
the single reporting route and points at the pgEdge Vulnerability Disclosure
Statement for scope, safe harbour and CVE handling.

The file is identical in every pgEdge product repository — nothing in it is
repo-specific.

## Why an in-repo copy when there is an org default

`pgEdge/.github` carries the same file as an organisation default, which covers
every repository that has none of its own. Defaults do not appear in a
repository's file tree, git history, clones or release archives — only in the
Security tab. A product a customer clones or vendors should carry its own
policy, and OpenSSF Scorecard's security-policy check only looks in the
repository itself.

## Draft on purpose — merge order matters

The only link in this file is `https://docs.pgedge.com/security`, and that URL
**returns 404 today**. Merging before the statement is live publishes a
security policy whose one actionable link is dead.

Merge order:

1. **pgEdge/pgedge-docs#138** — publishes `docs.pgedge.com/security`. Out of
   draft and awaiting review.
2. **pgEdge/.github#6** — the org-wide default.
3. This PR, alongside the other product repositories.

No action needed from you until #138 merges. Reviews welcome now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security guidance covering vulnerability reporting, supported versions, authorized testing, safe-harbour terms, disclosure practices, and published advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->