### PR TITLE
fix: classify leading-comment and parenthesised SELECTs correctly

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,12 @@ and this project adheres to
   the cap, and a query that already carries its own inline `LIMIT`
   clause is now wrapped so it cannot return more than 1000 rows either.
 
+- `query_database` now classifies a statement as a SELECT (and applies
+  the row cap and truncation marker) even when it starts with a
+  comment or is wrapped in parentheses; previously either fell
+  through every check, so no `LIMIT` was appended and the result set
+  came back uncapped and unmarked.
+
 ## [1.1.0] - 2026-08-17
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,7 +26,11 @@ and this project adheres to
   the row cap and truncation marker) even when it starts with a
   comment or is wrapped in parentheses; previously either fell
   through every check, so no `LIMIT` was appended and the result set
-  came back uncapped and unmarked.
+  came back uncapped and unmarked. A statement wrapped in parentheses
+  that also carries its own inline `LIMIT` or `OFFSET`, such as
+  `(SELECT ... LIMIT 5)`, is now recognised as already having one
+  instead of getting a second clause appended alongside it, which
+  previously produced a SQL syntax error.
 
 ## [1.1.0] - 2026-08-17
 

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -136,6 +136,55 @@ func normalizeForClassification(sqlQuery string) string {
 	return strings.ToUpper(stripLeadingParens(strings.TrimSpace(residue)))
 }
 
+// redundantWrapDepth reports how many layers of parentheses wrap the
+// ENTIRE statement -- e.g. 2 for "((SELECT ...))" but 0 for
+// "(SELECT ...) UNION (SELECT ...)", where the first '(' closes well
+// before the end of the string rather than at it. Unlike
+// stripLeadingParens, this never discards any text: it only measures how
+// many redundant layers exist, since a caller needs the untouched
+// residue to still search it (issue #275 follow-up).
+//
+// This distinction matters because such a wrap contributes nothing to
+// the statement's meaning: "(SELECT ... LIMIT 5)" behaves exactly like
+// "SELECT ... LIMIT 5" as a complete statement, so a clause inside it is
+// just as much "top level" as one with no wrapping at all.
+func redundantWrapDepth(s string) int {
+	s = strings.TrimSpace(s)
+	depth := 0
+	for strings.HasPrefix(s, "(") {
+		matchDepth := 0
+		closeAt := -1
+		for i := 0; i < len(s); i++ {
+			switch s[i] {
+			case '(':
+				matchDepth++
+			case ')':
+				matchDepth--
+				if matchDepth == 0 {
+					closeAt = i
+				}
+			}
+			if closeAt >= 0 {
+				break
+			}
+		}
+		// Only count this layer if its closing paren is the last
+		// non-whitespace character in the string -- otherwise something
+		// follows it (a UNION, a trailing LIMIT, ...) and the wrap isn't
+		// whole-statement, so matches inside it stay at their real depth.
+		if closeAt < 0 || strings.TrimSpace(s[closeAt+1:]) != "" {
+			break
+		}
+		inner := strings.TrimSpace(s[1:closeAt])
+		if inner == "" {
+			break
+		}
+		depth++
+		s = inner
+	}
+	return depth
+}
+
 // queryHasClause reports whether a SQL statement already contains a
 // top-level LIMIT or OFFSET clause. It checks the statement's residue, with
 // comments removed and string literals, dollar-quoted blocks and quoted
@@ -143,16 +192,22 @@ func normalizeForClassification(sqlQuery string) string {
 // cap by mentioning "limit" or "offset" in a string literal, a quoted
 // column alias, or a comment (issue #260).
 //
-// A match only counts at parenthesis depth zero, so a LIMIT/OFFSET that
-// belongs to a subquery or CTE, such as
+// A match only counts at the statement's effective top level: parenthesis
+// depth zero for an unwrapped statement, so a LIMIT/OFFSET that belongs to
+// a subquery or CTE, such as
 // "SELECT * FROM t WHERE id IN (SELECT id FROM u LIMIT 1)", isn't mistaken
-// for a clause on the outer statement.
+// for a clause on the outer statement; or redundantWrapDepth deeper when
+// the whole statement is itself wrapped in parentheses, such as
+// "(SELECT * FROM t LIMIT 5)", so that case isn't mistaken for having no
+// top-level clause at all and getting a second one appended alongside it
+// (issue #275 follow-up).
 func queryHasClause(pattern *regexp.Regexp, sqlQuery string) bool {
 	residue, _ := sqltext.Strip(sqlQuery)
+	topLevelDepth := redundantWrapDepth(residue)
 	for _, loc := range pattern.FindAllStringSubmatchIndex(residue, -1) {
 		// loc[2] and loc[3] bound the captured keyword itself, excluding
 		// the boundary characters matched alongside it.
-		if parenDepthAt(residue, loc[2]) == 0 {
+		if parenDepthAt(residue, loc[2]) == topLevelDepth {
 			return true
 		}
 	}

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -91,6 +91,51 @@ func resolveRowLimit(args map[string]any) int {
 var limitKeywordPattern = regexp.MustCompile(`(?i)(?:^|[^A-Z0-9_$])(LIMIT)(?:[^A-Z0-9_$]|$)`)
 var offsetKeywordPattern = regexp.MustCompile(`(?i)(?:^|[^A-Z0-9_$])(OFFSET)(?:[^A-Z0-9_$]|$)`)
 
+// stripLeadingParens peels away wrapping parentheses so a statement written
+// as "(SELECT ...)" is still recognised as a SELECT by the keyword-prefix
+// checks below (issue #275). It only ever narrows what's inspected for
+// classification purposes; the query actually executed is untouched.
+func stripLeadingParens(s string) string {
+	for strings.HasPrefix(s, "(") {
+		depth := 0
+		closeAt := -1
+		for i := 0; i < len(s); i++ {
+			switch s[i] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					closeAt = i
+				}
+			}
+			if closeAt >= 0 {
+				break
+			}
+		}
+		if closeAt < 0 {
+			break // unbalanced; leave as-is for the prefix check to reject
+		}
+		inner := strings.TrimSpace(s[1:closeAt])
+		if inner == "" {
+			break
+		}
+		s = inner
+	}
+	return s
+}
+
+// normalizeForClassification produces the text used to decide a
+// statement's type (SELECT/DDL/DML/RETURNING): comments and literals
+// stripped via sqltext.Strip, any wrapping parentheses peeled off, upper-
+// cased. Without this a leading comment or a parenthesised SELECT falls
+// through every HasPrefix check below, which meant no LIMIT was appended
+// and no truncation marker was ever emitted for it (issue #275).
+func normalizeForClassification(sqlQuery string) string {
+	residue, _ := sqltext.Strip(sqlQuery)
+	return strings.ToUpper(stripLeadingParens(strings.TrimSpace(residue)))
+}
+
 // queryHasClause reports whether a SQL statement already contains a
 // top-level LIMIT or OFFSET clause. It checks the statement's residue, with
 // comments removed and string literals, dollar-quoted blocks and quoted
@@ -332,9 +377,10 @@ To avoid rate limits (30,000 input tokens/minute):
 			// against the statement's residue rather than raw text, so a
 			// literal or identifier that merely mentions "limit"/"offset"
 			// doesn't defeat the safety cap (issue #260).
-			upperQuery := strings.ToUpper(strings.TrimSpace(sqlQuery))
 			hasExistingLimit := queryHasClause(limitKeywordPattern, sqlQuery)
 			hasExistingOffset := queryHasClause(offsetKeywordPattern, sqlQuery)
+
+			upperQuery := normalizeForClassification(sqlQuery)
 
 			// Check if this is a SELECT query - only SELECT queries support LIMIT/OFFSET
 			// DDL (CREATE, ALTER, DROP) and DML (INSERT, UPDATE, DELETE) don't support LIMIT

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -493,6 +493,36 @@ var queryHasClauseTests = []struct {
 		pattern:        offsetKeywordPattern,
 		expectDetected: false,
 	},
+	{
+		name:           "whole-statement-wrapped LIMIT is a top-level clause",
+		query:          "(SELECT * FROM t LIMIT 5)",
+		pattern:        limitKeywordPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "doubly whole-statement-wrapped LIMIT is a top-level clause",
+		query:          "((SELECT * FROM t LIMIT 5))",
+		pattern:        limitKeywordPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "whole-statement-wrapped OFFSET is a top-level clause",
+		query:          "(SELECT * FROM t OFFSET 5)",
+		pattern:        offsetKeywordPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "LIMIT inside only the first branch of a UNION is not a top-level clause",
+		query:          "(SELECT * FROM t LIMIT 5) UNION (SELECT * FROM u)",
+		pattern:        limitKeywordPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "trailing LIMIT after a parenthesised UNION is still a top-level clause",
+		query:          "(SELECT * FROM t) UNION (SELECT * FROM u) LIMIT 50",
+		pattern:        limitKeywordPattern,
+		expectDetected: true,
+	},
 }
 
 func TestStripLeadingParens(t *testing.T) {

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -241,11 +241,43 @@ func TestQueryTypeDetection(t *testing.T) {
 			hasReturning: true,
 			expectsRows:  true,
 		},
+
+		// Leading noise that must not defeat classification (issue #275)
+		{
+			name:          "leading line comment before SELECT",
+			query:         "-- probe\nSELECT g FROM generate_series(1,300) g",
+			isSelectQuery: true,
+			expectsRows:   true,
+		},
+		{
+			name:          "leading block comment before SELECT",
+			query:         "/* probe */ SELECT * FROM users",
+			isSelectQuery: true,
+			expectsRows:   true,
+		},
+		{
+			name:          "parenthesised SELECT",
+			query:         "(SELECT * FROM users)",
+			isSelectQuery: true,
+			expectsRows:   true,
+		},
+		{
+			name:          "doubly parenthesised SELECT",
+			query:         "((SELECT * FROM users))",
+			isSelectQuery: true,
+			expectsRows:   true,
+		},
+		{
+			name:        "leading comment before CREATE",
+			query:       "-- probe\nCREATE TABLE test (id int)",
+			isDDLQuery:  true,
+			expectsRows: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			upperQuery := strings.ToUpper(strings.TrimSpace(tt.query))
+			upperQuery := normalizeForClassification(tt.query)
 
 			// Test SELECT detection
 			isSelectQuery := strings.HasPrefix(upperQuery, "SELECT") ||
@@ -461,6 +493,30 @@ var queryHasClauseTests = []struct {
 		pattern:        offsetKeywordPattern,
 		expectDetected: false,
 	},
+}
+
+func TestStripLeadingParens(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no parens", "SELECT 1", "SELECT 1"},
+		{"single wrap", "(SELECT 1)", "SELECT 1"},
+		{"double wrap", "((SELECT 1))", "SELECT 1"},
+		{"wrap with surrounding whitespace", "( SELECT 1 )", "SELECT 1"},
+		{"unbalanced left as-is", "(SELECT 1", "(SELECT 1"},
+		{"empty parens left as-is", "()", "()"},
+		{"union of two parenthesised selects keeps first clause only", "(SELECT 1) UNION (SELECT 2)", "SELECT 1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripLeadingParens(tt.input); got != tt.want {
+				t.Errorf("stripLeadingParens(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestQueryHasClause(t *testing.T) {


### PR DESCRIPTION
## Summary
- `query_database`'s statement-type detection used `strings.HasPrefix` over the raw uppercased query text, so a statement starting with a `--`/`/* */` comment, or wrapped in parentheses, matched none of the SELECT/DDL/DML prefixes.
- On `main` that meant `isSelectQuery` was false, so no `LIMIT` was appended and no truncation marker was emitted: the result set came back uncapped and silently unmarked. On the previously deployed image, the exec branch ran instead and no rows came back at all.
- Classification now runs against the same `sqltext.Strip` residue `queryHasClause` already uses for #260, with any wrapping parentheses peeled off first, via a shared `normalizeForClassification` helper.

## Test plan
- [x] Extended `TestQueryTypeDetection` with a leading line comment, a leading block comment, a parenthesised SELECT, a doubly-parenthesised SELECT, and a leading comment before `CREATE`.
- [x] Added `TestStripLeadingParens` covering balanced/unbalanced/empty-paren cases.
- [x] `go test ./internal/tools/...` passes; `go vet ./...` clean.

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed packaged knowledgebase default handling.
  - Improved database query handling for comments, parentheses, unions, and nested clauses.
  - Enforced a maximum 1,000-row result cap for queries with inline limits.
  - Improved validation for invalid, fractional, non-finite, and out-of-range row limits.
  - Ensured truncation and pagination reporting remain accurate.

- **Documentation**
  - Added unreleased changelog entries covering these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->