### PR TITLE
docs: separate Jinja2 raw markers from their code fences

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,16 @@ and this project adheres to
 
 ### Fixed
 
+- The Jinja2 raw block markers that shield three code blocks from the
+  documentation site's macro processing are now separated from their
+  fences by blank lines. Without the separation the closing fence and
+  the marker after it parse as a single paragraph, so a renderer with
+  the `attr_list` markdown extension enabled treats the marker as an
+  attribute list for that paragraph and swallows it, emitting bogus
+  attributes on the wrapping tag instead. The affected pages are
+  `docs/reference/tools.md`, `docs/guide/cli-client.md` and
+  `docs/contributing/ci-cd.md`.
+
 - The release workflow now names its archives after the tag that
   triggered it. GoReleaser was left to work the version out for itself,
   which it does by asking git which tags point at the commit and taking

--- a/docs/contributing/ci-cd.md
+++ b/docs/contributing/ci-cd.md
@@ -329,6 +329,7 @@ jobs:
 ### Setup
 
 {% raw %}
+
 ```bash
 # Install pre-commit hook
 cat > .git/hooks/pre-commit << 'EOF'
@@ -353,6 +354,7 @@ EOF
 
 chmod +x .git/hooks/pre-commit
 ```
+
 {% endraw %}
 
 ### Skip Hook (When Needed)

--- a/docs/guide/cli-client.md
+++ b/docs/guide/cli-client.md
@@ -368,6 +368,7 @@ ollama pull llama3
 Create a configuration file and use it:
 
 {% raw %}
+
 ```bash
 # Create config file
 cat > .pgedge-pg-mcp-cli.yaml << EOF
@@ -385,6 +386,7 @@ EOF
 # Run with config file
 ./bin/pgedge-nla-cli -config .pgedge-pg-mcp-cli.yaml
 ```
+
 {% endraw %}
 
 ## Interactive Commands

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1013,5 +1013,6 @@ approximate nearest neighbor search...
 
 Total: 5 chunks, ~687 tokens
 ```
+
 {% endraw %}
 


### PR DESCRIPTION
## Summary

- Adds a blank line between the closing code fence and the Jinja2 raw
  end marker in `docs/reference/tools.md`,
  `docs/guide/cli-client.md` and `docs/contributing/ci-cd.md`, and one
  after the opening marker in the two files that lacked it.
- Without the separation the fence and the marker parse as a single
  paragraph, so a renderer with `attr_list` enabled reads the marker as
  an attribute list and swallows it, emitting `<p _="%"
  endraw="endraw">` instead of the marker's text; that is what surfaced
  on docs.pgedge.com.
- The markers themselves stay: the wrapped blocks contain shell
  here-document redirections and pgvector's `<#>` operator, which
  collide with the `<<` and `<#` delimiters this repo configures
  `mkdocs-macros` with, so the raw blocks are load-bearing here.

## Test plan

- [x] `mkdocs build` succeeds and the built pages contain no literal
      raw markers, matching the behaviour before the change.
- [x] Rendering each page through `markdown` with
      `pymdownx.superfences` and `attr_list` no longer produces the
      bogus `endraw="endraw"` attribute.

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of templated code examples across the documentation.
  * Prevented raw-block markers from being misinterpreted as code-fence attributes.
  * Updated the unreleased changelog with these documentation corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->