### PR TITLE
fix(ci): name release archives after the triggering tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,12 @@ jobs:
                   args: release --clean --config .goreleaser-amd64.yaml ${{ github.event_name == 'workflow_dispatch' && github.ref_type != 'tag' && '--snapshot' || '' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  # Name the archives after the tag that triggered this run. Left
+                  # unset, GoReleaser asks git which tags point at HEAD and takes
+                  # the first, which is the release candidate whenever a GA tag has
+                  # been added to the commit its own candidate was cut from. Empty
+                  # on a non-tag run, which GoReleaser ignores.
+                  GORELEASER_CURRENT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
 
             - name: Upload amd64 artifacts
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -303,6 +309,12 @@ jobs:
                   args: release --clean --config .goreleaser-arm64.yaml ${{ github.event_name == 'workflow_dispatch' && github.ref_type != 'tag' && '--snapshot' || '' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  # Name the archives after the tag that triggered this run. Left
+                  # unset, GoReleaser asks git which tags point at HEAD and takes
+                  # the first, which is the release candidate whenever a GA tag has
+                  # been added to the commit its own candidate was cut from. Empty
+                  # on a non-tag run, which GoReleaser ignores.
+                  GORELEASER_CURRENT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
 
             - name: Upload arm64 artifacts
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- The release workflow now names its archives after the tag that
+  triggered it. GoReleaser was left to work the version out for itself,
+  which it does by asking git which tags point at the commit and taking
+  the first, so promoting a release candidate to general availability,
+  which puts a second tag on the candidate's own commit, produced a
+  1.1.0 release whose server and CLI archives were named
+  `1.1.0-rc1`. The binaries inside always reported the right version,
+  since that comes from a constant in the source rather than from the
+  tag, and the RPM and Debian packages were unaffected. The 1.1.0
+  archives have been renamed in place, so only somebody who downloaded
+  them in the first hours after release saw the wrong names.
+
 ## [1.1.0] - 2026-09-03
 
 ### Security


### PR DESCRIPTION
Promoting `v1.1.0-rc1` to `v1.1.0` produced a GA release whose server and CLI archives were named `pgedge-postgres-mcp-server_1.1.0-rc1_linux_x86_64.tar.gz` and so on, whilst the web archive was correctly `1.1.0`.

**Cause.** The GoReleaser steps set no `GORELEASER_CURRENT_TAG`, so GoReleaser works the version out itself: it runs `git tag --points-at HEAD` with the default sort of `-version:refname` and takes the first result. Promotion puts a second tag on the candidate's own commit, and under that sort `v1.1.0-rc1` sorts ahead of `v1.1.0`, so the candidate's name won. The web archive escaped it because that step gets its version from `web/package.json` rather than from git.

**Fix.** Set `GORELEASER_CURRENT_TAG` from `github.ref_name` in both the amd64 and arm64 steps, so the archives follow the tag that actually triggered the run whatever else points at the commit. The expression yields an empty string on a non-tag run, which GoReleaser ignores (`getFromEnv` in `internal/pipe/git/git.go` overrides only on a non-empty value), so `workflow_dispatch` snapshot builds are unchanged.

**Blast radius of the original defect.** Filenames only. The binaries report `1.1.0`, since the version is a constant in the source rather than something the tag injects, and the RPMs and DEBs were named `1.1.0-1` correctly because their version comes from the tag-parsing action. The ten misnamed 1.1.0 archives have already been renamed in place and `checksums.txt` reissued, with one asset re-downloaded and verified against it.

**Testing.** This cannot be exercised without cutting a tag, so it is unverified beyond the YAML parsing and the reading of GoReleaser's own tag resolution above. The next promotion is the real test, and the failure mode is cosmetic and immediately visible on the release page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release archives now use the triggering release tag in their filenames, preventing incorrect version names.
  - Corrected the previously published 1.1.0 archive filenames that included the wrong pre-release suffix.
  - Binary versions and package names remain unchanged.

- **Documentation**
  - Added an unreleased changelog entry documenting the corrected release archive naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->