### PR TITLE
fix: enforce query_database's row limit cap unconditionally

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,12 @@ and this project adheres to
   since the actual filename depends on the embedding provider and
   model.
 
+- Closed the two ways `query_database`'s row limit could be defeated: a
+  `limit` argument outside its advertised 1-1000 bounds (including zero
+  or negative) now falls back to the default of 100 instead of removing
+  the cap, and a query that already carries its own inline `LIMIT`
+  clause is now wrapped so it cannot return more than 1000 rows either.
+
 ## [1.1.0] - 2026-08-17
 
 ### Added

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -13,6 +13,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"unicode"
@@ -57,6 +58,12 @@ func resolveRowLimit(args map[string]any) int {
 	var limit int
 	switch v := limitVal.(type) {
 	case float64:
+		// The schema declares "limit" as an integer; a fractional,
+		// infinite, or NaN value violates that contract outright rather
+		// than rounding to something that happens to look in-bounds.
+		if v != math.Trunc(v) || math.IsInf(v, 0) {
+			return defaultRowLimit
+		}
 		limit = int(v)
 	case int:
 		limit = v

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -33,6 +33,43 @@ func stripTrailingSemicolons(query string) string {
 	})
 }
 
+// defaultRowLimit, minRowLimit and maxRowLimit mirror the bounds the
+// query_database tool's "limit" argument advertises in its schema. The
+// schema is a client-side hint only; these constants are what the server
+// actually enforces.
+const (
+	defaultRowLimit = 100
+	minRowLimit     = 1
+	maxRowLimit     = 1000
+)
+
+// resolveRowLimit extracts the caller-supplied "limit" argument and clamps
+// it to the tool's advertised bounds. A missing, non-numeric, or
+// out-of-range value (including zero or negative, which previously
+// disabled the safety cap entirely rather than falling back to it - issue
+// #273) falls back to defaultRowLimit instead of removing the cap.
+func resolveRowLimit(args map[string]any) int {
+	limitVal, ok := args["limit"]
+	if !ok {
+		return defaultRowLimit
+	}
+
+	var limit int
+	switch v := limitVal.(type) {
+	case float64:
+		limit = int(v)
+	case int:
+		limit = v
+	default:
+		return defaultRowLimit
+	}
+
+	if limit < minRowLimit || limit > maxRowLimit {
+		return defaultRowLimit
+	}
+	return limit
+}
+
 // limitKeywordPattern and offsetKeywordPattern match a LIMIT/OFFSET clause
 // keyword bounded by characters that can't appear in a PostgreSQL unquoted
 // identifier, so that "credit_limit" or "foo$limit" (the dollar sign is a
@@ -256,16 +293,10 @@ To avoid rate limits (30,000 input tokens/minute):
 				}
 			}
 
-			// Determine the limit to use
-			limit := 100 // default
-			if limitVal, ok := args["limit"]; ok {
-				switch v := limitVal.(type) {
-				case float64:
-					limit = int(v)
-				case int:
-					limit = v
-				}
-			}
+			// Determine the limit to use, clamped to the schema's advertised
+			// bounds so an out-of-range value falls back to the default
+			// rather than disabling the cap (issue #273).
+			limit := resolveRowLimit(args)
 
 			// Determine the offset to use
 			offset := 0 // default
@@ -324,6 +355,21 @@ To avoid rate limits (30,000 input tokens/minute):
 			// limit+1 appended below, so it is keyed on the classification
 			// rather than on what the server turned out to return.
 			truncationDetectable := isSelectQuery
+
+			// An inline LIMIT the caller wrote themselves is honoured
+			// verbatim and was previously the one path with no enforced
+			// ceiling at all (issue #273): a query ending "LIMIT 30000"
+			// bypasses the "limit" argument entirely. Wrap the whole
+			// statement so the cap holds regardless of where the LIMIT
+			// clause came from; the inner LIMIT still narrows the result as
+			// written, it just can no longer widen it past maxRowLimit.
+			rowCapApplied := false
+			effectiveLimit := limit
+			if isSelectQuery && hasExistingLimit {
+				sqlQuery = fmt.Sprintf("SELECT * FROM (%s) AS pgedge_mcp_row_cap LIMIT %d", sqlQuery, maxRowLimit+1)
+				rowCapApplied = true
+				effectiveLimit = maxRowLimit
+			}
 
 			// Only inject LIMIT/OFFSET for SELECT queries that don't already have them
 			// Fetch limit+1 to detect if more rows exist
@@ -457,11 +503,12 @@ To avoid rate limits (30,000 input tokens/minute):
 				rowsAffected = tag.RowsAffected()
 			}
 
-			// Check if results were truncated (we fetched limit+1 to detect this)
+			// Check if results were truncated (we fetched limit+1, or the
+			// hard row-cap ceiling+1, to detect this)
 			wasTruncated := false
-			if truncationDetectable && !hasExistingLimit && limit > 0 && len(results) > limit {
+			if truncationDetectable && (rowCapApplied || !hasExistingLimit) && len(results) > effectiveLimit {
 				wasTruncated = true
-				results = results[:limit] // Truncate to requested limit
+				results = results[:effectiveLimit] // Truncate to requested/effective limit
 			}
 
 			// Format results as TSV (tab-separated values) for row-returning queries
@@ -500,13 +547,13 @@ To avoid rate limits (30,000 input tokens/minute):
 					endRow := offset + len(results)
 					if wasTruncated {
 						fmt.Fprintf(&sb, "Results (rows %d-%d, more available - use offset=%d for next page):\n%s",
-							startRow, endRow, offset+limit, resultsTSV)
+							startRow, endRow, offset+effectiveLimit, resultsTSV)
 					} else {
 						fmt.Fprintf(&sb, "Results (rows %d-%d):\n%s", startRow, endRow, resultsTSV)
 					}
 				} else if wasTruncated {
 					fmt.Fprintf(&sb, "Results (%d rows shown, more available - use offset=%d for next page or count_rows for total):\n%s",
-						len(results), limit, resultsTSV)
+						len(results), effectiveLimit, resultsTSV)
 				} else {
 					fmt.Fprintf(&sb, "Results (%d rows):\n%s", len(results), resultsTSV)
 				}

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -61,7 +61,12 @@ func resolveRowLimit(args map[string]any) int {
 		// The schema declares "limit" as an integer; a fractional,
 		// infinite, or NaN value violates that contract outright rather
 		// than rounding to something that happens to look in-bounds.
-		if v != math.Trunc(v) || math.IsInf(v, 0) {
+		// The range check runs before int(v): a magnitude beyond what
+		// int can represent (e.g. math.MaxFloat64) makes that conversion
+		// implementation-dependent per the Go spec, so it must be
+		// rejected on the float64 value itself, not after converting.
+		if v != math.Trunc(v) || math.IsInf(v, 0) ||
+			v < float64(minRowLimit) || v > float64(maxRowLimit) {
 			return defaultRowLimit
 		}
 		limit = int(v)

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -473,6 +473,32 @@ func TestQueryHasClause(t *testing.T) {
 	}
 }
 
+func TestResolveRowLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want int
+	}{
+		{"missing falls back to default", map[string]any{}, defaultRowLimit},
+		{"typical float64 from JSON", map[string]any{"limit": float64(50)}, 50},
+		{"typical int", map[string]any{"limit": 250}, 250},
+		{"minimum boundary", map[string]any{"limit": float64(1)}, 1},
+		{"maximum boundary", map[string]any{"limit": float64(1000)}, 1000},
+		{"zero falls back to default, not unbounded", map[string]any{"limit": float64(0)}, defaultRowLimit},
+		{"negative falls back to default, not unbounded", map[string]any{"limit": float64(-5)}, defaultRowLimit},
+		{"above maximum falls back to default", map[string]any{"limit": float64(30000)}, defaultRowLimit},
+		{"non-numeric type falls back to default", map[string]any{"limit": "100"}, defaultRowLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveRowLimit(tt.args); got != tt.want {
+				t.Errorf("resolveRowLimit(%v) = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatResultsAsTSV(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -494,6 +494,8 @@ func TestResolveRowLimit(t *testing.T) {
 		{"NaN falls back to default", map[string]any{"limit": math.NaN()}, defaultRowLimit},
 		{"positive infinity falls back to default", map[string]any{"limit": math.Inf(1)}, defaultRowLimit},
 		{"negative infinity falls back to default", map[string]any{"limit": math.Inf(-1)}, defaultRowLimit},
+		{"max float64 falls back to default rather than overflowing int", map[string]any{"limit": math.MaxFloat64}, defaultRowLimit},
+		{"negative max float64 falls back to default rather than overflowing int", map[string]any{"limit": -math.MaxFloat64}, defaultRowLimit},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -11,6 +11,7 @@
 package tools
 
 import (
+	"math"
 	"regexp"
 	"strings"
 	"testing"
@@ -488,6 +489,11 @@ func TestResolveRowLimit(t *testing.T) {
 		{"negative falls back to default, not unbounded", map[string]any{"limit": float64(-5)}, defaultRowLimit},
 		{"above maximum falls back to default", map[string]any{"limit": float64(30000)}, defaultRowLimit},
 		{"non-numeric type falls back to default", map[string]any{"limit": "100"}, defaultRowLimit},
+		{"fractional value falls back to default", map[string]any{"limit": 1000.9}, defaultRowLimit},
+		{"small fractional value falls back to default", map[string]any{"limit": 1.5}, defaultRowLimit},
+		{"NaN falls back to default", map[string]any{"limit": math.NaN()}, defaultRowLimit},
+		{"positive infinity falls back to default", map[string]any{"limit": math.Inf(1)}, defaultRowLimit},
+		{"negative infinity falls back to default", map[string]any{"limit": math.Inf(-1)}, defaultRowLimit},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Follow-up to #260: that fix closed the false-positive detection of an inline `LIMIT`/`OFFSET` clause, but left the actual bound unenforced.
- Clamp the `limit` argument to the schema's declared 1-1000 bounds; a value of 0, negative, or above 1000 now falls back to the default of 100 instead of skipping the `LIMIT` injection entirely.
- Wrap any query that already carries its own inline `LIMIT` clause as `SELECT * FROM (<query>) AS pgedge_mcp_row_cap LIMIT 1001`, so an inline `LIMIT` can narrow the result but can no longer widen it past the cap.

## Test plan
- [x] Added `TestResolveRowLimit` covering the boundary, zero, negative, over-max, and non-numeric cases.
- [x] `go test ./internal/tools/...` passes.
- [x] Verified against a local PostgreSQL 18 instance that the wrapped query form preserves row order and works with CTEs, `OFFSET`, and `FOR UPDATE`.

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced safe row limits for database queries, including invalid, negative, zero, fractional, infinite, or oversized values.
  * Prevented inline SQL limits from bypassing the maximum row cap.
  * Improved truncation and pagination messaging to reflect the effective row limit.
  * Disabled the knowledgebase by default when its packaged database path is unavailable.

* **Documentation**
  * Added unreleased changelog entries covering query limit protections and the packaged knowledgebase configuration fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->