### PR TITLE
fix: disable knowledgebase by default in packaged config

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Disabled the knowledgebase by default in the packaged
+  `postgres-mcp.yaml`; the shipped `database_path` never existed,
+  since the actual filename depends on the embedding provider and
+  model.
+
 ## [1.1.0] - 2026-08-17
 
 ### Added

--- a/pkg/common/postgres-mcp.yaml
+++ b/pkg/common/postgres-mcp.yaml
@@ -121,8 +121,10 @@ llm:
 # Knowledgebase database (for similarity_search tool)
 # Requires pgedge-ai-kb package
 knowledgebase:
-  enabled: true
-  database_path: /usr/share/pgedge/pgedge-ai-kb/kb.db
+  enabled: false
+  # Uncomment and set the path after installing your preferred KB package.
+  # The filename is provider- and model-specific, e.g.:
+  # database_path: /usr/share/pgedge/pgedge-ai-kb/kb-<provider>-<model>.db
   #embedding_provider: "voyage"  # Options: "voyage", "openai", "gemini", "ollama"
   #embedding_model: "voyage-3"
 


### PR DESCRIPTION
## Summary
- The default `postgres-mcp.yaml` shipped in RPM/deb packaging enabled the knowledgebase with a hardcoded `database_path` (`/usr/share/pgedge/pgedge-ai-kb/kb.db`) that no package ever creates.
- Sets `knowledgebase.enabled: false` and comments out `database_path`, with a note that the filename is provider/model-specific and must be set after installing the `pgedge-ai-kb` package.

## Test plan
- [x] Confirmed no test suite asserts on the packaged `pkg/common/postgres-mcp.yaml` contents.
- [ ] Install the RPM/deb and confirm the server starts cleanly with the knowledgebase disabled out of the box.

Closes #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled the knowledgebase by default in the packaged PostgreSQL MCP configuration.
  - Prevented startup issues caused by an invalid, provider- and model-specific database path.

- **Documentation**
  - Added an unreleased changelog entry explaining the configuration change and database path requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->