### PR TITLE
feat(cli): add /paste for multi-line input

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,24 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- The CLI has a `/paste` command for multi-line input. Pasting a
+  multi-line query at the normal prompt sends each line to the LLM as a
+  separate request, because the terminal delivers every newline as if
+  Enter had been pressed. After `/paste`, the CLI collects lines under a
+  `...:` continuation prompt until Ctrl+D is pressed on an empty line,
+  then sends the whole text as one request; Ctrl+C discards the text and
+  returns to the normal prompt. The collected lines are not added to the
+  command history. This needs nothing from the terminal, so it behaves
+  the same in every terminal emulator and on every platform. Fixes #57.
+
+### Changed
+
+- Pressing Ctrl+D at the CLI prompt now echoes `^D` rather than `exit`
+  before the goodbye message, so that the same key reads sensibly when
+  used to finish a `/paste`.
+
 ### Fixed
 
 - The release workflow now names its archives after the tag that

--- a/docs/guide/cli-client.md
+++ b/docs/guide/cli-client.md
@@ -406,8 +406,8 @@ The CLI supports the following keyboard shortcuts:
 | Escape | Cancel the current LLM request and return to prompt |
 | Up/Down | Navigate through command history |
 | Ctrl+R | Reverse search through command history |
-| Ctrl+C | Exit the chat client |
-| Ctrl+D | Exit the chat client (EOF) |
+| Ctrl+C | Exit the chat client, or cancel a `/paste` |
+| Ctrl+D | Exit the chat client (EOF), or send a `/paste` |
 
 ### Cancelling Requests
 
@@ -456,6 +456,30 @@ The chat client supports **slash commands** for managing settings and configurat
 ```
 
 Shows comprehensive help for all slash commands with examples.
+
+### Multi-line Input
+
+The terminal delivers each newline in pasted text as if you had pressed
+Enter, so a multi-line query pasted at the normal prompt is sent to the LLM
+one line at a time. The `/paste` command collects several lines and sends
+them as a single request instead:
+
+```
+You: /paste
+System: Paste your text; Ctrl+D on an empty line sends it, Ctrl+C cancels.
+...: SELECT empno,
+...:        ename,
+...:        sal
+...: FROM emp
+...: WHERE deptno = 10;
+...: ^D
+```
+
+The `...:` prompt marks each collected line. Press Ctrl+D on an empty line
+to send the text, or Ctrl+C to discard the text and return to the normal
+prompt. Lines collected by `/paste` are taken as written, so a line that
+starts with `/` is part of the text rather than a command, and the lines are
+not added to the command history.
 
 ### Manage Status Messages
 

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -613,7 +614,7 @@ func (c *Client) chatLoop(ctx context.Context) error {
 		HistoryLimit:           1000,
 		DisableAutoSaveHistory: false,
 		InterruptPrompt:        "^C",
-		EOFPrompt:              "exit",
+		EOFPrompt:              "^D",
 		HistorySearchFold:      true, // Enable case-insensitive history search
 		// Unfortunately, chzyer/readline doesn't support prefix-based history filtering
 		// on up/down arrows natively. Users can use Ctrl+R for reverse search.
@@ -657,6 +658,12 @@ func (c *Client) chatLoop(ctx context.Context) error {
 
 		// Check for slash commands (all CLI commands start with /)
 		if cmd := ParseSlashCommand(userInput); cmd != nil {
+			// /paste needs the readline instance, so it is handled here
+			// rather than in HandleSlashCommand.
+			if cmd.Command == "paste" {
+				c.handlePaste(ctx, rl)
+				continue
+			}
 			if c.HandleSlashCommand(ctx, cmd) {
 				continue // Command was handled
 			}
@@ -673,6 +680,66 @@ func (c *Client) chatLoop(ctx context.Context) error {
 		c.ui.PrintSeparator()
 		// Readline will automatically display the prompt on the next iteration
 	}
+}
+
+// lineReader is the part of readline.Instance that collectPastedInput uses,
+// kept as an interface so that the collection logic can be tested without a
+// terminal.
+type lineReader interface {
+	Readline() (string, error)
+}
+
+// collectPastedInput reads lines until Ctrl+D (reported by readline as
+// io.EOF) and returns them joined with newlines, with leading and trailing
+// blank lines removed. Ctrl+C (readline.ErrInterrupt) discards everything
+// read so far and returns aborted=true. Lines are taken verbatim, so a
+// pasted line that happens to start with '/' is content, not a command.
+func collectPastedInput(r lineReader) (text string, aborted bool, err error) {
+	var lines []string
+	for {
+		line, err := r.Readline()
+		switch {
+		case err == nil:
+			lines = append(lines, line)
+		case errors.Is(err, io.EOF):
+			return strings.Trim(strings.Join(lines, "\n"), " \t\r\n"), false, nil
+		case errors.Is(err, readline.ErrInterrupt):
+			return "", true, nil
+		default:
+			return "", false, err
+		}
+	}
+}
+
+// handlePaste implements the /paste command: it switches to a continuation
+// prompt, collects lines until Ctrl+D, and sends the result to the LLM as a
+// single query. Pasted lines are kept out of the readline history, since the
+// history file is line-based and the fragments would be useless there.
+func (c *Client) handlePaste(ctx context.Context, rl *readline.Instance) {
+	c.ui.PrintSystemMessage("Paste your text; Ctrl+D on an empty line sends it, Ctrl+C cancels.")
+
+	rl.HistoryDisable()
+	rl.SetPrompt(c.ui.GetContinuationPrompt())
+	text, aborted, err := collectPastedInput(rl)
+	rl.SetPrompt(c.ui.GetPrompt())
+	rl.HistoryEnable()
+
+	switch {
+	case err != nil:
+		c.ui.PrintError(fmt.Sprintf("Failed to read pasted input: %v", err))
+		return
+	case aborted:
+		c.ui.PrintSystemMessage("Paste cancelled.")
+		return
+	case text == "":
+		c.ui.PrintSystemMessage("Nothing to send.")
+		return
+	}
+
+	if err := c.processQuery(ctx, text); err != nil {
+		c.ui.PrintError(err.Error())
+	}
+	c.ui.PrintSeparator()
 }
 
 // getBriefDescription extracts the first line or sentence from a description

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -692,8 +692,9 @@ type lineReader interface {
 // collectPastedInput reads lines until Ctrl+D (reported by readline as
 // io.EOF) and returns them joined with newlines, with leading and trailing
 // blank lines removed. Ctrl+C (readline.ErrInterrupt) discards everything
-// read so far and returns aborted=true. Lines are taken verbatim, so a
-// pasted line that happens to start with '/' is content, not a command.
+// read so far and returns aborted=true. Lines are taken verbatim, including
+// their indentation, so a pasted line that happens to start with '/' is
+// content, not a command.
 func collectPastedInput(r lineReader) (text string, aborted bool, err error) {
 	var lines []string
 	for {
@@ -702,13 +703,26 @@ func collectPastedInput(r lineReader) (text string, aborted bool, err error) {
 		case err == nil:
 			lines = append(lines, line)
 		case errors.Is(err, io.EOF):
-			return strings.Trim(strings.Join(lines, "\n"), " \t\r\n"), false, nil
+			return strings.Join(trimBlankLines(lines), "\n"), false, nil
 		case errors.Is(err, readline.ErrInterrupt):
 			return "", true, nil
 		default:
 			return "", false, err
 		}
 	}
+}
+
+// trimBlankLines drops leading and trailing lines that contain only
+// whitespace, leaving every other line, and its whitespace, untouched.
+func trimBlankLines(lines []string) []string {
+	start, end := 0, len(lines)
+	for start < end && strings.TrimSpace(lines[start]) == "" {
+		start++
+	}
+	for end > start && strings.TrimSpace(lines[end-1]) == "" {
+		end--
+	}
+	return lines[start:end]
 }
 
 // handlePaste implements the /paste command: it switches to a continuation

--- a/internal/chat/commands.go
+++ b/internal/chat/commands.go
@@ -165,6 +165,8 @@ Available Commands:
   Navigation:
     /help                       Show this help message
     /clear                      Clear the screen
+    /paste                      Enter multi-line input; Ctrl+D sends,
+                                Ctrl+C cancels
     /quit, /exit                Exit the CLI
 
   LLM Settings:

--- a/internal/chat/paste_test.go
+++ b/internal/chat/paste_test.go
@@ -1,0 +1,127 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgEdge Natural Language Agent
+ *
+ * Copyright (c) 2025 - 2026, pgEdge, Inc.
+ * This software is released under The PostgreSQL License
+ *
+ *-------------------------------------------------------------------------
+ */
+
+package chat
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/chzyer/readline"
+)
+
+// scriptedReader returns each scripted result in turn, then io.EOF forever.
+type scriptedReader struct {
+	lines []string
+	errs  []error
+}
+
+func (r *scriptedReader) Readline() (string, error) {
+	if len(r.lines) == 0 {
+		return "", io.EOF
+	}
+	line, err := r.lines[0], r.errs[0]
+	r.lines, r.errs = r.lines[1:], r.errs[1:]
+	return line, err
+}
+
+// script builds a scriptedReader from a sequence of lines (strings) and
+// terminal events (errors), in the order readline would report them.
+func script(steps ...any) *scriptedReader {
+	r := &scriptedReader{}
+	for _, s := range steps {
+		switch v := s.(type) {
+		case string:
+			r.lines = append(r.lines, v)
+			r.errs = append(r.errs, nil)
+		case error:
+			r.lines = append(r.lines, "")
+			r.errs = append(r.errs, v)
+		default:
+			panic("script steps must be strings or errors")
+		}
+	}
+	return r
+}
+
+func TestCollectPastedInput(t *testing.T) {
+	boom := errors.New("terminal went away")
+
+	tests := []struct {
+		name        string
+		reader      *scriptedReader
+		wantText    string
+		wantAborted bool
+		wantErr     error
+	}{
+		{
+			name: "multi-line SQL joined with newlines on Ctrl+D",
+			reader: script(
+				"SELECT empno,",
+				"       ename",
+				"FROM emp",
+				"WHERE deptno = 10;",
+				io.EOF,
+			),
+			wantText: "SELECT empno,\n       ename\nFROM emp\nWHERE deptno = 10;",
+		},
+		{
+			name:     "leading and trailing blank lines are trimmed, inner ones kept",
+			reader:   script("", "first", "", "second", "", io.EOF),
+			wantText: "first\n\nsecond",
+		},
+		{
+			name:     "lines starting with a slash are content, not commands",
+			reader:   script("/help me write this", "/quit is not a command here", io.EOF),
+			wantText: "/help me write this\n/quit is not a command here",
+		},
+		{
+			name:     "Ctrl+D with nothing pasted yields empty text",
+			reader:   script(io.EOF),
+			wantText: "",
+		},
+		{
+			name:        "Ctrl+C discards collected lines and reports abort",
+			reader:      script("SELECT 1;", "SELECT 2;", readline.ErrInterrupt),
+			wantAborted: true,
+		},
+		{
+			name:    "other errors are returned",
+			reader:  script("SELECT 1;", boom),
+			wantErr: boom,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, aborted, err := collectPastedInput(tt.reader)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if aborted != tt.wantAborted {
+				t.Errorf("aborted = %v, want %v", aborted, tt.wantAborted)
+			}
+			if text != tt.wantText {
+				t.Errorf("text = %q, want %q", text, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestGetContinuationPrompt(t *testing.T) {
+	ui := NewUI(true, false)
+	if got := ui.GetContinuationPrompt(); got != "...: " {
+		t.Errorf("GetContinuationPrompt() = %q, want %q", got, "...: ")
+	}
+	if got, want := len(ui.GetContinuationPrompt()), len(ui.GetPrompt()); got != want {
+		t.Errorf("continuation prompt width %d does not match main prompt width %d", got, want)
+	}
+}

--- a/internal/chat/paste_test.go
+++ b/internal/chat/paste_test.go
@@ -79,6 +79,11 @@ func TestCollectPastedInput(t *testing.T) {
 			wantText: "first\n\nsecond",
 		},
 		{
+			name:     "indentation on the first and last lines is preserved",
+			reader:   script("  ", "    def f():", "        return 1  ", "\t", io.EOF),
+			wantText: "    def f():\n        return 1  ",
+		},
+		{
 			name:     "lines starting with a slash are content, not commands",
 			reader:   script("/help me write this", "/quit is not a command here", io.EOF),
 			wantText: "/help me write this\n/quit is not a command here",

--- a/internal/chat/ui.go
+++ b/internal/chat/ui.go
@@ -90,6 +90,13 @@ func (ui *UI) GetPrompt() string {
 	return ui.colorize(ColorGreen+ColorBold, "You: ")
 }
 
+// GetContinuationPrompt returns the prompt shown for each additional line
+// whilst collecting multi-line input with /paste; it is the same width as
+// the main prompt so that pasted lines stay aligned.
+func (ui *UI) GetContinuationPrompt() string {
+	return ui.colorize(ColorGreen+ColorBold, "...: ")
+}
+
 // PrintUserInput prints the user's input prompt (deprecated, kept for compatibility)
 func (ui *UI) PrintUserInput() {
 	fmt.Print(ui.GetPrompt())


### PR DESCRIPTION
Fixes #57.

Pasting a multi-line query at the CLI prompt sends each line to the LLM as a separate request, because the terminal delivers every newline as if Enter had been pressed. The proper fix is bracketed paste, but `chzyer/readline` has no support for it and each terminal encodes pastes slightly differently (Terminal.app, Ghostty and Windows disagree on CR versus LF), which is what sank the earlier attempt. Given how few people drive this through the CLI rather than the web client or an MCP host, this takes the portable route instead.

`/paste` switches to a `...:` continuation prompt and collects lines until Ctrl+D on an empty line, then sends the whole text as one request; Ctrl+C discards it. Collected lines are taken verbatim, so a leading `/` is content, and they are kept out of the line-based history file. Ctrl+D at the main prompt now echoes `^D` rather than `exit`, so the same key reads sensibly in both places.

Tested with unit tests on the collector and by driving the real binary through a pseudo-terminal for the send, cancel and empty cases; `make test` and `make lint` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `/paste` command for submitting multi-line input as a single request.
  - Use Ctrl+D to submit pasted content and Ctrl+C to cancel.
  - Pasted lines, including those beginning with `/`, are preserved as content and excluded from history.
  - Added a continuation prompt for multi-line entry.
  - Ctrl+D now displays `^D` before exiting when used at an empty prompt.

- **Documentation**
  - Updated CLI help, keyboard shortcut guidance, and the unreleased changelog with `/paste` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->