### PR TITLE
fix: negotiate legacy MCP protocol revisions up to 2025-11-25

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,13 @@ and this project adheres to
   variant; PostgreSQL rejected the two conflicting clauses outright
   either way.
 
+- The server now negotiates the legacy MCP handshake up to revision
+  `2025-11-25`, instead of always answering `2024-11-05` regardless of
+  what a client requests. This includes revision `2025-03-26`, which
+  introduced the Streamable HTTP transport: strict clients with no
+  fallback (e.g. OpenAI Codex) previously refused to connect because
+  the reported revision predated that transport outright.
+
 ## [1.1.0] - 2026-08-17
 
 ### Added

--- a/internal/mcp/http_server.go
+++ b/internal/mcp/http_server.go
@@ -331,12 +331,14 @@ func (s *Server) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// A request carrying io.modelcontextprotocol/protocolVersion in its
-	// _meta -- or, on this transport, just an MCP-Protocol-Version
-	// header, which no pre-2025-06-18 client ever sends -- is modern
-	// (2026-07-28, stateless per-request negotiation); a request with
-	// neither, including every initialize handshake, is legacy and
-	// reaches handleRequestHTTP exactly as before this server added
-	// modern support. See isModernHTTP in modern.go.
+	// _meta -- or, on this transport, an MCP-Protocol-Version header
+	// whose value isn't one of this server's supported legacy revisions
+	// -- is modern (2026-07-28, stateless per-request negotiation); a
+	// request with neither, including every initialize handshake and
+	// every legacy Streamable HTTP request carrying its own negotiated
+	// legacy version in that same header, is legacy and reaches
+	// handleRequestHTTP exactly as before this server added modern
+	// support. See isModernHTTP in modern.go.
 	//
 	// preflightRejected distinguishes a rejection at this stage (header
 	// mismatch, missing required _meta field, unsupported version) from

--- a/internal/mcp/modern.go
+++ b/internal/mcp/modern.go
@@ -71,19 +71,30 @@ func isModernRequest(params interface{}) (*RequestMeta, bool) {
 // modern, even when the body's _meta does not (because it is missing
 // entirely, or because its protocolVersion key is missing or
 // misspelled -- these long, easily-mistyped reserved keys make that a
-// real failure mode, not just a hypothetical one). No pre-2025-06-18
-// client -- including this server's own legacy revision, 2024-11-05 --
-// ever sends this header at all, so its mere presence, regardless of
-// value, is already a reliable modern signal on its own; the exact
-// version match is left to validateModernHeaders. Returns a nil meta
-// when the header is the only modern signal, which validateModernHeaders
-// and validateModernRequestHTTP both treat as "no usable body _meta",
-// not as "no _meta was expected."
+// real failure mode, not just a hypothetical one).
+//
+// A legacy Streamable HTTP client of revision 2025-06-18 or later is
+// required by that revision's own spec to send this same header, with a
+// legacy dated value (e.g. "2025-06-18"), on every request after its
+// initialize handshake -- so header presence alone stopped being a
+// reliable modern signal once this server started supporting those
+// revisions (issue #277). A header carrying one of this server's
+// supported legacy revisions is therefore left as legacy; any other
+// value, including the modern revision itself, is treated as modern,
+// which lets a request for a modern revision this server does not (yet)
+// implement still be recognised as modern and fail with
+// UnsupportedProtocolVersionError rather than as a malformed legacy one.
+//
+// The exact version match for a request that is modern either way is
+// left to validateModernHeaders. Returns a nil meta when the header is
+// the only modern signal, which validateModernHeaders and
+// validateModernRequestHTTP both treat as "no usable body _meta", not as
+// "no _meta was expected."
 func isModernHTTP(r *http.Request, params interface{}) (*RequestMeta, bool) {
 	if meta, isModern := isModernRequest(params); isModern {
 		return meta, true
 	}
-	if r.Header.Get("MCP-Protocol-Version") != "" {
+	if header := r.Header.Get("MCP-Protocol-Version"); header != "" && !isSupportedLegacyProtocolVersion(header) {
 		return nil, true
 	}
 	return nil, false

--- a/internal/mcp/modern_test.go
+++ b/internal/mcp/modern_test.go
@@ -12,8 +12,47 @@ package mcp
 
 import (
 	"encoding/base64"
+	"net/http"
 	"testing"
 )
+
+// TestIsModernHTTP_LegacyProtocolVersionHeaderIsNotModern is the
+// regression test for issue #277: a legacy Streamable HTTP client of
+// revision 2025-06-18 or later sends the MCP-Protocol-Version header on
+// every request, with a legacy dated value, and must not be misclassified
+// as a modern (2026-07-28) request on that basis alone.
+func TestIsModernHTTP_LegacyProtocolVersionHeaderIsNotModern(t *testing.T) {
+	for _, v := range supportedProtocolVersions {
+		r, _ := http.NewRequest(http.MethodPost, "/mcp/v1", nil)
+		r.Header.Set("MCP-Protocol-Version", v)
+
+		meta, isModern := isModernHTTP(r, nil)
+		if isModern {
+			t.Errorf("isModernHTTP with legacy header value %q = modern, want legacy", v)
+		}
+		if meta != nil {
+			t.Errorf("isModernHTTP with legacy header value %q returned non-nil meta %+v", v, meta)
+		}
+	}
+}
+
+// TestIsModernHTTP_ModernProtocolVersionHeaderIsModern covers the
+// counterpart: a header value that isn't one of this server's supported
+// legacy revisions -- including its own modern revision, and an
+// unrecognised future one -- is still treated as modern, so an
+// unsupported modern request fails downstream as
+// UnsupportedProtocolVersionError rather than as a malformed legacy one.
+func TestIsModernHTTP_ModernProtocolVersionHeaderIsModern(t *testing.T) {
+	for _, v := range []string{ModernProtocolVersion, "2099-01-01"} {
+		r, _ := http.NewRequest(http.MethodPost, "/mcp/v1", nil)
+		r.Header.Set("MCP-Protocol-Version", v)
+
+		_, isModern := isModernHTTP(r, nil)
+		if !isModern {
+			t.Errorf("isModernHTTP with header value %q = legacy, want modern", v)
+		}
+	}
+}
 
 // TestDecodeHeaderValue_PlainASCIIPassesThrough covers a header value
 // with no Base64 sentinel wrapping: it must be returned unchanged.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	ProtocolVersion = "2024-11-05"
+	ProtocolVersion = "2025-11-25"
 	ServerName      = "pgedge-postgres-mcp"
 	ServerVersion   = "1.1.0-beta1"
 
@@ -49,6 +49,23 @@ const (
 // rather than another entry here.
 var supportedProtocolVersions = []string{
 	"2024-11-05",
+	"2025-03-26",
+	"2025-06-18",
+	"2025-11-25",
+}
+
+// isSupportedLegacyProtocolVersion reports whether v is one of the
+// handshake-era revisions above. Used to tell a legacy Streamable HTTP
+// client's MCP-Protocol-Version header (mandatory from 2025-06-18 onward)
+// apart from the modern (2026-07-28) era's identically-named header, which
+// otherwise look the same on the wire (issue #277).
+func isSupportedLegacyProtocolVersion(v string) bool {
+	for _, supported := range supportedProtocolVersions {
+		if v == supported {
+			return true
+		}
+	}
+	return false
 }
 
 // NegotiateProtocolVersion returns the protocol revision this server will

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -268,6 +268,21 @@ func TestNegotiateProtocolVersion(t *testing.T) {
 			requested: "2020-01-01",
 			want:      supportedProtocolVersions[0],
 		},
+		{
+			name:      "2025-03-26 negotiates exactly (issue #277)",
+			requested: "2025-03-26",
+			want:      "2025-03-26",
+		},
+		{
+			name:      "2025-06-18 negotiates exactly (issue #277)",
+			requested: "2025-06-18",
+			want:      "2025-06-18",
+		},
+		{
+			name:      "a revision between two supported ones falls back to the older",
+			requested: "2025-05-01",
+			want:      "2025-03-26",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- The server always answered `initialize` with `protocolVersion: "2024-11-05"`, regardless of what the client requested, because `supportedProtocolVersions` only ever had that one entry.
- Revision `2025-03-26` introduced the Streamable HTTP transport; a client with a strict implementation and no fallback (OpenAI Codex, per the issue) refused to connect outright because the reported revision predated that transport entirely.
- Extends `supportedProtocolVersions` with `2025-03-26`, `2025-06-18`, `2025-11-25` and bumps the server's default (`ProtocolVersion`) to the newest of them. `NegotiateProtocolVersion` already picks the nearest supported revision at or below the request, so this alone is enough to answer appropriately instead of always falling back to the oldest.
- This interacts with the modern (2026-07-28) stateless protocol support added since #214/#266: `isModernHTTP` treated *any* `MCP-Protocol-Version` header as a modern signal, on the documented assumption that no pre-2025-06-18 client ever sends it. That assumption breaks once the server also speaks 2025-06-18/2025-11-25, which require that same header (with a legacy dated value) on every request. `isModernHTTP` now checks the header's *value* against the supported legacy revisions rather than just its presence, so a real legacy Streamable HTTP client isn't misclassified as modern and rejected for missing the modern-only `Mcp-Method`/`Mcp-Name` headers.

## Test plan
- [x] Extended `TestNegotiateProtocolVersion` with exact-match cases for `2025-03-26`/`2025-06-18` and a between-two-supported-revisions case.
- [x] Added `TestIsModernHTTP_LegacyProtocolVersionHeaderIsNotModern` and `TestIsModernHTTP_ModernProtocolVersionHeaderIsModern` covering the header-value disambiguation.
- [x] Confirmed every existing test that hardcodes `protocolVersion: "2024-11-05"` requests that exact (oldest) revision and still gets it back unchanged.
- [x] `go test ./internal/mcp/...` passes; `go vet ./...` clean; `go vet ./test/...` (integration tests, which need a live DB to run) compiles clean.

Closes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP protocol negotiation across legacy and modern clients.
  - Preserved compatibility with supported protocol revisions, including `2025-03-26`, `2025-06-18`, and `2025-11-25`.
  - Fixed initialization handshakes and legacy requests being incorrectly treated as modern HTTP requests.
  - Improved compatibility with Streamable HTTP transport and future protocol versions.
  - Enforced database query row limits and improved `SELECT` and `FETCH` limit handling.
  - Corrected knowledgebase default configuration behavior.

- **Documentation**
  - Added changelog information covering these fixes and compatibility improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->