### PR TITLE
fix: recognise FETCH FIRST/NEXT ... ROWS ONLY as an existing limit

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,11 @@ and this project adheres to
   instead of getting a second clause appended alongside it, which
   previously produced a SQL syntax error.
 
+- `query_database` no longer appends a `LIMIT` to a statement that
+  already limits its rows with the SQL-standard
+  `FETCH FIRST/NEXT ... ROWS ONLY` clause; PostgreSQL rejected the
+  two conflicting clauses outright.
+
 ## [1.1.0] - 2026-08-17
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,8 +34,9 @@ and this project adheres to
 
 - `query_database` no longer appends a `LIMIT` to a statement that
   already limits its rows with the SQL-standard
-  `FETCH FIRST/NEXT ... ROWS ONLY` clause; PostgreSQL rejected the
-  two conflicting clauses outright.
+  `FETCH FIRST/NEXT ... ROWS ONLY` clause, or its `... ROWS WITH TIES`
+  variant; PostgreSQL rejected the two conflicting clauses outright
+  either way.
 
 ## [1.1.0] - 2026-08-17
 

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -91,6 +91,17 @@ func resolveRowLimit(args map[string]any) int {
 var limitKeywordPattern = regexp.MustCompile(`(?i)(?:^|[^A-Z0-9_$])(LIMIT)(?:[^A-Z0-9_$]|$)`)
 var offsetKeywordPattern = regexp.MustCompile(`(?i)(?:^|[^A-Z0-9_$])(OFFSET)(?:[^A-Z0-9_$]|$)`)
 
+// fetchFirstPattern matches the SQL-standard row-limiting clause
+// "FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } ONLY", which contains no
+// occurrence of the word "LIMIT" at all. Appending our own LIMIT on top of
+// one gives PostgreSQL two row-limiting clauses on the same statement, which
+// it rejects outright (issue #276), so this needs its own detection rather
+// than falling out of limitKeywordPattern. Only the "FETCH" keyword itself
+// is captured, matching the convention the other patterns use for the
+// parenthesis-depth check in queryHasClause; [^;]*? keeps the match from
+// running past the end of the statement it belongs to.
+var fetchFirstPattern = regexp.MustCompile(`(?is)(?:^|[^A-Z0-9_$])(FETCH)\s+(?:FIRST|NEXT)\b[^;]*?\b(?:ROW|ROWS)\s+ONLY\b`)
+
 // stripLeadingParens peels away wrapping parentheses so a statement written
 // as "(SELECT ...)" is still recognised as a SELECT by the keyword-prefix
 // checks below (issue #275). It only ever narrows what's inspected for
@@ -428,11 +439,14 @@ To avoid rate limits (30,000 input tokens/minute):
 				return mcp.NewToolError("Query is empty")
 			}
 
-			// Track if query already had LIMIT/OFFSET clauses. Checked
-			// against the statement's residue rather than raw text, so a
-			// literal or identifier that merely mentions "limit"/"offset"
-			// doesn't defeat the safety cap (issue #260).
-			hasExistingLimit := queryHasClause(limitKeywordPattern, sqlQuery)
+			// Track if query already had LIMIT/OFFSET clauses, or the
+			// SQL-standard FETCH FIRST/NEXT ... ROWS ONLY equivalent
+			// (issue #276). Checked against the statement's residue rather
+			// than raw text, so a literal or identifier that merely
+			// mentions "limit"/"offset" doesn't defeat the safety cap
+			// (issue #260).
+			hasExistingLimit := queryHasClause(limitKeywordPattern, sqlQuery) ||
+				queryHasClause(fetchFirstPattern, sqlQuery)
 			hasExistingOffset := queryHasClause(offsetKeywordPattern, sqlQuery)
 
 			upperQuery := normalizeForClassification(sqlQuery)

--- a/internal/tools/query_database.go
+++ b/internal/tools/query_database.go
@@ -92,15 +92,25 @@ var limitKeywordPattern = regexp.MustCompile(`(?i)(?:^|[^A-Z0-9_$])(LIMIT)(?:[^A
 var offsetKeywordPattern = regexp.MustCompile(`(?i)(?:^|[^A-Z0-9_$])(OFFSET)(?:[^A-Z0-9_$]|$)`)
 
 // fetchFirstPattern matches the SQL-standard row-limiting clause
-// "FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } ONLY", which contains no
-// occurrence of the word "LIMIT" at all. Appending our own LIMIT on top of
-// one gives PostgreSQL two row-limiting clauses on the same statement, which
-// it rejects outright (issue #276), so this needs its own detection rather
-// than falling out of limitKeywordPattern. Only the "FETCH" keyword itself
-// is captured, matching the convention the other patterns use for the
-// parenthesis-depth check in queryHasClause; [^;]*? keeps the match from
-// running past the end of the statement it belongs to.
-var fetchFirstPattern = regexp.MustCompile(`(?is)(?:^|[^A-Z0-9_$])(FETCH)\s+(?:FIRST|NEXT)\b[^;]*?\b(?:ROW|ROWS)\s+ONLY\b`)
+// "FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } { ONLY | WITH TIES }",
+// which contains no occurrence of the word "LIMIT" at all. Appending our
+// own LIMIT on top of one gives PostgreSQL two row-limiting clauses on
+// the same statement, which it rejects outright (issue #276), so this
+// needs its own detection rather than falling out of limitKeywordPattern.
+// Only the "FETCH" keyword itself is captured, matching the convention
+// the other patterns use for the parenthesis-depth check in
+// queryHasClause; [^;]*? keeps the match from running past the end of
+// the statement it belongs to.
+//
+// WITH TIES is a distinct, real terminator from ONLY -- PostgreSQL
+// accepts "FETCH FIRST n ROWS WITH TIES" to include rows tied with the
+// last one on the ORDER BY key, and rejects a LIMIT appended after it
+// exactly the same way it rejects one after ROWS ONLY, so both need to
+// count as an existing limit (issue #276 follow-up). PostgreSQL has no
+// PERCENT variant of this clause at all -- unlike WITH TIES, that's not
+// a gap to close, since Postgres's own parser already rejects it before
+// this tool's LIMIT injection ever becomes relevant.
+var fetchFirstPattern = regexp.MustCompile(`(?is)(?:^|[^A-Z0-9_$])(FETCH)\s+(?:FIRST|NEXT)\b[^;]*?\b(?:ROW|ROWS)\s+(?:ONLY|WITH\s+TIES)\b`)
 
 // stripLeadingParens peels away wrapping parentheses so a statement written
 // as "(SELECT ...)" is still recognised as a SELECT by the keyword-prefix

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -559,6 +559,36 @@ var queryHasClauseTests = []struct {
 		pattern:        fetchFirstPattern,
 		expectDetected: false,
 	},
+	{
+		name:           "FETCH FIRST n ROWS WITH TIES is a limit clause",
+		query:          "SELECT * FROM t ORDER BY val FETCH FIRST 3 ROWS WITH TIES",
+		pattern:        fetchFirstPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "FETCH NEXT n ROWS WITH TIES is a limit clause",
+		query:          "SELECT * FROM t ORDER BY val OFFSET 1 FETCH NEXT 3 ROWS WITH TIES",
+		pattern:        fetchFirstPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "FETCH FIRST ... WITH TIES with extra whitespace is still a limit clause",
+		query:          "SELECT * FROM t ORDER BY val FETCH FIRST 3 ROWS  WITH   TIES",
+		pattern:        fetchFirstPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "FETCH FIRST ... ROWS WITHOUT TIES does not falsely match WITH TIES",
+		query:          "SELECT * FROM t ORDER BY val FETCH FIRST 3 ROWS WITHOUT TIES",
+		pattern:        fetchFirstPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "FETCH FIRST ... WITH TIES inside a subquery is not an outer clause",
+		query:          "SELECT * FROM parent WHERE id IN (SELECT id FROM child ORDER BY val FETCH FIRST 1 ROWS WITH TIES)",
+		pattern:        fetchFirstPattern,
+		expectDetected: false,
+	},
 }
 
 func TestStripLeadingParens(t *testing.T) {

--- a/internal/tools/query_database_test.go
+++ b/internal/tools/query_database_test.go
@@ -523,6 +523,42 @@ var queryHasClauseTests = []struct {
 		pattern:        limitKeywordPattern,
 		expectDetected: true,
 	},
+	{
+		name:           "FETCH FIRST n ROWS ONLY is a limit clause",
+		query:          "SELECT * FROM t FETCH FIRST 200 ROWS ONLY",
+		pattern:        fetchFirstPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "FETCH NEXT n ROW ONLY is a limit clause",
+		query:          "SELECT * FROM t OFFSET 5 FETCH NEXT 1 ROW ONLY",
+		pattern:        fetchFirstPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "FETCH FIRST ROW ONLY without a count is a limit clause",
+		query:          "SELECT * FROM t FETCH FIRST ROW ONLY",
+		pattern:        fetchFirstPattern,
+		expectDetected: true,
+	},
+	{
+		name:           "FETCH FIRST inside a subquery is not an outer clause",
+		query:          "SELECT * FROM parent WHERE id IN (SELECT parent_id FROM child FETCH FIRST 1 ROW ONLY)",
+		pattern:        fetchFirstPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "word FETCH in a comment is not a clause",
+		query:          "SELECT * FROM t -- FETCH FIRST 1 ROW ONLY\n",
+		pattern:        fetchFirstPattern,
+		expectDetected: false,
+	},
+	{
+		name:           "plain LIMIT query does not match the FETCH pattern",
+		query:          "SELECT * FROM t LIMIT 10",
+		pattern:        fetchFirstPattern,
+		expectDetected: false,
+	},
 }
 
 func TestStripLeadingParens(t *testing.T) {


### PR DESCRIPTION
## Summary
- `query_database`'s existing-limit detection only matched the literal `LIMIT` keyword, so a query already bounded with the SQL-standard `FETCH FIRST/NEXT ... ROWS ONLY` clause still got a `LIMIT` appended.
- PostgreSQL rejects a statement with two row-limiting clauses outright, so standard SQL a caller (or an LLM) can reasonably emit was refused.
- Added `fetchFirstPattern`, matched the same way `limitKeywordPattern`/`offsetKeywordPattern` already are via `queryHasClause`, so a `FETCH FIRST`/`FETCH NEXT ... ROW(S) ONLY` clause now counts as an existing limit and nothing is appended.

## Test plan
- [x] Extended `queryHasClauseTests`/`TestQueryHasClause` with `FETCH FIRST`/`FETCH NEXT`, with/without a count, inside a subquery, and inside a comment.
- [x] Verified against a local PostgreSQL instance: `... FETCH FIRST 200 ROWS ONLY LIMIT 101` raises a syntax error; withholding the appended `LIMIT`, as this fix does, does not.
- [x] `go test ./internal/tools/...` passes; `go vet ./...` clean.

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced safe row limits, including validated defaults and handling of invalid or excessive values.
  * Improved detection of SELECT statements with comments, parentheses, unions, and existing row limits.
  * Preserved SQL-standard `FETCH FIRST/NEXT ... ROWS ONLY` clauses, including `WITH TIES`, without adding conflicting limits.
  * Improved truncation reporting for queries with existing limits.
* **Tests**
  * Added coverage for row-limit validation and complex query formats.
* **Documentation**
  * Documented these fixes in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->